### PR TITLE
Spec stronger markdown crawling

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -265,12 +265,6 @@ function isMarkdownPath(candidatePath: string): boolean {
 	return /\.(md|markdown|mdown)$/i.test(candidatePath);
 }
 
-/** Covers Git ignore config files: .gitignore and .ignore. */
-function isIgnoreConfigPath(candidatePath: string): boolean {
-	const name = path.basename(candidatePath);
-	return ignoreConfigFiles.includes(name);
-}
-
 function isMissingPathError(error: unknown): boolean {
 	return (
 		typeof error === "object" &&
@@ -295,24 +289,6 @@ async function rulesForDir(dir: string, inherited: IgnoreRule[]) {
 	}
 
 	return hasRules ? [...inherited, { dir, matcher }] : inherited;
-}
-
-async function collectWorkspaceIgnoreRules(
-	dir: string,
-	inherited: IgnoreRule[] = [],
-): Promise<IgnoreRule[]> {
-	const rules = await rulesForDir(dir, inherited);
-	const collected =
-		rules.length > inherited.length ? [rules[rules.length - 1]] : [];
-
-	const entries = await fs.readdir(dir, { withFileTypes: true });
-	for (const entry of entries) {
-		if (!entry.isDirectory()) continue;
-		const entryPath = path.join(dir, entry.name);
-		if (isIgnoredByRules(entryPath, rules)) continue;
-		collected.push(...(await collectWorkspaceIgnoreRules(entryPath, rules)));
-	}
-	return collected;
 }
 
 function assertGranted(input: string): string {
@@ -463,6 +439,13 @@ function buildMenu() {
 					accelerator: "CmdOrCtrl+Shift+O",
 					enabled: menuState.hasWorkspace,
 					click: () => sendToRenderer("desktop:menu-show-workspace-switcher"),
+				},
+				{ type: "separator" },
+				{
+					id: "sync-workspace",
+					label: "Sync Workspace",
+					enabled: menuState.hasWorkspace,
+					click: () => sendToRenderer("desktop:menu-sync-workspace"),
 				},
 				{ type: "separator" },
 				{ role: "close" },
@@ -762,6 +745,8 @@ async function createWindow() {
 		},
 	});
 
+	mainWindow.on("focus", () => sendToRenderer("desktop:window-focus"));
+
 	if (isDev && process.env.ELECTRON_RENDERER_URL) {
 		await mainWindow.loadURL(process.env.ELECTRON_RENDERER_URL);
 	} else {
@@ -981,7 +966,7 @@ function registerIpc() {
 
 	ipcMain.handle(
 		"desktop:watch-path",
-		async (_event, { watchId, path: watchPath, options }) => {
+		async (_event, { watchId, path: watchPath }) => {
 			const id = String(watchId);
 			const resolved = assertGranted(watchPath);
 			const emit = (changedPath: string) => {
@@ -990,35 +975,16 @@ function registerIpc() {
 				]);
 			};
 
-			const replaceWatcher = async (currentWatcher: FSWatcher) => {
-				await currentWatcher.close();
-				if (watchers.get(id) !== currentWatcher) return;
-				const next = await createWatcher();
-				if (watchers.get(id) === currentWatcher) {
-					watchers.set(id, next);
-				} else {
-					await next.close();
-				}
-			};
-
 			const createWatcher = async () => {
-				const ignoreRules = options?.recursive
-					? await collectWorkspaceIgnoreRules(resolved)
-					: [];
 				const watcher = chokidar.watch(resolved, {
 					ignoreInitial: true,
-					depth: options?.recursive ? undefined : 0,
-					ignored: options?.recursive
-						? (path) => isIgnoredByRules(path, ignoreRules)
-						: undefined,
+					// Only the active file uses this watcher. The sidebar refreshes from
+					// snapshots so large workspaces do not create one watcher per folder.
+					depth: 0,
 				});
-				/** Changes to .ignore or .gitignore files can change which markdown files should be indexed. Replace the watcher in this case. */
 				const emitFile = (changedPath: string) => {
 					if (isMarkdownPath(changedPath)) {
 						emit(changedPath);
-					} else if (isIgnoreConfigPath(changedPath)) {
-						emit(changedPath);
-						void replaceWatcher(watcher);
 					}
 				};
 				watcher.on("add", emitFile);
@@ -1027,7 +993,7 @@ function registerIpc() {
 				watcher.on("addDir", emit);
 				watcher.on("unlinkDir", emit);
 				watcher.on("error", (error) => {
-					console.error("Workspace watcher failed:", error);
+					console.error("File watcher failed:", error);
 				});
 				return watcher;
 			};

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -83,6 +83,9 @@ const desktopApi = {
 		subscribe("desktop:menu-open-settings", callback),
 	onMenuShowWorkspaceSwitcher: (callback) =>
 		subscribe("desktop:menu-show-workspace-switcher", callback),
+	onMenuSyncWorkspace: (callback) =>
+		subscribe("desktop:menu-sync-workspace", callback),
+	onWindowFocus: (callback) => subscribe("desktop:window-focus", callback),
 } satisfies DesktopApi;
 
 contextBridge.exposeInMainWorld("desktopApi", desktopApi);

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,7 +1,7 @@
 import { Button, EditorView, type WikiTarget } from "@hubble.md/ui";
 import { useStoreValue } from "@simplestack/store/react";
 import { keymatch } from "keymatch";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { SettingsDialog } from "./components/SettingsDialog";
 import { Sidebar } from "./components/Sidebar";
@@ -25,6 +25,7 @@ import {
 	openWorkspace,
 	openWorkspaceWithSidebar,
 	refreshFiles,
+	refreshFilesDebounced,
 	reloadFromDiskConflict,
 	savePathContent,
 	setSidebarOpen,
@@ -63,7 +64,6 @@ function App() {
 		null,
 	);
 	const [dismissedVersion, setDismissedVersion] = useState<string | null>(null);
-	const syncWorkspaceTimerRef = useRef<number | null>(null);
 	const readyVersion =
 		updateState?.status === "ready"
 			? (updateState.availableVersion ?? "__unknown__")
@@ -144,27 +144,6 @@ function App() {
 		}
 	}, []);
 
-	const syncWorkspace = useCallback((delayMs = 0) => {
-		if (syncWorkspaceTimerRef.current !== null) {
-			window.clearTimeout(syncWorkspaceTimerRef.current);
-		}
-		syncWorkspaceTimerRef.current = window.setTimeout(() => {
-			syncWorkspaceTimerRef.current = null;
-			// The sidebar is snapshot-based; focus/menu sync replaces the old
-			// recursive workspace watcher that could exhaust file handles.
-			if (!workspaceStore.get().workspacePath) return;
-			void refreshFiles();
-		}, delayMs);
-	}, []);
-
-	useEffect(() => {
-		return () => {
-			if (syncWorkspaceTimerRef.current !== null) {
-				window.clearTimeout(syncWorkspaceTimerRef.current);
-			}
-		};
-	}, []);
-
 	useEffect(() => {
 		void desktopApi.setMenuState({ hasWorkspace });
 	}, [hasWorkspace]);
@@ -235,21 +214,21 @@ function App() {
 			desktopApi.onMenuShowWorkspaceSwitcher(() =>
 				setWorkspaceSwitcherOpen(true),
 			),
-			desktopApi.onMenuSyncWorkspace(() => syncWorkspace()),
+			desktopApi.onMenuSyncWorkspace(() => void refreshFiles()),
 		];
 		return () => {
 			for (const dispose of disposers) dispose();
 		};
-	}, [openFilePicker, openSettings, syncWorkspace]);
+	}, [openFilePicker, openSettings]);
 
 	useEffect(() => {
 		// Window focus can fire in bursts when switching apps, so debounce the
 		// sidebar refresh and keep the editor interactive while it runs.
-		const dispose = desktopApi.onWindowFocus(() => syncWorkspace(300));
+		const dispose = desktopApi.onWindowFocus(() => refreshFilesDebounced());
 		return () => {
 			dispose();
 		};
-	}, [syncWorkspace]);
+	}, []);
 
 	useEffect(() => {
 		let active = true;

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,7 +1,7 @@
 import { Button, EditorView, type WikiTarget } from "@hubble.md/ui";
 import { useStoreValue } from "@simplestack/store/react";
 import { keymatch } from "keymatch";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { SettingsDialog } from "./components/SettingsDialog";
 import { Sidebar } from "./components/Sidebar";
@@ -63,6 +63,7 @@ function App() {
 		null,
 	);
 	const [dismissedVersion, setDismissedVersion] = useState<string | null>(null);
+	const syncWorkspaceTimerRef = useRef<number | null>(null);
 	const readyVersion =
 		updateState?.status === "ready"
 			? (updateState.availableVersion ?? "__unknown__")
@@ -91,37 +92,6 @@ function App() {
 		}
 		await desktopApi.checkForUpdates();
 	}, [installUpdate, updateState]);
-
-	useEffect(() => {
-		if (!workspacePath) return;
-
-		let disposed = false;
-		let unwatch: null | (() => void) = null;
-
-		const handleChange = async (paths: string[]) => {
-			if (paths.length === 0) return;
-			void refreshFiles(workspacePath);
-		};
-
-		const setup = async () => {
-			unwatch = await desktopApi.watchPath(
-				workspacePath,
-				{ recursive: true },
-				(paths) => void handleChange(paths),
-			);
-			if (disposed && unwatch) {
-				unwatch();
-			}
-		};
-
-		void setup();
-		return () => {
-			disposed = true;
-			if (unwatch) {
-				unwatch();
-			}
-		};
-	}, [workspacePath]);
 
 	useEffect(() => {
 		const currentPath = state.currentPath;
@@ -172,6 +142,27 @@ function App() {
 		if (typeof selected === "string") {
 			await loadPath(selected);
 		}
+	}, []);
+
+	const syncWorkspace = useCallback((delayMs = 0) => {
+		if (syncWorkspaceTimerRef.current !== null) {
+			window.clearTimeout(syncWorkspaceTimerRef.current);
+		}
+		syncWorkspaceTimerRef.current = window.setTimeout(() => {
+			syncWorkspaceTimerRef.current = null;
+			// The sidebar is snapshot-based; focus/menu sync replaces the old
+			// recursive workspace watcher that could exhaust file handles.
+			if (!workspaceStore.get().workspacePath) return;
+			void refreshFiles();
+		}, delayMs);
+	}, []);
+
+	useEffect(() => {
+		return () => {
+			if (syncWorkspaceTimerRef.current !== null) {
+				window.clearTimeout(syncWorkspaceTimerRef.current);
+			}
+		};
 	}, []);
 
 	useEffect(() => {
@@ -244,11 +235,21 @@ function App() {
 			desktopApi.onMenuShowWorkspaceSwitcher(() =>
 				setWorkspaceSwitcherOpen(true),
 			),
+			desktopApi.onMenuSyncWorkspace(() => syncWorkspace()),
 		];
 		return () => {
 			for (const dispose of disposers) dispose();
 		};
-	}, [openFilePicker, openSettings]);
+	}, [openFilePicker, openSettings, syncWorkspace]);
+
+	useEffect(() => {
+		// Window focus can fire in bursts when switching apps, so debounce the
+		// sidebar refresh and keep the editor interactive while it runs.
+		const dispose = desktopApi.onWindowFocus(() => syncWorkspace(300));
+		return () => {
+			dispose();
+		};
+	}, [syncWorkspace]);
 
 	useEffect(() => {
 		let active = true;

--- a/apps/desktop/src/desktopApi/types.ts
+++ b/apps/desktop/src/desktopApi/types.ts
@@ -106,4 +106,6 @@ export type DesktopApi = {
 	onMenuOpenFolder(callback: () => void): Unsubscribe;
 	onMenuOpenSettings(callback: () => void): Unsubscribe;
 	onMenuShowWorkspaceSwitcher(callback: () => void): Unsubscribe;
+	onMenuSyncWorkspace(callback: () => void): Unsubscribe;
+	onWindowFocus(callback: () => void): Unsubscribe;
 };

--- a/apps/desktop/src/store/actions.test.ts
+++ b/apps/desktop/src/store/actions.test.ts
@@ -193,6 +193,45 @@ describe("desktop renameMarkdownFile", () => {
 	});
 });
 
+describe("desktop loadPath", () => {
+	beforeEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("refreshes the sidebar when a selected file no longer exists", async () => {
+		const api = createDesktopApi();
+		const missingPath = "/workspace/missing.md";
+		const remainingPath = "/workspace/remaining.md";
+		api.readFileText.mockRejectedValue(
+			new Error(`ENOENT: no such file or directory, open '${missingPath}'`),
+		);
+		api.listDirectory.mockResolvedValue([
+			{ path: remainingPath, modified_at: 2 },
+		]);
+		const { appStore, loadPath, workspaceStore } = await loadStoreActions(api);
+
+		appStore.set((current) => ({
+			...current,
+			workspace: {
+				...current.workspace,
+				workspacePath: "/workspace",
+				files: [
+					{ path: missingPath, modified_at: 1 },
+					{ path: remainingPath, modified_at: 2 },
+				],
+			},
+		}));
+
+		await loadPath(missingPath);
+
+		await vi.waitFor(() => {
+			expect(workspaceStore.get().files).toEqual([
+				{ path: remainingPath, modified_at: 2 },
+			]);
+		});
+	});
+});
+
 describe("desktop pinned notes", () => {
 	beforeEach(() => {
 		vi.unstubAllGlobals();

--- a/apps/desktop/src/store/actions.test.ts
+++ b/apps/desktop/src/store/actions.test.ts
@@ -230,6 +230,40 @@ describe("desktop loadPath", () => {
 			]);
 		});
 	});
+
+	it("debounces repeated missing-file sidebar refreshes", async () => {
+		vi.useFakeTimers();
+		try {
+			const api = createDesktopApi();
+			api.readFileText.mockRejectedValue(
+				new Error("ENOENT: no such file or directory"),
+			);
+			api.listDirectory.mockResolvedValue([]);
+			const { appStore, loadPath } = await loadStoreActions(api);
+
+			appStore.set((current) => ({
+				...current,
+				workspace: {
+					...current.workspace,
+					workspacePath: "/workspace",
+					files: [
+						{ path: "/workspace/a.md", modified_at: 1 },
+						{ path: "/workspace/b.md", modified_at: 1 },
+					],
+				},
+			}));
+
+			await loadPath("/workspace/a.md");
+			await loadPath("/workspace/b.md");
+
+			expect(api.listDirectory).not.toHaveBeenCalled();
+			await vi.advanceTimersByTimeAsync(250);
+
+			expect(api.listDirectory).toHaveBeenCalledTimes(1);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
 });
 
 describe("desktop pinned notes", () => {

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -40,6 +40,12 @@ export async function refreshFiles(path = workspaceStore.get().workspacePath) {
 	});
 }
 
+/**
+ * Debounced wrapper for event-driven sidebar refreshes.
+ *
+ * Keep `refreshFiles()` immediate for user actions that await a fresh snapshot.
+ * Prefer debounced for refreshes triggered by effects.
+ */
 export function refreshFilesDebounced(
 	path = workspaceStore.get().workspacePath,
 ) {

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -22,6 +22,7 @@ import {
 } from "./state";
 
 const REFRESH_FILES_DEBOUNCE_MS = 250;
+const missingPathErrorPattern = /\bENOENT\b|\bENOTDIR\b/;
 let refreshFilesTimer: ReturnType<typeof setTimeout> | null = null;
 
 export async function refreshFiles(path = workspaceStore.get().workspacePath) {
@@ -61,12 +62,17 @@ function errorMessage(err: unknown) {
 	return err instanceof Error ? err.message : String(err);
 }
 
-function syncWorkspaceAfterMissingPath(err: unknown) {
-	const message = errorMessage(err);
-	if (!/\bENOENT\b|\bENOTDIR\b/.test(message)) return;
+function refreshFilesAfterMissingPath(message: string) {
+	if (!missingPathErrorPattern.test(message)) return;
 	// Missing files usually mean the sidebar snapshot is stale because Hubble no
 	// longer watches the whole workspace.
 	refreshFilesDebounced();
+}
+
+function fileErrorMessage(err: unknown) {
+	const message = errorMessage(err);
+	refreshFilesAfterMissingPath(message);
+	return message;
 }
 
 function relativeWorkspacePath(path: string, workspacePath: string | null) {
@@ -111,8 +117,7 @@ async function syncPinnedNotes() {
 	try {
 		await writePinnedNotes(workspacePath, workspaceStore.get().pinnedNotes);
 	} catch (err) {
-		syncWorkspaceAfterMissingPath(err);
-		const message = errorMessage(err);
+		const message = fileErrorMessage(err);
 		toast.error("Failed to update pinned notes", { description: message });
 	}
 }
@@ -292,8 +297,7 @@ export async function savePathContent(
 			};
 		});
 	} catch (err) {
-		syncWorkspaceAfterMissingPath(err);
-		const message = errorMessage(err);
+		const message = fileErrorMessage(err);
 		toast.error("Failed to save file", { description: message });
 		viewerStore.set((state) => {
 			if (state.currentPath !== path) return state;
@@ -367,8 +371,7 @@ export async function renameMarkdownFile(path: string, nextName: string) {
 		}
 	} catch (err) {
 		pendingRenames.delete(path);
-		syncWorkspaceAfterMissingPath(err);
-		const message = errorMessage(err);
+		const message = fileErrorMessage(err);
 		toast.error("Failed to rename file", { description: message });
 	} finally {
 		window.setTimeout(() => pendingRenames.delete(path), 1000);
@@ -394,8 +397,7 @@ export async function createMarkdownFileInFolder(parentPath: string) {
 		await refreshFiles();
 		return path;
 	} catch (err) {
-		syncWorkspaceAfterMissingPath(err);
-		const message = errorMessage(err);
+		const message = fileErrorMessage(err);
 		toast.error("Failed to create file", { description: message });
 		return null;
 	}
@@ -436,8 +438,7 @@ export async function deleteMarkdownFile(path: string) {
 		await syncPinnedNotes();
 		await refreshFiles();
 	} catch (err) {
-		syncWorkspaceAfterMissingPath(err);
-		const message = errorMessage(err);
+		const message = fileErrorMessage(err);
 		toast.error("Failed to delete file", { description: message });
 	}
 }
@@ -482,8 +483,7 @@ export async function deleteFolder(path: string) {
 		await syncPinnedNotes();
 		await refreshFiles();
 	} catch (err) {
-		syncWorkspaceAfterMissingPath(err);
-		const message = errorMessage(err);
+		const message = fileErrorMessage(err);
 		toast.error("Failed to delete folder", { description: message });
 	}
 }
@@ -532,8 +532,7 @@ export const loadPath = latest(async ({ isStale }, path: string) => {
 		appStore.set((state) => withOpenedDoc(state, path, content));
 	} catch (err) {
 		if (isStale()) return;
-		syncWorkspaceAfterMissingPath(err);
-		const message = errorMessage(err);
+		const message = fileErrorMessage(err);
 		toast.error("Failed to open file", { description: message });
 		viewerStore.set((state) => ({
 			...emptyDoc(state.lastOpenedPath),
@@ -559,8 +558,7 @@ export async function togglePinnedNote(path: string) {
 	try {
 		await writePinnedNotes(workspacePath, nextPinnedNotes);
 	} catch (err) {
-		syncWorkspaceAfterMissingPath(err);
-		const message = errorMessage(err);
+		const message = fileErrorMessage(err);
 		toast.error("Failed to update pinned notes", { description: message });
 		await loadPinnedNotes(workspacePath);
 	}

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -37,6 +37,18 @@ export async function refreshFiles(path = workspaceStore.get().workspacePath) {
 	});
 }
 
+function errorMessage(err: unknown) {
+	return err instanceof Error ? err.message : String(err);
+}
+
+function syncWorkspaceAfterMissingPath(err: unknown) {
+	const message = errorMessage(err);
+	if (!/\bENOENT\b|\bENOTDIR\b/.test(message)) return;
+	// Missing files usually mean the sidebar snapshot is stale because Hubble no
+	// longer watches the whole workspace.
+	void refreshFiles();
+}
+
 function relativeWorkspacePath(path: string, workspacePath: string | null) {
 	if (!workspacePath) return path;
 	const prefix = workspacePath.endsWith("/")
@@ -79,7 +91,8 @@ async function syncPinnedNotes() {
 	try {
 		await writePinnedNotes(workspacePath, workspaceStore.get().pinnedNotes);
 	} catch (err) {
-		const message = err instanceof Error ? err.message : String(err);
+		syncWorkspaceAfterMissingPath(err);
+		const message = errorMessage(err);
 		toast.error("Failed to update pinned notes", { description: message });
 	}
 }
@@ -259,7 +272,8 @@ export async function savePathContent(
 			};
 		});
 	} catch (err) {
-		const message = err instanceof Error ? err.message : String(err);
+		syncWorkspaceAfterMissingPath(err);
+		const message = errorMessage(err);
 		toast.error("Failed to save file", { description: message });
 		viewerStore.set((state) => {
 			if (state.currentPath !== path) return state;
@@ -333,7 +347,8 @@ export async function renameMarkdownFile(path: string, nextName: string) {
 		}
 	} catch (err) {
 		pendingRenames.delete(path);
-		const message = err instanceof Error ? err.message : String(err);
+		syncWorkspaceAfterMissingPath(err);
+		const message = errorMessage(err);
 		toast.error("Failed to rename file", { description: message });
 	} finally {
 		window.setTimeout(() => pendingRenames.delete(path), 1000);
@@ -359,7 +374,8 @@ export async function createMarkdownFileInFolder(parentPath: string) {
 		await refreshFiles();
 		return path;
 	} catch (err) {
-		const message = err instanceof Error ? err.message : String(err);
+		syncWorkspaceAfterMissingPath(err);
+		const message = errorMessage(err);
 		toast.error("Failed to create file", { description: message });
 		return null;
 	}
@@ -400,7 +416,8 @@ export async function deleteMarkdownFile(path: string) {
 		await syncPinnedNotes();
 		await refreshFiles();
 	} catch (err) {
-		const message = err instanceof Error ? err.message : String(err);
+		syncWorkspaceAfterMissingPath(err);
+		const message = errorMessage(err);
 		toast.error("Failed to delete file", { description: message });
 	}
 }
@@ -445,7 +462,8 @@ export async function deleteFolder(path: string) {
 		await syncPinnedNotes();
 		await refreshFiles();
 	} catch (err) {
-		const message = err instanceof Error ? err.message : String(err);
+		syncWorkspaceAfterMissingPath(err);
+		const message = errorMessage(err);
 		toast.error("Failed to delete folder", { description: message });
 	}
 }
@@ -494,7 +512,8 @@ export const loadPath = latest(async ({ isStale }, path: string) => {
 		appStore.set((state) => withOpenedDoc(state, path, content));
 	} catch (err) {
 		if (isStale()) return;
-		const message = err instanceof Error ? err.message : String(err);
+		syncWorkspaceAfterMissingPath(err);
+		const message = errorMessage(err);
 		toast.error("Failed to open file", { description: message });
 		viewerStore.set((state) => ({
 			...emptyDoc(state.lastOpenedPath),
@@ -520,7 +539,8 @@ export async function togglePinnedNote(path: string) {
 	try {
 		await writePinnedNotes(workspacePath, nextPinnedNotes);
 	} catch (err) {
-		const message = err instanceof Error ? err.message : String(err);
+		syncWorkspaceAfterMissingPath(err);
+		const message = errorMessage(err);
 		toast.error("Failed to update pinned notes", { description: message });
 		await loadPinnedNotes(workspacePath);
 	}

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -69,7 +69,7 @@ function refreshFilesAfterMissingPath(message: string) {
 	refreshFilesDebounced();
 }
 
-function fileErrorMessage(err: unknown) {
+function handleFileError(err: unknown) {
 	const message = errorMessage(err);
 	refreshFilesAfterMissingPath(message);
 	return message;
@@ -117,7 +117,7 @@ async function syncPinnedNotes() {
 	try {
 		await writePinnedNotes(workspacePath, workspaceStore.get().pinnedNotes);
 	} catch (err) {
-		const message = fileErrorMessage(err);
+		const message = handleFileError(err);
 		toast.error("Failed to update pinned notes", { description: message });
 	}
 }
@@ -297,7 +297,7 @@ export async function savePathContent(
 			};
 		});
 	} catch (err) {
-		const message = fileErrorMessage(err);
+		const message = handleFileError(err);
 		toast.error("Failed to save file", { description: message });
 		viewerStore.set((state) => {
 			if (state.currentPath !== path) return state;
@@ -371,7 +371,7 @@ export async function renameMarkdownFile(path: string, nextName: string) {
 		}
 	} catch (err) {
 		pendingRenames.delete(path);
-		const message = fileErrorMessage(err);
+		const message = handleFileError(err);
 		toast.error("Failed to rename file", { description: message });
 	} finally {
 		window.setTimeout(() => pendingRenames.delete(path), 1000);
@@ -397,7 +397,7 @@ export async function createMarkdownFileInFolder(parentPath: string) {
 		await refreshFiles();
 		return path;
 	} catch (err) {
-		const message = fileErrorMessage(err);
+		const message = handleFileError(err);
 		toast.error("Failed to create file", { description: message });
 		return null;
 	}
@@ -438,7 +438,7 @@ export async function deleteMarkdownFile(path: string) {
 		await syncPinnedNotes();
 		await refreshFiles();
 	} catch (err) {
-		const message = fileErrorMessage(err);
+		const message = handleFileError(err);
 		toast.error("Failed to delete file", { description: message });
 	}
 }
@@ -483,7 +483,7 @@ export async function deleteFolder(path: string) {
 		await syncPinnedNotes();
 		await refreshFiles();
 	} catch (err) {
-		const message = fileErrorMessage(err);
+		const message = handleFileError(err);
 		toast.error("Failed to delete folder", { description: message });
 	}
 }
@@ -532,7 +532,7 @@ export const loadPath = latest(async ({ isStale }, path: string) => {
 		appStore.set((state) => withOpenedDoc(state, path, content));
 	} catch (err) {
 		if (isStale()) return;
-		const message = fileErrorMessage(err);
+		const message = handleFileError(err);
 		toast.error("Failed to open file", { description: message });
 		viewerStore.set((state) => ({
 			...emptyDoc(state.lastOpenedPath),
@@ -558,7 +558,7 @@ export async function togglePinnedNote(path: string) {
 	try {
 		await writePinnedNotes(workspacePath, nextPinnedNotes);
 	} catch (err) {
-		const message = fileErrorMessage(err);
+		const message = handleFileError(err);
 		toast.error("Failed to update pinned notes", { description: message });
 		await loadPinnedNotes(workspacePath);
 	}

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -21,8 +21,8 @@ import {
 	workspaceStore,
 } from "./state";
 
-const MISSING_PATH_SYNC_DELAY_MS = 250;
-let missingPathSyncTimer: ReturnType<typeof setTimeout> | null = null;
+const REFRESH_FILES_DEBOUNCE_MS = 250;
+let refreshFilesTimer: ReturnType<typeof setTimeout> | null = null;
 
 export async function refreshFiles(path = workspaceStore.get().workspacePath) {
 	if (!path) return;
@@ -40,6 +40,17 @@ export async function refreshFiles(path = workspaceStore.get().workspacePath) {
 	});
 }
 
+export function refreshFilesDebounced(
+	path = workspaceStore.get().workspacePath,
+) {
+	if (!path) return;
+	if (refreshFilesTimer !== null) clearTimeout(refreshFilesTimer);
+	refreshFilesTimer = setTimeout(() => {
+		refreshFilesTimer = null;
+		void refreshFiles(path);
+	}, REFRESH_FILES_DEBOUNCE_MS);
+}
+
 function errorMessage(err: unknown) {
 	return err instanceof Error ? err.message : String(err);
 }
@@ -49,11 +60,7 @@ function syncWorkspaceAfterMissingPath(err: unknown) {
 	if (!/\bENOENT\b|\bENOTDIR\b/.test(message)) return;
 	// Missing files usually mean the sidebar snapshot is stale because Hubble no
 	// longer watches the whole workspace.
-	if (missingPathSyncTimer !== null) clearTimeout(missingPathSyncTimer);
-	missingPathSyncTimer = setTimeout(() => {
-		missingPathSyncTimer = null;
-		void refreshFiles();
-	}, MISSING_PATH_SYNC_DELAY_MS);
+	refreshFilesDebounced();
 }
 
 function relativeWorkspacePath(path: string, workspacePath: string | null) {

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -21,6 +21,9 @@ import {
 	workspaceStore,
 } from "./state";
 
+const MISSING_PATH_SYNC_DELAY_MS = 250;
+let missingPathSyncTimer: ReturnType<typeof setTimeout> | null = null;
+
 export async function refreshFiles(path = workspaceStore.get().workspacePath) {
 	if (!path) return;
 	let files: FileEntry[] = [];
@@ -46,7 +49,11 @@ function syncWorkspaceAfterMissingPath(err: unknown) {
 	if (!/\bENOENT\b|\bENOTDIR\b/.test(message)) return;
 	// Missing files usually mean the sidebar snapshot is stale because Hubble no
 	// longer watches the whole workspace.
-	void refreshFiles();
+	if (missingPathSyncTimer !== null) clearTimeout(missingPathSyncTimer);
+	missingPathSyncTimer = setTimeout(() => {
+		missingPathSyncTimer = null;
+		void refreshFiles();
+	}, MISSING_PATH_SYNC_DELAY_MS);
 }
 
 function relativeWorkspacePath(path: string, workspacePath: string | null) {

--- a/docs/adr/0008-desktop-sidebar-index-is-ephemeral-navigation-state.md
+++ b/docs/adr/0008-desktop-sidebar-index-is-ephemeral-navigation-state.md
@@ -1,0 +1,31 @@
+# Desktop sidebar index is ephemeral navigation state
+
+Opening a large repo root in Hubble Desktop can make the app unresponsive if the app recursively watches every directory in the open folder. The sidebar file tree is useful navigation state, but it is not the source of truth for which files can be viewed.
+
+We choose to treat the desktop sidebar file list as an ephemeral, refreshable snapshot. Electron main owns one-shot markdown discovery for the current workspace. It respects `.gitignore` and `.ignore`, and always prunes known high-cost folders such as `.git/`, `dist/`, and `node_modules/`.
+
+The app does not keep a recursive watcher for the sidebar tree. Instead, the sidebar snapshot refreshes when the app window regains focus and when the user chooses `File > Sync Workspace`. File operations initiated inside Hubble continue to update the sidebar through existing app actions.
+
+The active editor file is different. Hubble keeps a direct non-recursive watcher on the currently open file so external edits can still trigger the existing disk-change conflict behavior.
+
+Folder expansion in the sidebar is presentational. Expanding a folder reveals paths from the current snapshot; it does not request a new crawl for that folder. Ignored files and files outside the sidebar snapshot can still be opened when the user explicitly picks them or when Hubble restores a readable last-opened file. Ignore rules filter sidebar discovery; they are not an access boundary.
+
+The first implementation will not persist the sidebar snapshot between app launches. Rebuilding the snapshot on boot avoids stale-cache invalidation for renamed folders, deleted files, changed ignore rules, and Hubble version changes.
+
+## Consequences
+
+- This refines ADR-0001 for desktop local folders: the editor can be usable even when sidebar navigation is stale or still refreshing.
+- The current file may have no matching selected row in the sidebar.
+- External sidebar changes are visible after focus refresh or `Sync Workspace`, not instantly.
+- Closing and reopening Hubble recrawls the open folder.
+- Sidebar absence is not equivalent to file deletion; a file can leave the sidebar because ignore rules changed.
+- Recursive watcher exhaustion is avoided for large folders.
+
+## Deferred optimizations
+
+- Persist the sidebar snapshot and validate it on next boot with cache versioning, file mtimes, and ignore-file mtimes.
+- Stream partial results into the sidebar instead of replacing the snapshot after each crawl.
+- Prioritize crawling expanded or visible folders if streaming results are introduced.
+- Add bounded subtree watchers only for small or expanded folders, with a hard watcher budget.
+- Add an optional Watchman backend behind the same refresh interface for very large folders.
+- Use Git-backed discovery for Git folders with `git ls-files --cached --others --exclude-standard`.

--- a/specs/gh-31/PRODUCT.md
+++ b/specs/gh-31/PRODUCT.md
@@ -1,0 +1,60 @@
+# Stronger markdown file crawling
+
+## Summary
+
+Opening a large folder in Hubble Desktop should keep the editor usable and avoid recursive filesystem watchers. The sidebar is a refreshable Markdown File snapshot, while the currently open file is watched directly for external edits.
+
+## Problem
+
+Opening a large repo root can currently hang the desktop app or trigger watcher exhaustion. Users experience this as beachballing, `EMFILE` errors, or repeated sidebar refresh work after unrelated filesystem changes.
+
+## Goals
+
+- Large Workspace Folders and Plain Folders remain usable after opening.
+- The sidebar lists only Markdown Files that are inside the open folder and not ignored.
+- Explicitly opened or restored files remain viewable even when ignored and absent from the sidebar.
+- The active file continues to detect external disk changes.
+- The sidebar can be refreshed on app focus and from a manual menu action.
+
+## Non-goals
+
+- No continuous directory-tree watcher for the sidebar.
+- No persisted sidebar index.
+- No Cloud Sync or web Workspace behavior changes.
+- No new user-facing file type support beyond existing markdown extensions.
+- No requirement for users to install Watchman or another external service.
+
+## Behavior
+
+1. When a user opens a Workspace Folder or Plain Folder, Hubble Desktop loads the folder and builds a sidebar snapshot from markdown files.
+2. The initial crawl includes `.md`, `.markdown`, and `.mdown` files.
+3. The crawl excludes non-markdown files from the sidebar.
+4. The crawl respects `.gitignore` and `.ignore` files from the open folder and nested folders.
+5. The crawl always excludes `.git/`, `dist/`, and `node_modules/`, even if ignore files do not.
+6. Ignore rules affect sidebar discovery only; an ignored file can still be viewed when opened explicitly or restored from app state.
+7. Ignored folders do not appear in the sidebar and do not need to be opened by Hubble to find sidebar-visible children.
+8. Expanding a sidebar folder is presentational: it reveals paths from the current snapshot and does not start a folder-specific crawl.
+9. Hubble does not maintain a recursive filesystem watcher for the sidebar file tree.
+10. When the app window regains focus, Hubble refreshes the sidebar snapshot for the current workspace.
+11. The File menu includes `Sync Workspace`, enabled when a workspace is open, to manually refresh the sidebar snapshot.
+12. App-driven file creates, renames, and deletes continue to update the sidebar through existing actions.
+13. External creates, renames, deletes, or ignore-file edits appear in the sidebar after app focus or `Sync Workspace`.
+14. If the active markdown file changes on disk, the editor keeps the existing external-change conflict behavior whether or not that file appears in the sidebar.
+15. If the active markdown file is ignored, it can stay open while remaining absent from the sidebar.
+16. If the active markdown file is deleted externally, the existing active-file watcher behavior handles that file without requiring a sidebar watcher.
+17. Repeated focus events should settle into one sidebar refresh instead of starting overlapping refreshes.
+18. Workspace switching is latest-wins: stale refreshes from a previous open folder must not mutate the newly opened folder state.
+19. Closing and reopening the app starts a fresh sidebar crawl; no persisted index is required for this slice.
+
+## UX validation
+
+Use Hubble Desktop with a large repo folder:
+
+1. Open `/Users/benholmes/Projects` or another large folder.
+2. Confirm there is no recursive watcher `EMFILE` spam and the app remains responsive.
+3. Confirm the sidebar lists sidebar-visible markdown files only.
+4. Open a specific markdown file with Open File; confirm it loads even if absent from the sidebar.
+5. Add an ignore rule for the active file; use `Sync Workspace` and confirm the file can stay open while disappearing from the sidebar.
+6. Create, rename, or delete a markdown file outside the app; focus Hubble or choose `Sync Workspace` and confirm the sidebar refreshes.
+7. Edit the active markdown file outside the app and confirm the existing external-change behavior still appears.
+8. Switch folders while a refresh is in flight; confirm the latest folder remains the one shown.

--- a/specs/gh-31/TECH.md
+++ b/specs/gh-31/TECH.md
@@ -1,0 +1,105 @@
+# Stronger markdown file crawling
+
+## Context
+
+Issue #31 specifies stronger desktop markdown crawling for large open folders. Research against `/Users/benholmes/Projects` showed the recursive watcher was the bottleneck, not the initial markdown crawl:
+
+- Snapshot crawl found thousands of markdown files in roughly one second.
+- The folder had roughly 24k non-ignored directories.
+- Recursive watching hit `EMFILE: too many open files, watch` and made the app beachball.
+
+The implementation should remove the sidebar's directory-tree watcher and keep only a direct watcher for the active file.
+
+Relevant code:
+
+- `apps/desktop/electron/main.ts` owns filesystem grants, `desktop:list-directory`, recursive markdown crawling, ignore parsing, menus, and `desktop:watch-path`.
+- `apps/desktop/electron/preload.ts` exposes the typed renderer bridge.
+- `apps/desktop/src/desktopApi/types.ts` defines the renderer-facing API.
+- `apps/desktop/src/App.tsx` subscribes to menu events, active-file watcher events, startup restoration, and app-level refresh triggers.
+- `apps/desktop/src/store/actions.ts` owns `refreshFiles`, file mutations, explicit `loadPath`, persisted last-opened path updates, and external file change handling.
+- `apps/desktop/src/store/persistence.ts` persists `workspacePath`, `lastOpenedPaths`, `document.lastOpenedPath`, and sidebar open state, but not the file list.
+- `docs/adr/0008-desktop-sidebar-index-is-ephemeral-navigation-state.md` records the sidebar file list as navigation state, not a file access boundary.
+
+## Affected apps and packages
+
+- `apps/desktop`: implement the watcher removal, focus/menu refresh bridge, renderer subscriptions, docs, and tests.
+- `packages/ui`: no planned changes.
+- `packages/sync`, `packages/sync-backend`, `packages/convex-client`, `packages/cli`, `apps/www`: no planned changes.
+
+## Architecture
+
+Use a snapshot-plus-refresh model.
+
+- `desktop:list-directory` remains the one-shot markdown discovery API.
+- `refreshFiles()` remains the renderer action that replaces `workspace.files` when the workspace path still matches.
+- No workspace/sidebar watcher is created.
+- `desktopApi.watchPath(currentPath, { recursive: false })` remains for the active editor file.
+- Electron main emits `desktop:window-focus` when the BrowserWindow focuses.
+- The renderer debounces focus events and calls `refreshFiles()`.
+- Electron main adds a `Sync Workspace` File menu item that emits `desktop:menu-sync-workspace`.
+- The renderer handles `Sync Workspace` through the same refresh callback.
+
+## Detailed plan
+
+1. Remove the indexer prototype.
+   - Delete `apps/desktop/electron/fileIndex.ts`.
+   - Delete `apps/desktop/electron/fileIndex.test.ts`.
+   - Delete `apps/desktop/electron/fileRules.ts`.
+   - Delete `apps/desktop/electron/fileRules.test.ts`.
+   - Remove `watchWorkspaceFiles` / `unwatchWorkspaceFiles` bridge and IPC.
+   - Keep ignore-aware snapshot crawling in `main.ts` for this slice.
+2. Keep active-file watching.
+   - Preserve the existing `App.tsx` effect that watches `state.currentPath`.
+   - Keep `recursive: false`.
+   - Keep existing external-change conflict behavior.
+3. Add app-focus refresh.
+   - In `createWindow()`, register `mainWindow.on("focus", () => sendToRenderer("desktop:window-focus"))`.
+   - Expose `desktopApi.onWindowFocus(callback)`.
+   - In `App.tsx`, debounce focus events by a short delay, then call `refreshFiles()` if a workspace is open.
+4. Add manual menu refresh.
+   - Add `File > Sync Workspace`.
+   - Enable it only when `menuState.hasWorkspace` is true.
+   - Emit `desktop:menu-sync-workspace`.
+   - Expose `desktopApi.onMenuSyncWorkspace(callback)`.
+   - Reuse the same renderer refresh callback as focus refresh.
+5. Preserve explicit ignored-file access.
+   - Do not use sidebar membership as an access check.
+   - Leave `loadPath` and file picker behavior independent from `workspace.files`.
+6. Keep stale refreshes safe.
+   - Rely on `refreshFiles(path)` checking `state.workspacePath !== path` before writing files.
+   - Do not clear the active editor just because a file is absent from the refreshed sidebar snapshot.
+
+## Testing and validation
+
+Automated checks:
+
+- `pnpm --filter @hubble.md/desktop test`
+- `pnpm check`
+- `pnpm build:desktop`
+
+Manual desktop validation:
+
+1. Run the desktop app.
+2. Open `/Users/benholmes/Projects`.
+3. Confirm no `EMFILE` watcher spam appears.
+4. Confirm the app remains responsive while scrolling the sidebar.
+5. Confirm `File > Sync Workspace` is enabled with a workspace open.
+6. Create or delete a markdown file outside Hubble; choose `Sync Workspace`; confirm the sidebar updates.
+7. Create or delete a markdown file outside Hubble; blur and refocus Hubble; confirm the sidebar updates.
+8. Edit the active markdown file outside Hubble; confirm the active-file watcher still triggers existing external-change behavior.
+9. Open an ignored markdown file explicitly; confirm it is viewable and absent from the sidebar.
+
+## Risks and mitigations
+
+- External sidebar changes are not instant. This is intentional; focus refresh and manual sync replace high-cost recursive watching.
+- Large refreshes can still take time. Current measurement shows snapshot crawling is acceptable compared with watcher overhead.
+- Focus events can fire repeatedly. Debounce renderer refreshes.
+- Menu sync can race with workspace switching. Keep path guards in `refreshFiles`.
+
+## Deferred optimizations
+
+- Persist the sidebar snapshot and validate it on next boot with cache versioning, file mtimes, and ignore-file mtimes.
+- Stream partial results into the sidebar instead of replacing the snapshot after each crawl.
+- Add bounded subtree watchers only for small or expanded folders, with a hard watcher budget.
+- Add an optional Watchman backend behind the same refresh/index interface for very large folders.
+- Use Git-backed discovery for Git folders with `git ls-files --cached --others --exclude-standard`.


### PR DESCRIPTION
## Summary
- remove the recursive workspace/sidebar watcher that caused EMFILE and beachballing on large folders
- keep the active-file watcher for external edit/conflict handling
- refresh the sidebar snapshot on app focus and via File > Sync Workspace
- keep ignored files openable/restorable even when absent from the sidebar
- update PRODUCT/TECH specs and ADR-0008 for the snapshot-based sidebar model

## Checks
- pnpm --filter @hubble.md/desktop test
- pnpm check
- pnpm build:desktop
- smoke: dev app opened playground sidebar and showed File > Sync Workspace
- diagnosis: recursive chokidar watch on /Users/benholmes/Projects hit EMFILE; snapshot crawl was ~1s for 4,268 markdown files

Closes #31