### PR TITLE
fix: allow esc to clear formatting on empty lines

### DIFF
--- a/packages/editor/src/MarkdownRolloverExtension.test.ts
+++ b/packages/editor/src/MarkdownRolloverExtension.test.ts
@@ -122,3 +122,44 @@ describe("markdown rollover esc-only behavior", () => {
 		expect(atEnd.canEscapeBoundary).toBe(true);
 	});
 });
+
+describe("escape stored marks on empty line", () => {
+	function emptyLineState() {
+		const doc = schema.node("doc", null, [schema.node("paragraph", null, [])]);
+		return EditorState.create({
+			schema,
+			doc,
+			selection: TextSelection.create(doc, 1),
+		});
+	}
+
+	it("can escape when stored formatting marks exist on empty line", () => {
+		const base = emptyLineState();
+		const state = base.apply(base.tr.addStoredMark(schema.marks.bold.create()));
+		expect(__testing.canEscapeBoundaryAtCursor(state, null)).toBe(true);
+	});
+
+	it("cannot escape when no stored marks on empty line", () => {
+		const state = emptyLineState();
+		expect(__testing.canEscapeBoundaryAtCursor(state, null)).toBe(false);
+	});
+
+	it("reports canEscapeBoundary true via getCaretFormattingState", () => {
+		const base = emptyLineState();
+		const state = base.apply(base.tr.addStoredMark(schema.marks.bold.create()));
+		const formatting = getCaretFormattingState(state);
+		expect(formatting.canEscapeBoundary).toBe(true);
+		expect(formatting.activeMarkNames).toContain("bold");
+	});
+
+	it("detects multiple stored formatting marks", () => {
+		const base = emptyLineState();
+		const state = base.apply(
+			base.tr
+				.addStoredMark(schema.marks.bold.create())
+				.addStoredMark(schema.marks.italic.create()),
+		);
+		expect(__testing.hasStoredFormattingMarks(state)).toBe(true);
+		expect(__testing.canEscapeBoundaryAtCursor(state, null)).toBe(true);
+	});
+});

--- a/packages/editor/src/MarkdownRolloverExtension.ts
+++ b/packages/editor/src/MarkdownRolloverExtension.ts
@@ -93,13 +93,23 @@ function maybeHandleEscapeAtBoundary(view: EditorView): boolean {
 	if (!canEscapeBoundaryAtCursor(state, escapedBoundary)) return false;
 
 	const boundaryMatch = getBoundaryMatchAtPos(state, state.selection.from);
-	if (!boundaryMatch) return false;
+	if (boundaryMatch) {
+		const tr = state.tr.removeStoredMark(boundaryMatch.markType);
+		tr.setMeta(MarkdownRolloverKey, {
+			pos: state.selection.from,
+			markName: boundaryMatch.markType.name,
+		} satisfies NonNullable<EscapedBoundaryState>);
+		view.dispatch(tr);
+		return true;
+	}
 
-	const tr = state.tr.removeStoredMark(boundaryMatch.markType);
-	tr.setMeta(MarkdownRolloverKey, {
-		pos: state.selection.from,
-		markName: boundaryMatch.markType.name,
-	} satisfies NonNullable<EscapedBoundaryState>);
+	let tr = state.tr;
+	for (const markName of MARK_PRIORITY) {
+		const markType = state.schema.marks[markName];
+		if (markType) {
+			tr = tr.removeStoredMark(markType);
+		}
+	}
 	view.dispatch(tr);
 	return true;
 }
@@ -111,19 +121,21 @@ function canEscapeBoundaryAtCursor(
 	if (!state.selection.empty) return false;
 
 	const boundaryMatch = getBoundaryMatchAtPos(state, state.selection.from);
-	if (!boundaryMatch) return false;
-	if (boundaryMatch.boundary !== "end") return false;
-	if (
-		isBoundaryEscaped(
-			escapedBoundary,
-			state.selection.from,
-			boundaryMatch.markType.name,
-		)
-	) {
-		return false;
+	if (boundaryMatch) {
+		if (boundaryMatch.boundary !== "end") return false;
+		if (
+			isBoundaryEscaped(
+				escapedBoundary,
+				state.selection.from,
+				boundaryMatch.markType.name,
+			)
+		) {
+			return false;
+		}
+		return isMarkEffectivelyActiveAtCursor(state, boundaryMatch.markType);
 	}
 
-	return isMarkEffectivelyActiveAtCursor(state, boundaryMatch.markType);
+	return hasStoredFormattingMarks(state);
 }
 
 function getBoundaryMatchAtPos(
@@ -187,6 +199,13 @@ function isMarkEffectivelyActiveAtCursor(
 	return !!getAdjacentInsertionMark(state, markType);
 }
 
+function hasStoredFormattingMarks(state: EditorState): boolean {
+	if (!state.storedMarks) return false;
+	return state.storedMarks.some((mark) =>
+		(MARK_PRIORITY as readonly string[]).includes(mark.type.name),
+	);
+}
+
 function isBoundaryEscaped(
 	escapedBoundary: EscapedBoundaryState,
 	pos: number,
@@ -227,5 +246,6 @@ export const __testing = {
 	canEscapeBoundaryAtCursor,
 	findByPriority,
 	getBoundaryMatchAtPos,
+	hasStoredFormattingMarks,
 	isBoundaryEscaped,
 };


### PR DESCRIPTION
## Summary

Fixes #7 — Escape key now clears formatting on new empty lines.

## Problem

When formatting was applied via keyboard shortcut (e.g. `cmd+B`) on a new empty line, pressing `Escape` did not remove the formatting. The `canEscapeBoundaryAtCursor` function only handled the case where the cursor sits at a mark boundary end (e.g., after bold text). On empty lines, there are no text nodes to form mark boundaries, so `getBoundaryMatchAtPos` returned `null` and the escape was ignored. The `esc` status charm also failed to appear.

## Changes

**`MarkdownRolloverExtension.ts`**
- Added `hasStoredFormattingMarks` helper that checks if the editor state has stored marks matching any known formatting mark (bold, italic, code, strike, link).
- Updated `canEscapeBoundaryAtCursor` to fall through to the stored-marks check when no boundary match exists.
- Updated `maybeHandleEscapeAtBoundary` to clear all stored formatting marks when there is no boundary match.

**`MarkdownRolloverExtension.test.ts`**
- Added 4 tests covering the empty-line stored marks escape behavior.

_This PR was generated with [Oz](https://www.warp.dev/oz)._
