### PR TITLE
fix: clear stored marks when pressing Escape on empty formatted line

### DIFF
--- a/packages/editor/src/MarkdownRolloverExtension.test.ts
+++ b/packages/editor/src/MarkdownRolloverExtension.test.ts
@@ -103,6 +103,28 @@ describe("markdown rollover esc-only behavior", () => {
 		]);
 	});
 
+	it("reports canEscapeBoundary true when stored marks exist with no adjacent text boundary", () => {
+		// Simulate cmd+B on an empty line: no adjacent marked text, but storedMarks are set
+		const base = stateAt(BOLD_END + 1);
+		const withStored = base.apply(
+			base.tr.addStoredMark(schema.marks.bold.create()),
+		);
+		expect(getCaretFormattingState(withStored).canEscapeBoundary).toBe(true);
+	});
+
+	it("reports canEscapeBoundary false with no stored marks and no text boundary", () => {
+		const state = stateAt(BOLD_END + 1);
+		expect(getCaretFormattingState(state).canEscapeBoundary).toBe(false);
+	});
+
+	it("canEscapeBoundaryAtCursor returns true for stored marks on empty position", () => {
+		const base = stateAt(BOLD_END + 1);
+		const withStored = base.apply(
+			base.tr.addStoredMark(schema.marks.italic.create()),
+		);
+		expect(__testing.canEscapeBoundaryAtCursor(withStored, null)).toBe(true);
+	});
+
 	it("reports canEscapeBoundary false for non-empty selections", () => {
 		const doc = buildDoc();
 		const state = EditorState.create({

--- a/packages/editor/src/MarkdownRolloverExtension.ts
+++ b/packages/editor/src/MarkdownRolloverExtension.ts
@@ -93,15 +93,22 @@ function maybeHandleEscapeAtBoundary(view: EditorView): boolean {
 	if (!canEscapeBoundaryAtCursor(state, escapedBoundary)) return false;
 
 	const boundaryMatch = getBoundaryMatchAtPos(state, state.selection.from);
-	if (!boundaryMatch) return false;
+	if (boundaryMatch) {
+		const tr = state.tr.removeStoredMark(boundaryMatch.markType);
+		tr.setMeta(MarkdownRolloverKey, {
+			pos: state.selection.from,
+			markName: boundaryMatch.markType.name,
+		} satisfies NonNullable<EscapedBoundaryState>);
+		view.dispatch(tr);
+		return true;
+	}
 
-	const tr = state.tr.removeStoredMark(boundaryMatch.markType);
-	tr.setMeta(MarkdownRolloverKey, {
-		pos: state.selection.from,
-		markName: boundaryMatch.markType.name,
-	} satisfies NonNullable<EscapedBoundaryState>);
-	view.dispatch(tr);
-	return true;
+	// No text boundary — fall back to clearing any active stored marks
+	if (hasActiveStoredMarks(state)) {
+		view.dispatch(state.tr.setStoredMarks([]));
+		return true;
+	}
+	return false;
 }
 
 function canEscapeBoundaryAtCursor(
@@ -111,19 +118,22 @@ function canEscapeBoundaryAtCursor(
 	if (!state.selection.empty) return false;
 
 	const boundaryMatch = getBoundaryMatchAtPos(state, state.selection.from);
-	if (!boundaryMatch) return false;
-	if (boundaryMatch.boundary !== "end") return false;
-	if (
-		isBoundaryEscaped(
-			escapedBoundary,
-			state.selection.from,
-			boundaryMatch.markType.name,
-		)
-	) {
-		return false;
+	if (boundaryMatch) {
+		if (boundaryMatch.boundary !== "end") return false;
+		if (
+			isBoundaryEscaped(
+				escapedBoundary,
+				state.selection.from,
+				boundaryMatch.markType.name,
+			)
+		) {
+			return false;
+		}
+		return isMarkEffectivelyActiveAtCursor(state, boundaryMatch.markType);
 	}
 
-	return isMarkEffectivelyActiveAtCursor(state, boundaryMatch.markType);
+	// No text boundary — fall back to checking for active stored marks
+	return hasActiveStoredMarks(state);
 }
 
 function getBoundaryMatchAtPos(
@@ -172,6 +182,14 @@ function getActiveMarkNamesAtCursor(
 	}
 
 	return MARK_PRIORITY.filter((name) => names.has(name));
+}
+
+function hasActiveStoredMarks(state: EditorState): boolean {
+	const { storedMarks } = state;
+	if (!storedMarks || storedMarks.length === 0) return false;
+	return storedMarks.some((mark) =>
+		MARK_PRIORITY.includes(mark.type.name as (typeof MARK_PRIORITY)[number]),
+	);
 }
 
 function isMarkActiveForInsertion(state: EditorState, markType: MarkType) {


### PR DESCRIPTION
## Problem

When formatting (e.g. `cmd+B`) was applied on a new line before any text was typed, pressing `Esc` did not clear it. The status charm also didn't show the `esc` option.

**Root cause:** `canEscapeBoundaryAtCursor` and `maybeHandleEscapeAtBoundary` both relied solely on `getBoundaryMatchAtPos`, which finds boundaries by inspecting adjacent text nodes. On a truly empty line, there are no adjacent nodes, so it returned `null` and both functions short-circuited.

## Fix

Added a `hasActiveStoredMarks` helper that detects when a known formatting mark (bold, italic, strike, etc.) is present in `state.storedMarks` — the ProseMirror state used when marks are toggled on an empty cursor.

Both functions now fall back to this check when no text boundary is found:

- `canEscapeBoundaryAtCursor` returns `true` → status charm shows `esc`
- `maybeHandleEscapeAtBoundary` calls `setStoredMarks([])` → formatting is cleared

## Tests

Three new unit tests cover:
- `canEscapeBoundary` is `true` when stored marks are present with no adjacent boundary
- `canEscapeBoundary` is `false` when no stored marks and no boundary
- `canEscapeBoundaryAtCursor` returns `true` for stored italic marks on an empty position

Closes #7

_This PR was generated with [Oz](https://www.warp.dev/oz)._
