### PR TITLE
fix: use stored mark for link on empty selection so typing inherits link

### DIFF
--- a/apps/desktop/src/editor/SmartLinkExtension.ts
+++ b/apps/desktop/src/editor/SmartLinkExtension.ts
@@ -44,6 +44,18 @@ function toggleLinkAtSelection() {
 			const range = selection.empty
 				? findWordRangeAtCursor(state)
 				: { from: selection.from, to: selection.to };
+
+			// Empty selection with no word under cursor: toggle the stored
+			// link mark so subsequent typing inherits it, matching bold/italic.
+			if (selection.empty && (!range || range.from >= range.to)) {
+				if (dispatch) {
+					const tr = state.tr.addStoredMark(linkType.create({ href: "" }));
+					dispatch(tr);
+				}
+				window.dispatchEvent(new CustomEvent(FOCUS_LINK_POPOVER_EVENT));
+				return true;
+			}
+
 			if (!range || range.from >= range.to) return false;
 
 			const hasLink = state.doc.rangeHasMark(range.from, range.to, linkType);


### PR DESCRIPTION
## Problem

Pressing `Cmd+K` with a collapsed cursor (no text selected) and no word under the cursor does nothing — the command returns `false`. When the user then starts typing, the text is plain (not inside a link), unlike bold/italic which correctly apply to subsequent keystrokes via ProseMirror's stored-marks mechanism.

## Root cause

The link mark is configured with `inclusive: false` (correct for links — you generally don't want adjacent typed text to inherit the mark). However, `toggleLinkAtSelection` only handled two cases:

1. Empty selection **with a word** under the cursor → wrap the word in a link mark
2. Non-empty selection → apply link mark to the range

It never handled the empty-selection-no-word case, which is exactly when stored marks are needed.

## Fix

When the selection is empty and `findWordRangeAtCursor` returns null, the command now calls `state.tr.addStoredMark(linkType.create({ href: "" }))` so that subsequent typed characters inherit the link mark. This matches how bold and italic behave on collapsed selections.

_This PR was generated with [Warp](https://www.warp.dev/)._
