### PR TITLE
Add fenced code block support

### DIFF
--- a/packages/editor/src/CodeBlockMarkdown.test.ts
+++ b/packages/editor/src/CodeBlockMarkdown.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { markdownToTiptapDoc } from "./markdownToProsemirror";
+import { tiptapDocToMarkdown } from "./prosemirrorToMarkdown";
+
+describe("code block markdown conversion", () => {
+	it("preserves fenced code block language", () => {
+		const doc = markdownToTiptapDoc("```ts\nconst x: number = 1;\n```");
+
+		expect(doc.content?.[0]).toEqual({
+			type: "codeBlock",
+			attrs: { language: "ts" },
+			content: [{ type: "text", text: "const x: number = 1;" }],
+		});
+		expect(tiptapDocToMarkdown(doc)).toBe("```ts\nconst x: number = 1;\n```");
+	});
+
+	it("keeps bare fenced code blocks bare", () => {
+		const doc = markdownToTiptapDoc("```\nplain\n```");
+
+		expect(doc.content?.[0]?.attrs).toEqual({ language: null });
+		expect(tiptapDocToMarkdown(doc)).toBe("```\nplain\n```");
+	});
+});

--- a/packages/editor/src/markdownToProsemirror.ts
+++ b/packages/editor/src/markdownToProsemirror.ts
@@ -76,7 +76,7 @@ function blockToPM(node: Content): JSONContent[] {
 			return [
 				{
 					type: "codeBlock",
-					// TipTap CodeBlock (not Lowlight) doesn’t have a language attr in StarterKit; keep plain.
+					attrs: { language: node.lang ?? null },
 					content: node.value ? [{ type: "text", text: node.value }] : [],
 				},
 			];

--- a/packages/editor/src/prosemirrorToMarkdown.ts
+++ b/packages/editor/src/prosemirrorToMarkdown.ts
@@ -44,9 +44,13 @@ function blockToMarkdown(node: JSONContent): string {
 		}
 
 		case "codeBlock": {
-			const content = node.content?.[0]?.text ?? "";
-			// Use triple backticks for code blocks
-			return `\`\`\`\n${content}\n\`\`\``;
+			const content =
+				node.content
+					?.map((child) => (child.type === "text" ? (child.text ?? "") : ""))
+					.join("") ?? "";
+			const language =
+				typeof node.attrs?.language === "string" ? node.attrs.language : "";
+			return `\`\`\`${language}\n${content}\n\`\`\``;
 		}
 
 		case "horizontalRule": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -29,6 +29,7 @@
 		"@floating-ui/dom": "^1.7.5",
 		"@hubble.md/editor": "workspace:*",
 		"@tiptap/core": "^3.4.3",
+		"@tiptap/extension-code-block-lowlight": "3.20.0",
 		"@tiptap/extension-list": "^3.4.2",
 		"@tiptap/pm": "^3.3.0",
 		"@tiptap/react": "^3.3.0",
@@ -36,7 +37,9 @@
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
 		"cmdk": "^1.1.1",
+		"highlight.js": "^11.11.1",
 		"keymatch": "^1.0.5",
+		"lowlight": "^3.3.0",
 		"tailwind-merge": "^3.5.0",
 		"zod": "^4.4.3"
 	},

--- a/packages/ui/src/editor/CodeBlockExtension.tsx
+++ b/packages/ui/src/editor/CodeBlockExtension.tsx
@@ -1,0 +1,170 @@
+import { Select } from "@base-ui/react/select";
+import { CodeBlockLowlight } from "@tiptap/extension-code-block-lowlight";
+import { TextSelection } from "@tiptap/pm/state";
+import {
+	NodeViewContent,
+	type NodeViewProps,
+	NodeViewWrapper,
+	ReactNodeViewRenderer,
+} from "@tiptap/react";
+import { common, createLowlight } from "lowlight";
+import { useState } from "react";
+import MingcuteCopy2Line from "~icons/mingcute/copy-2-line";
+import MingcuteSelectorVerticalLine from "~icons/mingcute/selector-vertical-line";
+import { Button } from "../primitives/button";
+
+const TAB_SIZE = 4;
+
+const lowlight = createLowlight(common);
+lowlight.registerAlias({
+	javascript: ["js", "jsx"],
+	typescript: ["ts", "tsx"],
+	xml: ["html"],
+	bash: ["sh", "shell"],
+	markdown: ["md"],
+});
+
+export const HubbleCodeBlock = CodeBlockLowlight.extend({
+	addKeyboardShortcuts() {
+		return {
+			...this.parent?.(),
+			Backspace: ({ editor }) => {
+				const { state } = editor;
+				const { selection } = state;
+				if (!selection.empty) return false;
+
+				const { $from } = selection;
+				if ($from.parent.type !== this.type) return false;
+
+				const blockStart = $from.start();
+				const textBeforeCursor = state.doc.textBetween(
+					blockStart,
+					$from.pos,
+					"\n",
+					"\n",
+				);
+				const lineStart = textBeforeCursor.lastIndexOf("\n") + 1;
+				const column = textBeforeCursor.length - lineStart;
+				const linePrefix = textBeforeCursor.slice(lineStart);
+
+				if (
+					column === 0 ||
+					column % TAB_SIZE !== 0 ||
+					linePrefix.length !== column ||
+					!/^\s+$/.test(linePrefix) ||
+					!linePrefix.endsWith(" ".repeat(TAB_SIZE))
+				) {
+					return false;
+				}
+
+				return editor.commands.command(({ tr }) => {
+					const from = $from.pos - TAB_SIZE;
+					tr.delete(from, $from.pos);
+					tr.setSelection(TextSelection.create(tr.doc, from));
+					return true;
+				});
+			},
+		};
+	},
+	addNodeView() {
+		return ReactNodeViewRenderer(CodeBlockView);
+	},
+}).configure({
+	lowlight,
+	enableTabIndentation: true,
+	tabSize: TAB_SIZE,
+});
+
+function CodeBlockView({ node, updateAttributes }: NodeViewProps) {
+	const language =
+		typeof node.attrs.language === "string" ? node.attrs.language : "";
+	const [copied, setCopied] = useState(false);
+
+	return (
+		<NodeViewWrapper className="pm-code-block" as="div">
+			<div className="pm-code-block-controls" contentEditable={false}>
+				<Select.Root
+					value={language}
+					onValueChange={(next) => updateAttributes({ language: next || null })}
+				>
+					<Select.Trigger
+						render={
+							<Button
+								type="button"
+								variant="ghost"
+								size="xs"
+								aria-label="Code block language"
+								title="Code block language"
+								className="pm-code-block-language"
+							/>
+						}
+					>
+						<Select.Value>
+							{languageLabel(language) || "Plain text"}
+						</Select.Value>
+						<MingcuteSelectorVerticalLine
+							className="size-3.5 shrink-0 text-muted-foreground"
+							aria-hidden="true"
+						/>
+					</Select.Trigger>
+					<Select.Portal>
+						<Select.Positioner align="end" side="bottom" sideOffset={4}>
+							<Select.Popup className="z-50 w-40 origin-(--transform-origin) rounded-[var(--radius-popover)] border border-border bg-popover p-1 text-[11px] text-popover-foreground shadow-overlay outline-hidden transition-[transform,opacity] data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95">
+								{codeBlockLanguages.map((option) => (
+									<Select.Item
+										key={option.value}
+										value={option.value}
+										className="flex w-full cursor-pointer items-center rounded-sm px-2 py-1 text-start text-[11px] text-foreground outline-hidden select-none data-highlighted:bg-accent"
+									>
+										<Select.ItemText>{option.label}</Select.ItemText>
+									</Select.Item>
+								))}
+							</Select.Popup>
+						</Select.Positioner>
+					</Select.Portal>
+				</Select.Root>
+				<Button
+					type="button"
+					variant="ghost"
+					size="icon-xs"
+					aria-label="Copy code"
+					title={copied ? "Copied" : "Copy code"}
+					onClick={() => {
+						void navigator.clipboard.writeText(node.textContent).then(() => {
+							setCopied(true);
+							window.setTimeout(() => setCopied(false), 1200);
+						});
+					}}
+				>
+					<MingcuteCopy2Line className="size-3.5" />
+				</Button>
+			</div>
+			<pre>
+				<NodeViewContent<"code">
+					as="code"
+					className={language ? `language-${language}` : undefined}
+				/>
+			</pre>
+		</NodeViewWrapper>
+	);
+}
+
+function languageLabel(value: string) {
+	return codeBlockLanguages.find((option) => option.value === value)?.label;
+}
+
+const codeBlockLanguages = [
+	{ value: "", label: "Plain text" },
+	{ value: "js", label: "JavaScript" },
+	{ value: "ts", label: "TypeScript" },
+	{ value: "jsx", label: "JSX" },
+	{ value: "tsx", label: "TSX" },
+	{ value: "json", label: "JSON" },
+	{ value: "css", label: "CSS" },
+	{ value: "html", label: "HTML" },
+	{ value: "md", label: "Markdown" },
+	{ value: "sh", label: "Shell" },
+	{ value: "python", label: "Python" },
+	{ value: "rust", label: "Rust" },
+	{ value: "go", label: "Go" },
+] as const;

--- a/packages/ui/src/editor/EditorView.css
+++ b/packages/ui/src/editor/EditorView.css
@@ -37,6 +37,11 @@
 	margin-block-start: var(--editor-paragraph-gap);
 }
 
+[data-hubble-editor] .ProseMirror > :is(p, .pm-code-block) + .pm-code-block,
+[data-hubble-editor] .ProseMirror > .pm-code-block + :is(p, ul, ol) {
+	margin-block-start: var(--editor-paragraph-gap);
+}
+
 [data-hubble-editor] .ProseMirror > * + :is(h1, h2) {
 	margin-block-start: var(--editor-section-gap);
 }
@@ -139,15 +144,118 @@
 
 [data-hubble-editor] .ProseMirror pre {
 	background: var(--muted);
-	padding: 0.6rem 0.8rem;
+	padding-block: 1.5rem;
+	padding-inline: 0.85rem;
 	border-radius: var(--radius-md);
 	font-size: 0.9em;
 	overflow-x: auto;
 }
 
+[data-hubble-editor] .pm-code-block {
+	position: relative;
+}
+
+[data-hubble-editor] .pm-code-block-controls {
+	position: absolute;
+	z-index: 1;
+	inset-block-start: 0.45rem;
+	inset-inline-end: 0.45rem;
+	display: flex;
+	align-items: center;
+	gap: 0.15rem;
+}
+
+[data-hubble-editor] .pm-code-block-language {
+	max-inline-size: 9rem;
+	border: 0;
+	padding-inline: 0.4rem 0.2rem;
+}
+
+[data-hubble-editor] .pm-code-block-language [data-slot="value"] {
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
 [data-hubble-editor] .ProseMirror pre code {
 	background: transparent;
+	color: #000;
 	padding: 0;
+}
+
+[data-hubble-editor] .ProseMirror .xml .hljs-meta {
+	color: #c0c0c0;
+}
+
+[data-hubble-editor] .ProseMirror .hljs-comment,
+[data-hubble-editor] .ProseMirror .hljs-quote {
+	color: #007400;
+}
+
+[data-hubble-editor] .ProseMirror .hljs-tag,
+[data-hubble-editor] .ProseMirror .hljs-attribute,
+[data-hubble-editor] .ProseMirror .hljs-keyword,
+[data-hubble-editor] .ProseMirror .hljs-selector-tag,
+[data-hubble-editor] .ProseMirror .hljs-literal,
+[data-hubble-editor] .ProseMirror .hljs-name {
+	color: #aa0d91;
+}
+
+[data-hubble-editor] .ProseMirror .hljs-variable,
+[data-hubble-editor] .ProseMirror .hljs-template-variable {
+	color: #3f6e74;
+}
+
+[data-hubble-editor] .ProseMirror .hljs-code,
+[data-hubble-editor] .ProseMirror .hljs-string,
+[data-hubble-editor] .ProseMirror .hljs-meta .hljs-string {
+	color: #c41a16;
+}
+
+[data-hubble-editor] .ProseMirror .hljs-regexp,
+[data-hubble-editor] .ProseMirror .hljs-link {
+	color: #0e0eff;
+}
+
+[data-hubble-editor] .ProseMirror .hljs-title,
+[data-hubble-editor] .ProseMirror .hljs-symbol,
+[data-hubble-editor] .ProseMirror .hljs-bullet,
+[data-hubble-editor] .ProseMirror .hljs-number {
+	color: #1c00cf;
+}
+
+[data-hubble-editor] .ProseMirror .hljs-section,
+[data-hubble-editor] .ProseMirror .hljs-meta {
+	color: #643820;
+}
+
+[data-hubble-editor] .ProseMirror .hljs-title.class_,
+[data-hubble-editor] .ProseMirror .hljs-class .hljs-title,
+[data-hubble-editor] .ProseMirror .hljs-type,
+[data-hubble-editor] .ProseMirror .hljs-built_in,
+[data-hubble-editor] .ProseMirror .hljs-params {
+	color: #5c2699;
+}
+
+[data-hubble-editor] .ProseMirror .hljs-attr {
+	color: #836c28;
+}
+
+[data-hubble-editor] .ProseMirror .hljs-subst {
+	color: #000;
+}
+
+[data-hubble-editor] .ProseMirror .hljs-selector-id,
+[data-hubble-editor] .ProseMirror .hljs-selector-class {
+	color: #9b703f;
+}
+
+[data-hubble-editor] .ProseMirror .hljs-doctag,
+[data-hubble-editor] .ProseMirror .hljs-strong {
+	font-weight: 700;
+}
+
+[data-hubble-editor] .ProseMirror .hljs-emphasis {
+	font-style: italic;
 }
 
 [data-hubble-editor] .ProseMirror span[data-link="true"] {

--- a/packages/ui/src/editor/EditorView.tsx
+++ b/packages/ui/src/editor/EditorView.tsx
@@ -19,6 +19,7 @@ import {
 } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { HubbleCodeBlock } from "./CodeBlockExtension";
 import { LinkClickExtension } from "./LinkClickExtension";
 import { LinkCreationGhostExtension } from "./LinkCreationGhostExtension";
 import { LinkPopover, type WikiTarget } from "./LinkPopover";
@@ -128,7 +129,8 @@ export function EditorView({
 
 	const editor = useEditor({
 		extensions: [
-			StarterKit.configure({ listItem: false }),
+			StarterKit.configure({ codeBlock: false, listItem: false }),
+			HubbleCodeBlock,
 			LinkExtension,
 			SmartLinkExtension,
 			LinkClickExtension.configure({ onOpenExternalLink, onOpenWikiLink }),

--- a/packages/ui/src/editor/codeBlockExtension.test.ts
+++ b/packages/ui/src/editor/codeBlockExtension.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment happy-dom
+
+import { Editor } from "@tiptap/core";
+import { TextSelection } from "@tiptap/pm/state";
+import StarterKit from "@tiptap/starter-kit";
+import { afterEach, describe, expect, it } from "vitest";
+import { HubbleCodeBlock } from "./CodeBlockExtension";
+
+const editors: Editor[] = [];
+
+afterEach(() => {
+	for (const editor of editors) editor.destroy();
+	editors.length = 0;
+});
+
+describe("code block editor extension", () => {
+	it("inserts spaces for Tab inside code blocks", () => {
+		const editor = createCodeBlockEditor();
+
+		expect(editor.commands.keyboardShortcut("Tab")).toBe(true);
+
+		expect(editor.getJSON().content?.[0]).toMatchObject({
+			type: "codeBlock",
+			attrs: { language: "ts" },
+			content: [{ type: "text", text: "const x = 1;    " }],
+		});
+	});
+
+	it("deletes a soft-tab segment with Backspace inside leading indentation", () => {
+		const editor = createCodeBlockEditor("    const x = 1;", 5);
+
+		expect(editor.commands.keyboardShortcut("Backspace")).toBe(true);
+
+		expect(editor.getJSON().content?.[0]).toMatchObject({
+			type: "codeBlock",
+			attrs: { language: "ts" },
+			content: [{ type: "text", text: "const x = 1;" }],
+		});
+	});
+});
+
+function createCodeBlockEditor(text = "const x = 1;", cursorPos?: number) {
+	const editor = new Editor({
+		element: document.createElement("div"),
+		extensions: [StarterKit.configure({ codeBlock: false }), HubbleCodeBlock],
+		content: {
+			type: "doc",
+			content: [
+				{
+					type: "codeBlock",
+					attrs: { language: "ts" },
+					content: [{ type: "text", text }],
+				},
+			],
+		},
+	});
+	editors.push(editor);
+	Object.defineProperty(editor, "isFocused", { value: true });
+	const codeBlock = editor.state.doc.firstChild;
+	if (!codeBlock) throw new Error("Expected code block");
+	editor.view.dispatch(
+		editor.state.tr.setSelection(
+			TextSelection.create(
+				editor.state.doc,
+				cursorPos ?? codeBlock.nodeSize - 1,
+			),
+		),
+	);
+	return editor;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -385,6 +385,9 @@ importers:
       '@tiptap/core':
         specifier: ^3.4.3
         version: 3.20.0(@tiptap/pm@3.20.0)
+      '@tiptap/extension-code-block-lowlight':
+        specifier: 3.20.0
+        version: 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/extension-code-block@3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)(highlight.js@11.11.1)(lowlight@3.3.0)
       '@tiptap/extension-list':
         specifier: ^3.4.2
         version: 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)
@@ -406,9 +409,15 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      highlight.js:
+        specifier: ^11.11.1
+        version: 11.11.1
       keymatch:
         specifier: ^1.0.5
         version: 1.0.5
+      lowlight:
+        specifier: ^3.3.0
+        version: 3.3.0
       react:
         specifier: ^19.1.0
         version: 19.2.4
@@ -1855,6 +1864,15 @@ packages:
     peerDependencies:
       '@tiptap/extension-list': ^3.20.0
 
+  '@tiptap/extension-code-block-lowlight@3.20.0':
+    resolution: {integrity: sha512-9lN9rn07lOWkLnByT5C1axtq56MHpOI7MpLaCmX3p+x1bDl6Uvixm6AoBdTLfZUmUYeEFBsf7t5cR+QepMbkiA==}
+    peerDependencies:
+      '@tiptap/core': ^3.20.0
+      '@tiptap/extension-code-block': ^3.20.0
+      '@tiptap/pm': ^3.20.0
+      highlight.js: ^11
+      lowlight: ^2 || ^3
+
   '@tiptap/extension-code-block@3.20.0':
     resolution: {integrity: sha512-lBbmNek14aCjrHcBcq3PRqWfNLvC6bcRa2Osc6e/LtmXlcpype4f6n+Yx+WZ+f2uUh0UmDRCz7BEyUETEsDmlQ==}
     peerDependencies:
@@ -3087,6 +3105,10 @@ packages:
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
+  highlight.js@11.11.1:
+    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+    engines: {node: '>=12.0.0'}
+
   hono@4.12.8:
     resolution: {integrity: sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==}
     engines: {node: '>=16.9.0'}
@@ -3441,6 +3463,9 @@ packages:
   lowercase-keys@2.0.0:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
     engines: {node: '>=8'}
+
+  lowlight@3.3.0:
+    resolution: {integrity: sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -6037,6 +6062,14 @@ snapshots:
     dependencies:
       '@tiptap/extension-list': 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)
 
+  '@tiptap/extension-code-block-lowlight@3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/extension-code-block@3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)(highlight.js@11.11.1)(lowlight@3.3.0)':
+    dependencies:
+      '@tiptap/core': 3.20.0(@tiptap/pm@3.20.0)
+      '@tiptap/extension-code-block': 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)
+      '@tiptap/pm': 3.20.0
+      highlight.js: 11.11.1
+      lowlight: 3.3.0
+
   '@tiptap/extension-code-block@3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)':
     dependencies:
       '@tiptap/core': 3.20.0(@tiptap/pm@3.20.0)
@@ -7536,6 +7569,8 @@ snapshots:
 
   headers-polyfill@4.0.3: {}
 
+  highlight.js@11.11.1: {}
+
   hono@4.12.8: {}
 
   hosted-git-info@4.1.0:
@@ -7806,6 +7841,12 @@ snapshots:
       tslib: 2.8.1
 
   lowercase-keys@2.0.0: {}
+
+  lowlight@3.3.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      devlop: 1.1.0
+      highlight.js: 11.11.1
 
   lru-cache@5.1.1:
     dependencies:


### PR DESCRIPTION
Closes #6

## Summary
- preserve fenced code block language in markdown import/export
- add right-aligned ghost language dropdown using the app Select popup styling
- add copy-code button beside the language picker
- use TipTap lowlight with Xcode-style syntax colors
- keep soft-space Tab indentation and make Backspace remove a full 4-space soft-tab segment at indentation stops

## Checks
- pnpm --filter @hubble.md/editor test -- CodeBlockMarkdown.test.ts
- pnpm --filter @hubble.md/ui test -- codeBlockExtension.test.ts
- pnpm check
- pnpm build:desktop
- HUBBLE_DESKTOP_ENABLE_CDP=1 pnpm dev:desktop; opened playground note, verified right-aligned ghost controls, Xcode keyword color, 24px top/bottom code padding, copy button writes code text to clipboard, language dropdown saves fences, and Backspace soft-tab removal