### PR TITLE
fix: allow Escape to clear formatting on empty lines

### DIFF
--- a/packages/editor/src/MarkdownRolloverExtension.test.ts
+++ b/packages/editor/src/MarkdownRolloverExtension.test.ts
@@ -122,3 +122,50 @@ describe("markdown rollover esc-only behavior", () => {
 		expect(atEnd.canEscapeBoundary).toBe(true);
 	});
 });
+
+describe("escape stored marks on empty paragraph", () => {
+	function emptyParaState() {
+		const doc = schema.node("doc", null, [
+			schema.node("paragraph", null, []),
+		]);
+		return EditorState.create({
+			schema,
+			doc,
+			selection: TextSelection.create(doc, 1),
+		});
+	}
+
+	it("hasStoredMarksOnEmptyNode returns true with stored bold mark", () => {
+		const base = emptyParaState();
+		const state = base.apply(base.tr.addStoredMark(schema.marks.bold.create()));
+		expect(__testing.hasStoredMarksOnEmptyNode(state)).toBe(true);
+	});
+
+	it("hasStoredMarksOnEmptyNode returns false without stored marks", () => {
+		const state = emptyParaState();
+		expect(__testing.hasStoredMarksOnEmptyNode(state)).toBe(false);
+	});
+
+	it("canEscapeBoundary is true on empty paragraph with stored mark", () => {
+		const base = emptyParaState();
+		const state = base.apply(base.tr.addStoredMark(schema.marks.bold.create()));
+		const caretState = getCaretFormattingState(state);
+		expect(caretState.canEscapeBoundary).toBe(true);
+		expect(caretState.activeMarkNames).toContain("bold");
+	});
+
+	it("canEscapeBoundary is false on empty paragraph without stored marks", () => {
+		const state = emptyParaState();
+		const caretState = getCaretFormattingState(state);
+		expect(caretState.canEscapeBoundary).toBe(false);
+		expect(caretState.activeMarkNames).toEqual([]);
+	});
+
+	it("hasStoredMarksOnEmptyNode returns false on non-empty paragraph", () => {
+		const state = stateAt(BOLD_END);
+		const withStored = state.apply(
+			state.tr.addStoredMark(schema.marks.bold.create()),
+		);
+		expect(__testing.hasStoredMarksOnEmptyNode(withStored)).toBe(false);
+	});
+});

--- a/packages/editor/src/MarkdownRolloverExtension.ts
+++ b/packages/editor/src/MarkdownRolloverExtension.ts
@@ -93,15 +93,17 @@ function maybeHandleEscapeAtBoundary(view: EditorView): boolean {
 	if (!canEscapeBoundaryAtCursor(state, escapedBoundary)) return false;
 
 	const boundaryMatch = getBoundaryMatchAtPos(state, state.selection.from);
-	if (!boundaryMatch) return false;
+	if (boundaryMatch) {
+		const tr = state.tr.removeStoredMark(boundaryMatch.markType);
+		tr.setMeta(MarkdownRolloverKey, {
+			pos: state.selection.from,
+			markName: boundaryMatch.markType.name,
+		} satisfies NonNullable<EscapedBoundaryState>);
+		view.dispatch(tr);
+		return true;
+	}
 
-	const tr = state.tr.removeStoredMark(boundaryMatch.markType);
-	tr.setMeta(MarkdownRolloverKey, {
-		pos: state.selection.from,
-		markName: boundaryMatch.markType.name,
-	} satisfies NonNullable<EscapedBoundaryState>);
-	view.dispatch(tr);
-	return true;
+	return maybeClearStoredMarksOnEmptyNode(view);
 }
 
 function canEscapeBoundaryAtCursor(
@@ -111,19 +113,21 @@ function canEscapeBoundaryAtCursor(
 	if (!state.selection.empty) return false;
 
 	const boundaryMatch = getBoundaryMatchAtPos(state, state.selection.from);
-	if (!boundaryMatch) return false;
-	if (boundaryMatch.boundary !== "end") return false;
-	if (
-		isBoundaryEscaped(
-			escapedBoundary,
-			state.selection.from,
-			boundaryMatch.markType.name,
-		)
-	) {
-		return false;
+	if (boundaryMatch) {
+		if (boundaryMatch.boundary !== "end") return false;
+		if (
+			isBoundaryEscaped(
+				escapedBoundary,
+				state.selection.from,
+				boundaryMatch.markType.name,
+			)
+		) {
+			return false;
+		}
+		return isMarkEffectivelyActiveAtCursor(state, boundaryMatch.markType);
 	}
 
-	return isMarkEffectivelyActiveAtCursor(state, boundaryMatch.markType);
+	return hasStoredMarksOnEmptyNode(state);
 }
 
 function getBoundaryMatchAtPos(
@@ -212,6 +216,33 @@ function getAdjacentInsertionMark(
 	return null;
 }
 
+function hasStoredMarksOnEmptyNode(state: EditorState): boolean {
+	const $pos = state.doc.resolve(state.selection.from);
+	if ($pos.parent.content.size !== 0) return false;
+	const storedMarks = state.storedMarks;
+	if (!storedMarks || storedMarks.length === 0) return false;
+	return MARK_PRIORITY.some((markName) => {
+		const markType = state.schema.marks[markName];
+		return markType && !!markType.isInSet(storedMarks);
+	});
+}
+
+function maybeClearStoredMarksOnEmptyNode(view: EditorView): boolean {
+	const { state } = view;
+	if (!hasStoredMarksOnEmptyNode(state)) return false;
+	const storedMarks = state.storedMarks!;
+	for (const markName of MARK_PRIORITY) {
+		const markType = state.schema.marks[markName];
+		if (!markType) continue;
+		if (markType.isInSet(storedMarks)) {
+			const tr = state.tr.removeStoredMark(markType);
+			view.dispatch(tr);
+			return true;
+		}
+	}
+	return false;
+}
+
 function findByPriority(
 	state: EditorState,
 	marks: readonly Mark[],
@@ -227,5 +258,6 @@ export const __testing = {
 	canEscapeBoundaryAtCursor,
 	findByPriority,
 	getBoundaryMatchAtPos,
+	hasStoredMarksOnEmptyNode,
 	isBoundaryEscaped,
 };


### PR DESCRIPTION
## Description

Allow `Escape` to clear formatting (stored marks) on new empty lines, and show the `esc` status charm in that state.

Closes #11

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update

## Testing

- [x] Existing tests pass
- [x] Added new tests for changes
- [ ] Tested manually (describe below)

**Manual Testing Details:**

Not applicable in CI — tested via unit tests covering the new behavior.

### What changed

`getBoundaryMatchAtPos` only detects mark boundaries between adjacent text nodes. On an empty paragraph there are no text nodes, so it always returned `null`, preventing Escape from firing and the charm from appearing.

Two new helpers were added:
- `hasStoredMarksOnEmptyNode` — returns `true` when the cursor is inside an empty paragraph that has stored marks from `MARK_PRIORITY`.
- `maybeClearStoredMarksOnEmptyNode` — removes the highest-priority stored mark one at a time on Escape.

`canEscapeBoundaryAtCursor` and `maybeHandleEscapeAtBoundary` now fall through to these helpers when no text boundary is found.

Five new unit tests cover the empty-paragraph stored-marks scenario.

## Checklist

- [x] I discussed this change in a GitHub issue before submitting this PR
- [x] I have run the linter, formatter, and tests to ensure my code is ready for review

_This PR was generated with [Oz](https://www.warp.dev/oz)._
