### PR TITLE
Add desktop settings update flow

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -14,6 +14,7 @@ import {
 } from "electron";
 import electronUpdater from "electron-updater";
 import ignore from "ignore";
+import type { DesktopUpdateState } from "../src/desktopApi/types";
 
 type FileEntry = {
 	path: string;
@@ -40,6 +41,7 @@ const isDev = !app.isPackaged;
 const { autoUpdater } = electronUpdater;
 const debugPort = process.env.HUBBLE_DESKTOP_DEBUG_PORT ?? "9222";
 const updateFeedUrl = process.env.HUBBLE_DESKTOP_UPDATE_URL;
+const supportsAutoUpdates = !isDev && process.platform === "darwin";
 // Check every 4 hours after the initial packaged-app update check.
 const updateCheckIntervalMs = 4 * 60 * 60 * 1000;
 
@@ -55,9 +57,17 @@ let pendingOpenPath: string | null = firstExistingFileArg(
 	process.argv.slice(1),
 );
 let menuState: MenuState = { hasWorkspace: false };
-let updateDownloaded = false;
-let updateCheckInFlight = false;
-let manualUpdateCheck = false;
+let updateState: DesktopUpdateState = {
+	isSupported: supportsAutoUpdates,
+	status: "idle",
+	currentVersion: app.getVersion(),
+	availableVersion: null,
+	progressPercent: null,
+	message: supportsAutoUpdates
+		? null
+		: "Updates are available on packaged macOS builds only.",
+	lastCheckedAt: null,
+};
 const watchers = new Map<string, FSWatcher>();
 const grantedFiles = new Set<string>();
 const grantedRoots = new Set<string>();
@@ -348,20 +358,26 @@ function buildMenu() {
 			label: app.name,
 			submenu: [
 				{
+					id: "settings",
+					label: "Settings...",
+					accelerator: "CmdOrCtrl+,",
+					click: () => sendToRenderer("desktop:menu-open-settings"),
+				},
+				{ type: "separator" },
+				{
 					id: "check-for-updates",
-					label: updateCheckInFlight
-						? "Checking for Updates..."
-						: "Check for Updates...",
-					enabled: !updateCheckInFlight,
-					click: () => {
-						void checkForUpdates({ manual: true });
-					},
+					label:
+						updateState.status === "checking"
+							? "Checking for Updates..."
+							: "Check for Updates...",
+					enabled: updateState.status !== "checking",
+					click: () => sendToRenderer("desktop:menu-check-for-updates"),
 				},
 				{
 					id: "restart-to-update",
 					label: "Restart to Update",
-					enabled: updateDownloaded,
-					visible: updateDownloaded,
+					enabled: updateState.status === "ready",
+					visible: updateState.status === "ready",
 					click: () => autoUpdater.quitAndInstall(false, true),
 				},
 				{ type: "separator" },
@@ -379,49 +395,52 @@ function buildMenu() {
 	Menu.setApplicationMenu(Menu.buildFromTemplate(template));
 }
 
-async function checkForUpdates({ manual = false } = {}) {
-	if (isDev || process.platform !== "darwin" || updateCheckInFlight) return;
-	updateCheckInFlight = true;
-	manualUpdateCheck = manual;
+function syncUpdateState(nextState: DesktopUpdateState) {
+	updateState = nextState;
 	buildMenu();
-	try {
-		await autoUpdater.checkForUpdates();
-	} catch (error) {
-		if (manual) {
-			dialog.showErrorBox(
-				"Unable to Check for Updates",
-				error instanceof Error ? error.message : String(error),
-			);
-		}
-		finishUpdateCheck();
-	}
+	sendToRenderer("desktop:update-state", updateState);
 }
 
-function finishUpdateCheck() {
-	updateCheckInFlight = false;
-	manualUpdateCheck = false;
-	buildMenu();
-}
-
-async function showUpdateMessage(message: string) {
-	await dialog.showMessageBox(mainWindow ?? undefined, {
-		type: "info",
-		message,
+function patchUpdateState(patch: Partial<DesktopUpdateState>) {
+	syncUpdateState({
+		...updateState,
+		...patch,
 	});
 }
 
-function showManualUpdateMessage(message: string) {
-	if (!manualUpdateCheck) return;
-	void showUpdateMessage(message);
-}
-
-function showManualUpdateError(error: Error) {
-	if (!manualUpdateCheck) return;
-	dialog.showErrorBox("Unable to Check for Updates", error.message);
+async function checkForUpdates() {
+	if (!supportsAutoUpdates) {
+		patchUpdateState({
+			status: "idle",
+			message: "Updates are available on packaged macOS builds only.",
+		});
+		return;
+	}
+	if (
+		updateState.status === "checking" ||
+		updateState.status === "downloading" ||
+		updateState.status === "ready"
+	) {
+		return;
+	}
+	patchUpdateState({
+		status: "checking",
+		progressPercent: null,
+		message: null,
+	});
+	try {
+		await autoUpdater.checkForUpdates();
+	} catch (error) {
+		patchUpdateState({
+			status: "error",
+			message: error instanceof Error ? error.message : String(error),
+			lastCheckedAt: Date.now(),
+		});
+	}
 }
 
 function configureAutoUpdates() {
-	if (isDev || process.platform !== "darwin") return;
+	if (!supportsAutoUpdates) return;
 	if (updateFeedUrl) {
 		autoUpdater.setFeedURL({
 			provider: "generic",
@@ -430,24 +449,47 @@ function configureAutoUpdates() {
 	}
 	autoUpdater.autoDownload = true;
 	autoUpdater.autoInstallOnAppQuit = true;
-	autoUpdater.on("update-available", () => {
-		showManualUpdateMessage("An update is downloading in the background.");
+	autoUpdater.on("update-available", (info) => {
+		patchUpdateState({
+			status: "downloading",
+			availableVersion: info.version ?? null,
+			progressPercent: 0,
+			message: "Downloading update...",
+			lastCheckedAt: Date.now(),
+		});
 	});
 	autoUpdater.on("update-not-available", () => {
-		showManualUpdateMessage("Hubble is up to date.");
-		finishUpdateCheck();
+		patchUpdateState({
+			status: "up-to-date",
+			availableVersion: null,
+			progressPercent: null,
+			message: "Hubble is up to date.",
+			lastCheckedAt: Date.now(),
+		});
 	});
-	autoUpdater.on("update-downloaded", () => {
-		updateDownloaded = true;
-		showManualUpdateMessage(
-			"Update ready. Use Hubble > Restart to Update when ready.",
-		);
-		finishUpdateCheck();
+	autoUpdater.on("download-progress", (progress) => {
+		patchUpdateState({
+			status: "downloading",
+			progressPercent: progress.percent,
+			message: "Downloading update...",
+		});
+	});
+	autoUpdater.on("update-downloaded", (info) => {
+		patchUpdateState({
+			status: "ready",
+			availableVersion: info.version ?? updateState.availableVersion,
+			progressPercent: 100,
+			message: "Restart Hubble to install the update.",
+			lastCheckedAt: Date.now(),
+		});
 	});
 	autoUpdater.on("error", (error) => {
 		console.error("Auto-update error", error);
-		showManualUpdateError(error);
-		finishUpdateCheck();
+		patchUpdateState({
+			status: "error",
+			message: error.message,
+			lastCheckedAt: Date.now(),
+		});
 	});
 
 	void checkForUpdates();
@@ -853,6 +895,19 @@ function registerIpc() {
 		const pathToOpen = pendingOpenPath;
 		pendingOpenPath = null;
 		return pathToOpen;
+	});
+
+	ipcMain.handle("desktop:get-update-state", () => updateState);
+
+	ipcMain.handle("desktop:check-for-updates", async () => {
+		await checkForUpdates();
+	});
+
+	ipcMain.handle("desktop:install-update", () => {
+		if (updateState.status !== "ready") {
+			throw new Error("No downloaded update is ready to install.");
+		}
+		autoUpdater.quitAndInstall(false, true);
 	});
 
 	ipcMain.handle("desktop:set-menu-state", (_event, state: MenuState) => {

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -1,8 +1,11 @@
 import { contextBridge, ipcRenderer } from "electron";
 import type { DesktopApi } from "../src/desktopApi/types";
 
-function subscribe(channel: string, callback: (...args: never[]) => void) {
-	const listener = (_event: Electron.IpcRendererEvent, ...args: never[]) =>
+function subscribe<T extends unknown[]>(
+	channel: string,
+	callback: (...args: T) => void,
+) {
+	const listener = (_event: Electron.IpcRendererEvent, ...args: T) =>
 		callback(...args);
 	ipcRenderer.on(channel, listener);
 	return () => ipcRenderer.removeListener(channel, listener);
@@ -53,13 +56,22 @@ const desktopApi = {
 		`hubble-asset://local/?path=${encodeURIComponent(path)}`,
 	getLaunchFilePath: () => ipcRenderer.invoke("desktop:get-launch-file-path"),
 	setMenuState: (state) => ipcRenderer.invoke("desktop:set-menu-state", state),
+	getUpdateState: () => ipcRenderer.invoke("desktop:get-update-state"),
+	checkForUpdates: () => ipcRenderer.invoke("desktop:check-for-updates"),
+	installUpdate: () => ipcRenderer.invoke("desktop:install-update"),
 	onOpenFile: (callback) =>
 		subscribe("desktop:open-file", (path: string) => callback(path)),
+	onUpdateStateChange: (callback) =>
+		subscribe("desktop:update-state", callback),
 	onMenuCreateMarkdownFile: (callback) =>
 		subscribe("desktop:menu-create-markdown-file", callback),
 	onMenuOpenFile: (callback) => subscribe("desktop:menu-open-file", callback),
 	onMenuOpenFolder: (callback) =>
 		subscribe("desktop:menu-open-folder", callback),
+	onMenuOpenSettings: (callback) =>
+		subscribe("desktop:menu-open-settings", callback),
+	onMenuCheckForUpdates: (callback) =>
+		subscribe("desktop:menu-check-for-updates", callback),
 	onMenuShowWorkspaceSwitcher: (callback) =>
 		subscribe("desktop:menu-show-workspace-switcher", callback),
 } satisfies DesktopApi;

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -3,9 +3,12 @@ import { useStoreValue } from "@simplestack/store/react";
 import { keymatch } from "keymatch";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
+import { SettingsDialog, SettingsSection } from "./components/SettingsDialog";
 import { Sidebar } from "./components/Sidebar";
 import { Toolbar } from "./components/Toolbar";
+import { UpdateReadyBanner, UpdatesSection } from "./components/UpdatesSection";
 import { desktopApi } from "./desktopApi";
+import type { DesktopUpdateState } from "./desktopApi/types";
 import { createEmbedExtension } from "./editor/EmbedExtension";
 import { handleImageDrop, handleImagePaste } from "./editor/handleImagePaste";
 import { createImageExtension } from "./editor/ImageExtension";
@@ -49,6 +52,28 @@ function App() {
 	const hasWorkspace = workspacePath !== null;
 	const [scrollContainerEl, setScrollContainerEl] =
 		useState<HTMLDivElement | null>(null);
+	const [settingsOpen, setSettingsOpen] = useState(false);
+	const [updateState, setUpdateState] = useState<DesktopUpdateState | null>(
+		null,
+	);
+
+	const openSettings = useCallback(() => {
+		setSettingsOpen(true);
+	}, []);
+
+	const requestUpdateCheck = useCallback(async () => {
+		await desktopApi.checkForUpdates();
+	}, []);
+
+	const installUpdate = useCallback(async () => {
+		try {
+			await desktopApi.installUpdate();
+		} catch (error) {
+			toast.error("Failed to install update", {
+				description: error instanceof Error ? error.message : String(error),
+			});
+		}
+	}, []);
 
 	useEffect(() => {
 		if (!workspacePath) return;
@@ -138,6 +163,9 @@ function App() {
 			if (keymatch(event, "CmdOrCtrl+N")) {
 				event.preventDefault();
 				await createMarkdownFile();
+			} else if (keymatch(event, "CmdOrCtrl+,")) {
+				event.preventDefault();
+				openSettings();
 			} else if (keymatch(event, "CmdOrCtrl+Shift+O")) {
 				if (!workspaceStore.get().workspacePath) return;
 				event.preventDefault();
@@ -162,7 +190,21 @@ function App() {
 		};
 		window.addEventListener("keydown", onKeyDown);
 		return () => window.removeEventListener("keydown", onKeyDown);
-	}, [openFilePicker]);
+	}, [openFilePicker, openSettings]);
+
+	useEffect(() => {
+		let active = true;
+		void desktopApi.getUpdateState().then((nextState) => {
+			if (active) setUpdateState(nextState);
+		});
+		const unsubscribe = desktopApi.onUpdateStateChange((nextState) => {
+			setUpdateState(nextState);
+		});
+		return () => {
+			active = false;
+			unsubscribe();
+		};
+	}, []);
 
 	useEffect(() => {
 		const unlisten = desktopApi.onOpenFile((path) => {
@@ -178,6 +220,11 @@ function App() {
 			desktopApi.onMenuCreateMarkdownFile(() => void createMarkdownFile()),
 			desktopApi.onMenuOpenFile(() => void openFilePicker()),
 			desktopApi.onMenuOpenFolder(() => void openWorkspaceWithSidebar()),
+			desktopApi.onMenuOpenSettings(() => openSettings()),
+			desktopApi.onMenuCheckForUpdates(() => {
+				openSettings();
+				void requestUpdateCheck();
+			}),
 			desktopApi.onMenuShowWorkspaceSwitcher(() =>
 				setWorkspaceSwitcherOpen(true),
 			),
@@ -185,7 +232,7 @@ function App() {
 		return () => {
 			for (const dispose of disposers) dispose();
 		};
-	}, [openFilePicker]);
+	}, [openFilePicker, openSettings, requestUpdateCheck]);
 
 	useEffect(() => {
 		let active = true;
@@ -217,6 +264,13 @@ function App() {
 	return (
 		<main className="flex h-dvh flex-col bg-background text-foreground">
 			<Toolbar scrollContainer={scrollContainerEl} />
+			{updateState?.status === "ready" ? (
+				<UpdateReadyBanner
+					version={updateState.availableVersion}
+					onOpenSettings={openSettings}
+					onInstall={installUpdate}
+				/>
+			) : null}
 			<div className="flex min-h-0 flex-1 overflow-hidden">
 				<Sidebar />
 				<section className="flex-1 overflow-hidden" aria-live="polite">
@@ -273,6 +327,21 @@ function App() {
 					)}
 				</section>
 			</div>
+			<SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen}>
+				{updateState ? (
+					<UpdatesSection
+						state={updateState}
+						onCheckForUpdates={() => void requestUpdateCheck()}
+						onInstall={() => void installUpdate()}
+					/>
+				) : (
+					<SettingsSection title="Updates">
+						<p className="text-sm text-muted-foreground">
+							Loading update status...
+						</p>
+					</SettingsSection>
+				)}
+			</SettingsDialog>
 		</main>
 	);
 }

--- a/apps/desktop/src/components/SettingsDialog.tsx
+++ b/apps/desktop/src/components/SettingsDialog.tsx
@@ -1,0 +1,48 @@
+import { Modal } from "@hubble.md/ui";
+import type { ReactNode } from "react";
+
+export function SettingsDialog({
+	open,
+	onOpenChange,
+	children,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	children: ReactNode;
+}) {
+	return (
+		<Modal
+			open={open}
+			onOpenChange={onOpenChange}
+			title="Settings"
+			description="App preferences and desktop behavior."
+			className="max-w-2xl"
+		>
+			<div className="flex max-h-[min(80dvh,42rem)] flex-col gap-4 overflow-y-auto">
+				{children}
+			</div>
+		</Modal>
+	);
+}
+
+export function SettingsSection({
+	title,
+	description,
+	children,
+}: {
+	title: string;
+	description?: string;
+	children: ReactNode;
+}) {
+	return (
+		<section className="rounded-lg border border-border bg-card/70 p-4 shadow-panel inset-shadow-chrome">
+			<div className="flex flex-col gap-1">
+				<h3 className="text-sm font-semibold">{title}</h3>
+				{description ? (
+					<p className="text-xs text-muted-foreground">{description}</p>
+				) : null}
+			</div>
+			<div className="[margin-block-start:1rem]">{children}</div>
+		</section>
+	);
+}

--- a/apps/desktop/src/components/UpdatesSection.tsx
+++ b/apps/desktop/src/components/UpdatesSection.tsx
@@ -1,0 +1,165 @@
+import { Button } from "@hubble.md/ui";
+import type { DesktopUpdateState } from "../desktopApi/types";
+import { SettingsSection } from "./SettingsDialog";
+
+export function UpdateReadyBanner({
+	version,
+	onOpenSettings,
+	onInstall,
+}: {
+	version: string | null;
+	onOpenSettings: () => void;
+	onInstall: () => void;
+}) {
+	return (
+		<div className="border-b border-primary/20 bg-primary/8">
+			<div className="flex flex-wrap items-center justify-between gap-3 [padding-block:0.625rem] [padding-inline:0.875rem]">
+				<p className="text-sm text-foreground">
+					{version
+						? `Update ${version} is ready to install.`
+						: "A new update is ready to install."}
+				</p>
+				<div className="flex shrink-0 items-center gap-2">
+					<Button size="sm" variant="outline" onClick={onOpenSettings}>
+						View details
+					</Button>
+					<Button size="sm" onClick={onInstall}>
+						Restart to Update
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export function UpdatesSection({
+	state,
+	onCheckForUpdates,
+	onInstall,
+}: {
+	state: DesktopUpdateState;
+	onCheckForUpdates: () => void;
+	onInstall: () => void;
+}) {
+	const isChecking = state.status === "checking";
+	const isReady = state.status === "ready";
+	const isDownloading = state.status === "downloading";
+	const canCheck =
+		state.isSupported && !isChecking && !isDownloading && !isReady;
+
+	return (
+		<SettingsSection
+			title="Updates"
+			description="Background checks stay quiet. Use this panel for manual checks and installs."
+		>
+			<div className="flex flex-col gap-4">
+				<div className="flex flex-wrap items-start justify-between gap-3">
+					<div className="flex min-w-0 flex-col gap-2">
+						<div className="flex flex-wrap items-center gap-2">
+							<UpdateStatusBadge status={state.status} />
+							<p className="text-xs text-muted-foreground">
+								Current version {state.currentVersion}
+							</p>
+						</div>
+						<p className="text-sm text-foreground">
+							{updateSummaryText(state)}
+						</p>
+						{state.lastCheckedAt ? (
+							<p className="text-xs text-muted-foreground">
+								Last checked {formatUpdateTimestamp(state.lastCheckedAt)}.
+							</p>
+						) : null}
+						{!state.isSupported && state.message ? (
+							<p className="text-xs text-muted-foreground">{state.message}</p>
+						) : null}
+					</div>
+					<div className="flex shrink-0 flex-wrap items-center gap-2">
+						<Button
+							size="sm"
+							variant="outline"
+							disabled={!canCheck}
+							onClick={onCheckForUpdates}
+						>
+							{isChecking ? "Checking..." : "Check for Updates"}
+						</Button>
+						{isReady ? (
+							<Button size="sm" onClick={onInstall}>
+								Restart to Update
+							</Button>
+						) : null}
+					</div>
+				</div>
+				{isDownloading ? (
+					<div className="flex flex-col gap-2">
+						<div className="h-2 overflow-hidden rounded-full bg-muted">
+							<div
+								className="h-full rounded-full bg-primary transition-[width]"
+								style={{
+									width: `${Math.min(100, Math.max(8, Math.round(state.progressPercent ?? 8)))}%`,
+								}}
+							/>
+						</div>
+						<p className="text-xs text-muted-foreground">
+							{state.progressPercent !== null
+								? `${Math.round(state.progressPercent)}% downloaded`
+								: "Downloading update..."}
+						</p>
+					</div>
+				) : null}
+				{state.status === "error" && state.message ? (
+					<p className="rounded-md border border-destructive/20 bg-destructive/10 p-3 text-xs text-destructive">
+						{state.message}
+					</p>
+				) : null}
+			</div>
+		</SettingsSection>
+	);
+}
+
+function UpdateStatusBadge({
+	status,
+}: {
+	status: DesktopUpdateState["status"];
+}) {
+	const label =
+		status === "up-to-date"
+			? "Up to date"
+			: status === "ready"
+				? "Update ready"
+				: status.charAt(0).toUpperCase() + status.slice(1);
+	return (
+		<span className="rounded-full border border-border bg-muted/70 [padding-block:0.2rem] [padding-inline:0.5rem] text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+			{label}
+		</span>
+	);
+}
+
+function updateSummaryText(state: DesktopUpdateState) {
+	switch (state.status) {
+		case "idle":
+			return state.isSupported
+				? "Automatic background checks are enabled."
+				: "Updates are unavailable in this build.";
+		case "checking":
+			return "Checking for the latest release...";
+		case "up-to-date":
+			return "You're on the latest release.";
+		case "downloading":
+			return state.availableVersion
+				? `Version ${state.availableVersion} is downloading now.`
+				: "A new release is downloading now.";
+		case "ready":
+			return state.availableVersion
+				? `Version ${state.availableVersion} is ready to install.`
+				: "A new release is ready to install.";
+		case "error":
+			return "Update check failed.";
+	}
+}
+
+function formatUpdateTimestamp(value: number) {
+	return new Intl.DateTimeFormat(undefined, {
+		dateStyle: "medium",
+		timeStyle: "short",
+	}).format(value);
+}

--- a/apps/desktop/src/desktopApi/types.ts
+++ b/apps/desktop/src/desktopApi/types.ts
@@ -31,6 +31,24 @@ export type MenuState = {
 	hasWorkspace: boolean;
 };
 
+export type DesktopUpdateStatus =
+	| "idle"
+	| "checking"
+	| "up-to-date"
+	| "downloading"
+	| "ready"
+	| "error";
+
+export type DesktopUpdateState = {
+	isSupported: boolean;
+	status: DesktopUpdateStatus;
+	currentVersion: string;
+	availableVersion: string | null;
+	progressPercent: number | null;
+	message: string | null;
+	lastCheckedAt: number | null;
+};
+
 export type DesktopApi = {
 	listDirectory(path: string): Promise<FileEntry[]>;
 	listEmbedFiles(
@@ -61,9 +79,17 @@ export type DesktopApi = {
 	toAssetUrl(path: string): string;
 	getLaunchFilePath(): Promise<string | null>;
 	setMenuState(state: MenuState): Promise<void>;
+	getUpdateState(): Promise<DesktopUpdateState>;
+	checkForUpdates(): Promise<void>;
+	installUpdate(): Promise<void>;
 	onOpenFile(callback: (path: string) => void): Unsubscribe;
+	onUpdateStateChange(
+		callback: (state: DesktopUpdateState) => void,
+	): Unsubscribe;
 	onMenuCreateMarkdownFile(callback: () => void): Unsubscribe;
 	onMenuOpenFile(callback: () => void): Unsubscribe;
 	onMenuOpenFolder(callback: () => void): Unsubscribe;
+	onMenuOpenSettings(callback: () => void): Unsubscribe;
+	onMenuCheckForUpdates(callback: () => void): Unsubscribe;
 	onMenuShowWorkspaceSwitcher(callback: () => void): Unsubscribe;
 };


### PR DESCRIPTION
## Summary
- add a reusable desktop Settings dialog with `Cmd+,`
- bridge updater state and actions into the renderer
- show update status in Settings and a ready-to-install banner

Closes #33