### PR TITLE
Add synced note pinning

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -18,7 +18,10 @@ import {
 } from "electron";
 import electronUpdater from "electron-updater";
 import ignore from "ignore";
-import type { DesktopUpdateState } from "../src/desktopApi/types";
+import type {
+	DesktopUpdateState,
+	WorkspaceConfig,
+} from "../src/desktopApi/types";
 
 type FileEntry = {
 	path: string;
@@ -93,6 +96,9 @@ let grantsLoaded = false;
 
 const ignoreConfigFiles = [".gitignore", ".ignore"];
 const ignoredWorkspaceDirs = new Set([".git", "dist", "node_modules"]);
+const workspaceConfigVersion = 1;
+const workspaceConfigDir = ".hubble";
+const workspaceConfigFile = "config.json";
 const iframeHeadStyles = [
 	{ name: "hubble-theme", source: embedTheme },
 ] as const;
@@ -107,6 +113,50 @@ const iframeBodyEndScripts = [
 
 function grantsPath(): string {
 	return path.join(app.getPath("userData"), "grants.json");
+}
+
+function workspaceConfigPath(workspacePath: string): string {
+	const root = assertGrantedRoot(workspacePath);
+	return path.join(root, workspaceConfigDir, workspaceConfigFile);
+}
+
+function emptyWorkspaceConfig(): WorkspaceConfig {
+	return { version: workspaceConfigVersion, pinnedNotes: [] };
+}
+
+function isValidConfigNote(note: unknown): note is string {
+	return (
+		typeof note === "string" &&
+		note.length > 0 &&
+		!path.isAbsolute(note) &&
+		!note.split("/").includes("..")
+	);
+}
+
+function parseWorkspaceConfig(raw: string): WorkspaceConfig {
+	try {
+		const parsed = JSON.parse(raw) as {
+			version?: unknown;
+			pinnedNotes?: unknown;
+		};
+		if (parsed.version !== workspaceConfigVersion)
+			return emptyWorkspaceConfig();
+		if (!Array.isArray(parsed.pinnedNotes)) return emptyWorkspaceConfig();
+		const pinnedNotes = parsed.pinnedNotes.filter(isValidConfigNote);
+		return { version: workspaceConfigVersion, pinnedNotes };
+	} catch {
+		return emptyWorkspaceConfig();
+	}
+}
+
+function normalizeWorkspaceConfig(input: WorkspaceConfig): WorkspaceConfig {
+	const pinnedNotes = Array.isArray(input.pinnedNotes)
+		? input.pinnedNotes.filter(isValidConfigNote)
+		: [];
+	return {
+		version: workspaceConfigVersion,
+		pinnedNotes: [...new Set(pinnedNotes)],
+	};
 }
 
 async function loadGrants() {
@@ -746,6 +796,40 @@ function registerIpc() {
 			const files: EmbedFileEntry[] = [];
 			await collectWorkspaceFiles(root, root, String(glob ?? "**/*"), files);
 			return files.sort((a, b) => a.path.localeCompare(b.path));
+		},
+	);
+
+	ipcMain.handle(
+		"desktop:read-workspace-config",
+		async (_event, { workspacePath }) => {
+			try {
+				return parseWorkspaceConfig(
+					await fs.readFile(workspaceConfigPath(workspacePath), "utf8"),
+				);
+			} catch (err) {
+				if (
+					err &&
+					typeof err === "object" &&
+					"code" in err &&
+					err.code === "ENOENT"
+				) {
+					return emptyWorkspaceConfig();
+				}
+				throw err;
+			}
+		},
+	);
+
+	ipcMain.handle(
+		"desktop:write-workspace-config",
+		async (_event, { workspacePath, config }) => {
+			const configPath = workspaceConfigPath(workspacePath);
+			await fs.mkdir(path.dirname(configPath), { recursive: true });
+			await fs.writeFile(
+				configPath,
+				`${JSON.stringify(normalizeWorkspaceConfig(config), null, 2)}\n`,
+			);
+			grantFile(configPath);
 		},
 	);
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -18,6 +18,7 @@ import {
 } from "electron";
 import electronUpdater from "electron-updater";
 import ignore from "ignore";
+import { z } from "zod/v4";
 import type {
 	DesktopUpdateState,
 	WorkspaceConfig,
@@ -99,6 +100,19 @@ const ignoredWorkspaceDirs = new Set([".git", "dist", "node_modules"]);
 const workspaceConfigVersion = 1;
 const workspaceConfigDir = ".hubble";
 const workspaceConfigFile = "config.json";
+const workspaceConfigSchema = z.object({
+	version: z.literal(workspaceConfigVersion),
+	pinnedNotes: z.array(
+		z
+			.string()
+			.min(1)
+			// Pin refs live inside the workspace config; reject absolute paths and
+			// traversal so config edits cannot point pin state outside the workspace.
+			.refine(
+				(note) => !path.isAbsolute(note) && !note.split("/").includes(".."),
+			),
+	),
+});
 const iframeHeadStyles = [
 	{ name: "hubble-theme", source: embedTheme },
 ] as const;
@@ -124,38 +138,20 @@ function emptyWorkspaceConfig(): WorkspaceConfig {
 	return { version: workspaceConfigVersion, pinnedNotes: [] };
 }
 
-function isValidConfigNote(note: unknown): note is string {
-	return (
-		typeof note === "string" &&
-		note.length > 0 &&
-		!path.isAbsolute(note) &&
-		!note.split("/").includes("..")
-	);
-}
-
 function parseWorkspaceConfig(raw: string): WorkspaceConfig {
 	try {
-		const parsed = JSON.parse(raw) as {
-			version?: unknown;
-			pinnedNotes?: unknown;
-		};
-		if (parsed.version !== workspaceConfigVersion)
-			return emptyWorkspaceConfig();
-		if (!Array.isArray(parsed.pinnedNotes)) return emptyWorkspaceConfig();
-		const pinnedNotes = parsed.pinnedNotes.filter(isValidConfigNote);
-		return { version: workspaceConfigVersion, pinnedNotes };
+		return workspaceConfigSchema.parse(JSON.parse(raw));
 	} catch {
 		return emptyWorkspaceConfig();
 	}
 }
 
 function normalizeWorkspaceConfig(input: WorkspaceConfig): WorkspaceConfig {
-	const pinnedNotes = Array.isArray(input.pinnedNotes)
-		? input.pinnedNotes.filter(isValidConfigNote)
-		: [];
+	const config = workspaceConfigSchema.safeParse(input);
+	if (!config.success) return emptyWorkspaceConfig();
 	return {
 		version: workspaceConfigVersion,
-		pinnedNotes: [...new Set(pinnedNotes)],
+		pinnedNotes: [...new Set(config.data.pinnedNotes)],
 	};
 }
 

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -19,6 +19,13 @@ const desktopApi = {
 		ipcRenderer.invoke("desktop:list-directory", { path }),
 	listEmbedFiles: (workspacePath, glob) =>
 		ipcRenderer.invoke("desktop:embed-list-files", { workspacePath, glob }),
+	readWorkspaceConfig: (workspacePath) =>
+		ipcRenderer.invoke("desktop:read-workspace-config", { workspacePath }),
+	writeWorkspaceConfig: (workspacePath, config) =>
+		ipcRenderer.invoke("desktop:write-workspace-config", {
+			workspacePath,
+			config,
+		}),
 	readFileText: (path) =>
 		ipcRenderer.invoke("desktop:read-file-text", { path }),
 	writeFileText: (path, content) =>

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -41,7 +41,8 @@
 		"shadcn": "^4.1.0",
 		"sonner": "^2.0.7",
 		"tailwind-merge": "^3.5.0",
-		"tw-animate-css": "^1.4.0"
+		"tw-animate-css": "^1.4.0",
+		"zod": "^4.4.3"
 	},
 	"devDependencies": {
 		"@iconify-json/mingcute": "^1.2.7",

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
 	renameMarkdownFile,
 	setSidebarOpen,
 	setSortMode,
+	togglePinnedNote,
 } from "../store/actions";
 import {
 	currentPathStore,
@@ -24,7 +25,8 @@ export function Sidebar({ footer }: { footer?: ReactNode }) {
 	const workspace = useStoreValue(workspaceStore);
 	const sidebarOpen = useStoreValue(sidebarOpenStore);
 	const currentPath = useStoreValue(currentPathStore);
-	const { workspacePath, files, sortMode } = workspace;
+	const { workspacePath, files, pinnedNotes, sortMode } = workspace;
+	const pinnedSet = new Set(pinnedNotes);
 
 	if (!sidebarOpen) return null;
 	const collapseSidebar = () => setSidebarOpen(false);
@@ -70,6 +72,7 @@ export function Sidebar({ footer }: { footer?: ReactNode }) {
 			files={files.map((file) => ({
 				path: file.path,
 				modifiedAt: file.modified_at,
+				pinned: pinnedSet.has(file.path),
 			}))}
 			currentPath={currentPath ?? null}
 			sortMode={sortMode}
@@ -87,6 +90,7 @@ export function Sidebar({ footer }: { footer?: ReactNode }) {
 			revealLabel={revealFileLabel(desktopApi.platform)}
 			onRenameFile={(path, nextName) => void renameMarkdownFile(path, nextName)}
 			onDeleteFile={(path) => void deleteMarkdownFile(path)}
+			onTogglePinnedFile={(path) => void togglePinnedNote(path)}
 			onCreateFile={(folderId) =>
 				createMarkdownFileInFolder(absolutePath(folderId))
 			}

--- a/apps/desktop/src/desktopApi/types.ts
+++ b/apps/desktop/src/desktopApi/types.ts
@@ -51,6 +51,11 @@ export type DesktopUpdateState = {
 
 export type DesktopPlatform = NodeJS.Platform;
 
+export type WorkspaceConfig = {
+	version: 1;
+	pinnedNotes: string[];
+};
+
 export type DesktopApi = {
 	platform: DesktopPlatform;
 	listDirectory(path: string): Promise<FileEntry[]>;
@@ -58,6 +63,11 @@ export type DesktopApi = {
 		workspacePath: string,
 		glob: string,
 	): Promise<EmbedFileEntry[]>;
+	readWorkspaceConfig(workspacePath: string): Promise<WorkspaceConfig>;
+	writeWorkspaceConfig(
+		workspacePath: string,
+		config: WorkspaceConfig,
+	): Promise<void>;
 	readFileText(path: string): Promise<string>;
 	writeFileText(path: string, content: string): Promise<void>;
 	renameFile(fromPath: string, toPath: string): Promise<void>;

--- a/apps/desktop/src/store/actions.test.ts
+++ b/apps/desktop/src/store/actions.test.ts
@@ -4,6 +4,8 @@ type MockDesktopApi = {
 	readFileText: ReturnType<typeof vi.fn>;
 	writeFileText: ReturnType<typeof vi.fn>;
 	listDirectory: ReturnType<typeof vi.fn>;
+	readWorkspaceConfig: ReturnType<typeof vi.fn>;
+	writeWorkspaceConfig: ReturnType<typeof vi.fn>;
 	renameFile: ReturnType<typeof vi.fn>;
 };
 
@@ -12,6 +14,8 @@ function createDesktopApi(): MockDesktopApi {
 		readFileText: vi.fn(async () => "before"),
 		writeFileText: vi.fn(async () => {}),
 		listDirectory: vi.fn(async () => []),
+		readWorkspaceConfig: vi.fn(async () => ({ version: 1, pinnedNotes: [] })),
+		writeWorkspaceConfig: vi.fn(async () => {}),
 		renameFile: vi.fn(async () => {}),
 	};
 }
@@ -161,5 +165,89 @@ describe("desktop renameMarkdownFile", () => {
 		expect(workspaceStore.get().lastOpenedPaths["/workspace"]).toBe(
 			"/workspace/renamed.md",
 		);
+	});
+
+	it("updates pinned note paths in workspace config", async () => {
+		const api = createDesktopApi();
+		const { appStore, renameMarkdownFile, workspaceStore } =
+			await loadStoreActions(api);
+		const path = "/workspace/original.md";
+
+		appStore.set((current) => ({
+			...current,
+			workspace: {
+				...current.workspace,
+				workspacePath: "/workspace",
+				files: [{ path, modified_at: 1 }],
+				pinnedNotes: [path],
+			},
+		}));
+
+		await renameMarkdownFile(path, "renamed");
+
+		expect(workspaceStore.get().pinnedNotes).toEqual(["/workspace/renamed.md"]);
+		expect(api.writeWorkspaceConfig).toHaveBeenCalledWith("/workspace", {
+			version: 1,
+			pinnedNotes: ["renamed.md"],
+		});
+	});
+});
+
+describe("desktop pinned notes", () => {
+	beforeEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("loads missing workspace config as an empty pin set", async () => {
+		const api = createDesktopApi();
+		api.readWorkspaceConfig.mockResolvedValue({ version: 1, pinnedNotes: [] });
+		const { openWorkspace, workspaceStore } = await loadStoreActions(api);
+
+		await openWorkspace("/workspace");
+
+		expect(api.readWorkspaceConfig).toHaveBeenCalledWith("/workspace");
+		expect(workspaceStore.get().pinnedNotes).toEqual([]);
+	});
+
+	it("loads persisted pins as absolute workspace paths", async () => {
+		const api = createDesktopApi();
+		api.readWorkspaceConfig.mockResolvedValue({
+			version: 1,
+			pinnedNotes: ["notes/a.md"],
+		});
+		const { openWorkspace, workspaceStore } = await loadStoreActions(api);
+
+		await openWorkspace("/workspace");
+
+		expect(workspaceStore.get().pinnedNotes).toEqual(["/workspace/notes/a.md"]);
+	});
+
+	it("pins and unpins notes through workspace config", async () => {
+		const api = createDesktopApi();
+		const { appStore, togglePinnedNote, workspaceStore } =
+			await loadStoreActions(api);
+
+		appStore.set((current) => ({
+			...current,
+			workspace: {
+				...current.workspace,
+				workspacePath: "/workspace",
+				files: [{ path: "/workspace/note.md", modified_at: 1 }],
+			},
+		}));
+
+		await togglePinnedNote("/workspace/note.md");
+		expect(workspaceStore.get().pinnedNotes).toEqual(["/workspace/note.md"]);
+		expect(api.writeWorkspaceConfig).toHaveBeenLastCalledWith("/workspace", {
+			version: 1,
+			pinnedNotes: ["note.md"],
+		});
+
+		await togglePinnedNote("/workspace/note.md");
+		expect(workspaceStore.get().pinnedNotes).toEqual([]);
+		expect(api.writeWorkspaceConfig).toHaveBeenLastCalledWith("/workspace", {
+			version: 1,
+			pinnedNotes: [],
+		});
 	});
 });

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -37,6 +37,42 @@ export async function refreshFiles(path = workspaceStore.get().workspacePath) {
 	});
 }
 
+function relativeWorkspacePath(path: string, workspacePath: string | null) {
+	if (!workspacePath) return path;
+	const prefix = workspacePath.endsWith("/")
+		? workspacePath
+		: `${workspacePath}/`;
+	return path.startsWith(prefix) ? path.slice(prefix.length) : path;
+}
+
+function absoluteWorkspacePath(relativePath: string, workspacePath: string) {
+	return workspacePath.endsWith("/")
+		? `${workspacePath}${relativePath}`
+		: `${workspacePath}/${relativePath}`;
+}
+
+async function loadPinnedNotes(workspacePath: string) {
+	const config = await desktopApi.readWorkspaceConfig(workspacePath);
+	workspaceStore.set((state) => {
+		if (state.workspacePath !== workspacePath) return state;
+		return {
+			...state,
+			pinnedNotes: config.pinnedNotes.map((note) =>
+				absoluteWorkspacePath(note, workspacePath),
+			),
+		};
+	});
+}
+
+async function writePinnedNotes(workspacePath: string, pinnedNotes: string[]) {
+	await desktopApi.writeWorkspaceConfig(workspacePath, {
+		version: 1,
+		pinnedNotes: pinnedNotes.map((note) =>
+			relativeWorkspacePath(note, workspacePath),
+		),
+	});
+}
+
 export function touchFile(path: string) {
 	workspaceStore.set((state) => {
 		if (!isInWorkspace(path, state.workspacePath)) return state;
@@ -115,10 +151,11 @@ export async function openWorkspace(path?: string) {
 			workspacePath: nextPath,
 			recentWorkspaces: [nextPath, ...filtered].slice(0, MAX_RECENT),
 			files: [],
+			pinnedNotes: [],
 		};
 	});
 	switcherOpenStore.set(false);
-	await refreshFiles(nextPath);
+	await Promise.all([refreshFiles(nextPath), loadPinnedNotes(nextPath)]);
 
 	const lastFile = workspaceStore.get().lastOpenedPaths[nextPath];
 	if (lastFile) {
@@ -254,6 +291,9 @@ export async function renameMarkdownFile(path: string, nextName: string) {
 				files: state.workspace.files.map((file) =>
 					file.path === path ? { ...file, path: nextPath } : file,
 				),
+				pinnedNotes: state.workspace.pinnedNotes.map((pinnedPath) =>
+					pinnedPath === path ? nextPath : pinnedPath,
+				),
 				lastOpenedPaths: Object.fromEntries(
 					Object.entries(state.workspace.lastOpenedPaths).map(
 						([workspacePath, openedPath]) => [
@@ -275,6 +315,10 @@ export async function renameMarkdownFile(path: string, nextName: string) {
 						: state.document.lastOpenedPath,
 			},
 		}));
+		const workspacePath = workspaceStore.get().workspacePath;
+		if (workspacePath) {
+			await writePinnedNotes(workspacePath, workspaceStore.get().pinnedNotes);
+		}
 		await refreshFiles();
 		if (isCurrentFile) {
 			await loadPath(nextPath);
@@ -321,6 +365,9 @@ export async function deleteMarkdownFile(path: string) {
 			workspace: {
 				...state.workspace,
 				files: state.workspace.files.filter((file) => file.path !== path),
+				pinnedNotes: state.workspace.pinnedNotes.filter(
+					(pinnedPath) => pinnedPath !== path,
+				),
 				lastOpenedPaths: Object.fromEntries(
 					Object.entries(state.workspace.lastOpenedPaths).filter(
 						([, openedPath]) => openedPath !== path,
@@ -342,6 +389,10 @@ export async function deleteMarkdownFile(path: string) {
 									: state.document.lastOpenedPath,
 						},
 		}));
+		const workspacePath = workspaceStore.get().workspacePath;
+		if (workspacePath) {
+			await writePinnedNotes(workspacePath, workspaceStore.get().pinnedNotes);
+		}
 		await refreshFiles();
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
@@ -358,6 +409,9 @@ export async function deleteFolder(path: string) {
 				...state.workspace,
 				files: state.workspace.files.filter(
 					(file) => !pathInFolder(file.path, path),
+				),
+				pinnedNotes: state.workspace.pinnedNotes.filter(
+					(pinnedPath) => !pathInFolder(pinnedPath, path),
 				),
 				lastOpenedPaths: Object.fromEntries(
 					Object.entries(state.workspace.lastOpenedPaths).filter(
@@ -383,6 +437,10 @@ export async function deleteFolder(path: string) {
 									: state.document.lastOpenedPath,
 						},
 		}));
+		const workspacePath = workspaceStore.get().workspacePath;
+		if (workspacePath) {
+			await writePinnedNotes(workspacePath, workspaceStore.get().pinnedNotes);
+		}
 		await refreshFiles();
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
@@ -445,3 +503,23 @@ export const loadPath = latest(async ({ isStale }, path: string) => {
 		window.clearTimeout(timer);
 	}
 });
+
+export async function togglePinnedNote(path: string) {
+	const workspacePath = workspaceStore.get().workspacePath;
+	if (!workspacePath || !isInWorkspace(path, workspacePath)) return;
+	const pinnedNotes = workspaceStore.get().pinnedNotes;
+	const nextPinnedNotes = pinnedNotes.includes(path)
+		? pinnedNotes.filter((pinnedPath) => pinnedPath !== path)
+		: [...pinnedNotes, path];
+	workspaceStore.set((state) => ({
+		...state,
+		pinnedNotes: nextPinnedNotes,
+	}));
+	try {
+		await writePinnedNotes(workspacePath, nextPinnedNotes);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		toast.error("Failed to update pinned notes", { description: message });
+		await loadPinnedNotes(workspacePath);
+	}
+}

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -73,6 +73,17 @@ async function writePinnedNotes(workspacePath: string, pinnedNotes: string[]) {
 	});
 }
 
+async function syncPinnedNotes() {
+	const workspacePath = workspaceStore.get().workspacePath;
+	if (!workspacePath) return;
+	try {
+		await writePinnedNotes(workspacePath, workspaceStore.get().pinnedNotes);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		toast.error("Failed to update pinned notes", { description: message });
+	}
+}
+
 export function touchFile(path: string) {
 	workspaceStore.set((state) => {
 		if (!isInWorkspace(path, state.workspacePath)) return state;
@@ -315,10 +326,7 @@ export async function renameMarkdownFile(path: string, nextName: string) {
 						: state.document.lastOpenedPath,
 			},
 		}));
-		const workspacePath = workspaceStore.get().workspacePath;
-		if (workspacePath) {
-			await writePinnedNotes(workspacePath, workspaceStore.get().pinnedNotes);
-		}
+		await syncPinnedNotes();
 		await refreshFiles();
 		if (isCurrentFile) {
 			await loadPath(nextPath);
@@ -389,10 +397,7 @@ export async function deleteMarkdownFile(path: string) {
 									: state.document.lastOpenedPath,
 						},
 		}));
-		const workspacePath = workspaceStore.get().workspacePath;
-		if (workspacePath) {
-			await writePinnedNotes(workspacePath, workspaceStore.get().pinnedNotes);
-		}
+		await syncPinnedNotes();
 		await refreshFiles();
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
@@ -437,10 +442,7 @@ export async function deleteFolder(path: string) {
 									: state.document.lastOpenedPath,
 						},
 		}));
-		const workspacePath = workspaceStore.get().workspacePath;
-		if (workspacePath) {
-			await writePinnedNotes(workspacePath, workspaceStore.get().pinnedNotes);
-		}
+		await syncPinnedNotes();
 		await refreshFiles();
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);

--- a/apps/desktop/src/store/persistence.ts
+++ b/apps/desktop/src/store/persistence.ts
@@ -6,6 +6,7 @@ type WorkspaceState = {
 	lastOpenedPaths: Record<string, string>;
 	sortMode: SortMode;
 	files: { path: string; modified_at: number }[];
+	pinnedNotes: string[];
 };
 
 type DocumentState = ReturnType<typeof emptyDoc>;
@@ -60,6 +61,7 @@ function hydrateWorkspace(ws: Persisted["workspace"]): WorkspaceState {
 				: {},
 		sortMode: ws?.sortMode === "alpha" ? "alpha" : "recent",
 		files: [],
+		pinnedNotes: [],
 	};
 }
 

--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -16,6 +16,8 @@ import MingcuteDeleteLine from "~icons/mingcute/delete-line";
 import MingcuteEditLine from "~icons/mingcute/edit-line";
 import MingcuteFolderOpenLine from "~icons/mingcute/folder-open-line";
 import MingcuteMore2Line from "~icons/mingcute/more-2-line";
+import MingcutePinFill from "~icons/mingcute/pin-fill";
+import MingcutePinLine from "~icons/mingcute/pin-line";
 import MingcuteRightLine from "~icons/mingcute/right-line";
 import MingcuteSortDescendingLine from "~icons/mingcute/sort-descending-line";
 import {
@@ -43,6 +45,8 @@ const sidebarActionIconClass =
 	"inline-flex size-4 shrink-0 items-center justify-center [&_svg]:size-3.5";
 const sidebarRowContentClass =
 	"flex min-w-0 flex-1 items-center gap-1 [padding-block:var(--row-pad-block)] [padding-inline-end:var(--row-pad-inline)] text-start text-[length:var(--font-size-sidebar)]";
+const sidebarRowActionButtonClass =
+	"inline-flex size-5 shrink-0 items-center justify-center rounded-sm border border-transparent bg-transparent text-muted-foreground/70 opacity-0 outline-hidden transition-[opacity,color] hover:text-foreground focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/40 group-hover/sidebar-row:opacity-100 aria-expanded:text-foreground aria-expanded:opacity-100";
 const DEFAULT_SIDEBAR_WIDTH = 220;
 const MIN_SIDEBAR_WIDTH = 180;
 const MAX_SIDEBAR_WIDTH = 360;
@@ -67,6 +71,7 @@ export function Sidebar({
 	revealLabel,
 	onRenameFile,
 	onDeleteFile,
+	onTogglePinnedFile,
 	onCreateFile,
 	onDeleteFolder,
 }: {
@@ -88,6 +93,7 @@ export function Sidebar({
 	revealLabel?: string;
 	onRenameFile?: (path: string, nextName: string) => void;
 	onDeleteFile?: (path: string) => void;
+	onTogglePinnedFile?: (path: string) => void;
 	onCreateFile?: (folderId: string | null) => Promise<string | null>;
 	onDeleteFolder?: (folderId: string) => void;
 }) {
@@ -145,13 +151,14 @@ export function Sidebar({
 	const activateRow = useCallback(
 		(row: SidebarRow) => {
 			if (row.kind === "file") onSelectFile(row.file.path);
-			else toggleFolder(row.id);
+			else if (row.kind === "folder") toggleFolder(row.id);
 		},
 		[onSelectFile, toggleFolder],
 	);
 	const enterRowEdit = useCallback(
 		(row: SidebarRow) => {
 			if (row.kind === "file" && onRenameFile) beginRename(row.file, row.label);
+			else if (row.kind === "section") return;
 			else activateRow(row);
 		},
 		[activateRow, beginRename, onRenameFile],
@@ -328,6 +335,23 @@ export function Sidebar({
 					const isFocused = focusedIndex === index;
 					const isRenaming =
 						row.kind === "file" && row.file.path === renamingPath;
+					const isPinnedSectionEnd =
+						row.kind === "file" &&
+						row.file.pinned &&
+						rows[index + 1]?.kind !== "file";
+					if (row.kind === "section") {
+						return (
+							<div
+								key={row.id}
+								role="presentation"
+								data-sidebar-index={index}
+								className="flex items-center gap-1 px-2 pb-1 pt-2 text-[10px] font-medium uppercase text-muted-foreground"
+							>
+								<MingcutePinFill className="size-3 shrink-0" />
+								{row.label}
+							</div>
+						);
+					}
 					const rowStyle = {
 						paddingInlineStart: `${0.5 + row.depth * 0.75}rem`,
 					} as React.CSSProperties;
@@ -352,11 +376,12 @@ export function Sidebar({
 							aria-expanded={row.kind === "folder" ? row.expanded : undefined}
 							aria-selected={isActive}
 							className={cn(
-								"group/sidebar-row flex w-full items-center rounded-[var(--radius-row)] text-sidebar-foreground",
+								"group/sidebar-row relative flex w-full items-center rounded-[var(--radius-row)] text-sidebar-foreground",
 								!isActive && isFocused && "bg-accent",
 								isActive &&
 									"bg-sidebar-accent text-sidebar-accent-foreground font-medium",
 								isRenaming && "relative z-30",
+								isPinnedSectionEnd && "mb-3",
 							)}
 							onPointerEnter={() => setFocusedIndex(index)}
 							onPointerLeave={() => setFocusedIndex(null)}
@@ -410,6 +435,9 @@ export function Sidebar({
 									className={cn(
 										sidebarRowContentClass,
 										"truncate border-none bg-transparent",
+										row.kind === "file" &&
+											row.file.pinned &&
+											"[padding-inline-end:1.75rem]",
 									)}
 									style={rowStyle}
 									onClick={(event) => {
@@ -426,39 +454,80 @@ export function Sidebar({
 									}}
 								>
 									{chevron}
-									<span className="min-w-0 flex-1 truncate">{row.label}</span>
+									<span
+										className={cn(
+											"min-w-0 flex-1 truncate",
+											row.kind === "file" &&
+												row.file.pinned &&
+												"[direction:rtl] [text-align:left]",
+										)}
+									>
+										{row.label}
+									</span>
 								</button>
 							)}
-							{row.kind === "folder" &&
-								(onRevealFolder || onCreateFile || onDeleteFolder) && (
-									<FolderActionsMenu
-										id={row.id}
-										label={row.label}
-										open={openActionsPath === row.id}
-										onOpenChange={(open) =>
-											setOpenActionsPath(open ? row.id : null)
-										}
-										onRevealFolder={onRevealFolder}
-										revealLabel={revealLabel}
-										onCreateFile={(id) => void createFile(id)}
-										onDeleteFolder={onDeleteFolder}
-									/>
-								)}
-							{row.kind === "file" &&
-								(onRevealFile || onRenameFile || onDeleteFile) && (
-									<FileActionsMenu
-										file={row.file}
-										label={row.label}
-										open={openActionsPath === row.file.path}
-										onOpenChange={(open) =>
-											setOpenActionsPath(open ? row.file.path : null)
-										}
-										onRevealFile={onRevealFile}
-										revealLabel={revealLabel}
-										onRenameFile={beginRename}
-										onDeleteFile={onDeleteFile}
-									/>
-								)}
+							{row.kind === "file" && row.file.pinned && onTogglePinnedFile && (
+								<span
+									className={cn(
+										"pointer-events-none absolute inset-y-0 end-0 w-12 rounded-e-[var(--radius-row)] opacity-0 transition-opacity group-hover/sidebar-row:opacity-100",
+										isActive
+											? "bg-linear-to-r from-transparent from-0% via-sidebar-accent via-35% to-sidebar-accent"
+											: "bg-linear-to-r from-transparent from-0% via-accent via-35% to-accent",
+									)}
+								/>
+							)}
+							<div className="absolute inset-y-0 end-0.5 flex items-center gap-0.5">
+								{row.kind === "folder" &&
+									(onRevealFolder || onCreateFile || onDeleteFolder) && (
+										<FolderActionsMenu
+											id={row.id}
+											label={row.label}
+											open={openActionsPath === row.id}
+											onOpenChange={(open) =>
+												setOpenActionsPath(open ? row.id : null)
+											}
+											onRevealFolder={onRevealFolder}
+											revealLabel={revealLabel}
+											onCreateFile={(id) => void createFile(id)}
+											onDeleteFolder={onDeleteFolder}
+										/>
+									)}
+								{row.kind === "file" &&
+									row.file.pinned &&
+									onTogglePinnedFile && (
+										<button
+											type="button"
+											className={sidebarRowActionButtonClass}
+											aria-label={`Unpin ${row.label}`}
+											title={`Unpin ${row.label}`}
+											onClick={(event) => {
+												event.stopPropagation();
+												onTogglePinnedFile(row.file.path);
+											}}
+										>
+											<MingcutePinFill className="size-3.5" />
+										</button>
+									)}
+								{row.kind === "file" &&
+									(onRevealFile ||
+										onRenameFile ||
+										onDeleteFile ||
+										onTogglePinnedFile) && (
+										<FileActionsMenu
+											file={row.file}
+											label={row.label}
+											open={openActionsPath === row.file.path}
+											onOpenChange={(open) =>
+												setOpenActionsPath(open ? row.file.path : null)
+											}
+											onRevealFile={onRevealFile}
+											revealLabel={revealLabel}
+											onRenameFile={beginRename}
+											onTogglePinnedFile={onTogglePinnedFile}
+											onDeleteFile={onDeleteFile}
+										/>
+									)}
+							</div>
 						</div>
 					);
 				})}
@@ -690,6 +759,7 @@ function FileActionsMenu({
 	onRevealFile,
 	revealLabel,
 	onRenameFile,
+	onTogglePinnedFile,
 	onDeleteFile,
 }: {
 	file: SidebarFile;
@@ -699,6 +769,7 @@ function FileActionsMenu({
 	onRevealFile?: (path: string) => void;
 	revealLabel?: string;
 	onRenameFile?: (file: SidebarFile, label: string) => void;
+	onTogglePinnedFile?: (path: string) => void;
 	onDeleteFile?: (path: string) => void;
 }) {
 	return (
@@ -717,6 +788,14 @@ function FileActionsMenu({
 					onClick={() => onRenameFile(file, label)}
 				>
 					Rename
+				</ActionItem>
+			)}
+			{onTogglePinnedFile && (
+				<ActionItem
+					icon={<MingcutePinLine />}
+					onClick={() => onTogglePinnedFile(file.path)}
+				>
+					{file.pinned ? "Unpin" : "Pin"}
 				</ActionItem>
 			)}
 			{onDeleteFile && (
@@ -752,7 +831,7 @@ function ActionsMenu({
 				render={
 					<button
 						type="button"
-						className="me-1 inline-flex size-6 shrink-0 items-center justify-center rounded-sm border border-transparent bg-transparent text-muted-foreground/70 opacity-0 outline-hidden transition-[opacity,color] hover:text-foreground focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/40 group-hover/sidebar-row:opacity-100 aria-expanded:text-foreground aria-expanded:opacity-100"
+						className={sidebarRowActionButtonClass}
 						aria-label={`Actions for ${label}`}
 						title={`Actions for ${label}`}
 						onContextMenu={(event) => {

--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -44,7 +44,7 @@ const sidebarActionClass =
 const sidebarActionIconClass =
 	"inline-flex size-4 shrink-0 items-center justify-center [&_svg]:size-3.5";
 const sidebarRowContentClass =
-	"flex min-w-0 flex-1 items-center gap-1 [padding-block:var(--row-pad-block)] [padding-inline-end:var(--row-pad-inline)] text-start text-[length:var(--font-size-sidebar)]";
+	"flex min-w-0 flex-1 items-center gap-1 [padding-block:var(--row-pad-block)] [padding-inline-end:1.25rem] text-start text-[length:var(--font-size-sidebar)]";
 const sidebarRowActionButtonClass =
 	"inline-flex size-5 shrink-0 items-center justify-center rounded-sm border border-transparent bg-transparent text-muted-foreground/70 opacity-0 outline-hidden transition-[opacity,color] hover:text-foreground focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/40 group-hover/sidebar-row:opacity-100 aria-expanded:text-foreground aria-expanded:opacity-100";
 const DEFAULT_SIDEBAR_WIDTH = 220;
@@ -335,10 +335,10 @@ export function Sidebar({
 					const isFocused = focusedIndex === index;
 					const isRenaming =
 						row.kind === "file" && row.file.path === renamingPath;
+					const isPinnedFile = row.kind === "file" && row.file.pinned;
+					const canTogglePinnedFile = isPinnedFile && onTogglePinnedFile;
 					const isPinnedSectionEnd =
-						row.kind === "file" &&
-						row.file.pinned &&
-						rows[index + 1]?.kind !== "file";
+						isPinnedFile && rows[index + 1]?.kind !== "file";
 					if (row.kind === "section") {
 						return (
 							<div
@@ -435,9 +435,6 @@ export function Sidebar({
 									className={cn(
 										sidebarRowContentClass,
 										"truncate border-none bg-transparent",
-										row.kind === "file" &&
-											row.file.pinned &&
-											"[padding-inline-end:1.75rem]",
 									)}
 									style={rowStyle}
 									onClick={(event) => {
@@ -457,22 +454,20 @@ export function Sidebar({
 									<span
 										className={cn(
 											"min-w-0 flex-1 truncate",
-											row.kind === "file" &&
-												row.file.pinned &&
-												"[direction:rtl] [text-align:left]",
+											isPinnedFile && "[direction:rtl] [text-align:left]",
 										)}
 									>
 										{row.label}
 									</span>
 								</button>
 							)}
-							{row.kind === "file" && row.file.pinned && onTogglePinnedFile && (
+							{canTogglePinnedFile && (
 								<span
 									className={cn(
-										"pointer-events-none absolute inset-y-0 end-0 w-12 rounded-e-[var(--radius-row)] opacity-0 transition-opacity group-hover/sidebar-row:opacity-100",
+										"pointer-events-none absolute inset-y-0 end-0 w-16 rounded-e-[var(--radius-row)] opacity-0 transition-opacity group-hover/sidebar-row:opacity-100",
 										isActive
-											? "bg-linear-to-r from-transparent from-0% via-sidebar-accent via-35% to-sidebar-accent"
-											: "bg-linear-to-r from-transparent from-0% via-accent via-35% to-accent",
+											? "bg-linear-to-r from-transparent from-0% via-sidebar-accent via-25% to-sidebar-accent"
+											: "bg-linear-to-r from-transparent from-0% via-accent via-25% to-accent",
 									)}
 								/>
 							)}
@@ -492,22 +487,20 @@ export function Sidebar({
 											onDeleteFolder={onDeleteFolder}
 										/>
 									)}
-								{row.kind === "file" &&
-									row.file.pinned &&
-									onTogglePinnedFile && (
-										<button
-											type="button"
-											className={sidebarRowActionButtonClass}
-											aria-label={`Unpin ${row.label}`}
-											title={`Unpin ${row.label}`}
-											onClick={(event) => {
-												event.stopPropagation();
-												onTogglePinnedFile(row.file.path);
-											}}
-										>
-											<MingcutePinFill className="size-3.5" />
-										</button>
-									)}
+								{canTogglePinnedFile && (
+									<button
+										type="button"
+										className={sidebarRowActionButtonClass}
+										aria-label="Unpin"
+										title="Unpin"
+										onClick={(event) => {
+											event.stopPropagation();
+											onTogglePinnedFile(row.file.path);
+										}}
+									>
+										<MingcutePinFill className="size-3.5" />
+									</button>
+								)}
 								{row.kind === "file" &&
 									(onRevealFile ||
 										onRenameFile ||

--- a/packages/ui/src/components/useSidebarTree.ts
+++ b/packages/ui/src/components/useSidebarTree.ts
@@ -6,6 +6,7 @@ export type SidebarSortMode = "alpha" | "recent";
 export type SidebarFile = {
 	path: string;
 	modifiedAt?: number;
+	pinned?: boolean;
 };
 
 type FolderNode = {
@@ -17,6 +18,12 @@ type FolderNode = {
 };
 
 export type SidebarRow =
+	| {
+			kind: "section";
+			id: string;
+			label: string;
+			depth: number;
+	  }
 	| {
 			kind: "folder";
 			id: string;
@@ -89,8 +96,15 @@ export function useSidebarTree({
 		[highlightPath, getDisplayPath],
 	);
 	const rows = useMemo(
-		() => flattenTree(tree, sortMode, expandedFolders),
-		[tree, sortMode, expandedFolders],
+		() =>
+			flattenRows({
+				files,
+				getDisplayPath,
+				tree,
+				sortMode,
+				expandedFolders,
+			}),
+		[expandedFolders, files, getDisplayPath, sortMode, tree],
 	);
 
 	useEffect(() => {
@@ -192,13 +206,35 @@ function buildFileTree(
 	return root;
 }
 
-function flattenTree(
-	root: FolderNode,
-	sortMode: SidebarSortMode,
-	expandedFolders: Set<string>,
-): SidebarRow[] {
+function flattenRows({
+	files,
+	getDisplayPath,
+	tree,
+	sortMode,
+	expandedFolders,
+}: {
+	files: SidebarFile[];
+	getDisplayPath: (path: string) => string;
+	tree: FolderNode;
+	sortMode: SidebarSortMode;
+	expandedFolders: Set<string>;
+}): SidebarRow[] {
 	const rows: SidebarRow[] = [];
-	appendFolderChildren(root, 0, sortMode, expandedFolders, rows);
+	const pinnedFiles = files
+		.filter((file) => file.pinned)
+		.sort((a, b) => compareFiles(a, b, sortMode));
+	if (pinnedFiles.length > 0) {
+		rows.push({ kind: "section", id: "pinned", label: "Pinned", depth: 0 });
+		for (const file of pinnedFiles) {
+			rows.push({
+				kind: "file",
+				file,
+				label: normalizeDisplayPath(getDisplayPath(file.path)),
+				depth: 0,
+			});
+		}
+	}
+	appendFolderChildren(tree, 0, sortMode, expandedFolders, rows);
 	return rows;
 }
 
@@ -236,6 +272,7 @@ function appendFolderChildren(
 	}
 
 	for (const file of files) {
+		if (file.pinned) continue;
 		rows.push({
 			kind: "file",
 			file,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@iconify-json/mingcute':
         specifier: ^1.2.7


### PR DESCRIPTION
Summary:
- add versioned `.hubble/config.json` workspace config for pinned notes
- load pins on workspace open and persist pin/unpin, rename, delete updates
- hoist pinned notes into a top `Pinned` section, including notes from nested folders
- front-truncate pinned paths so long directory prefixes collapse and filename tails remain visible
- show uppercase `PINNED` with a filled pin icon
- overlay pinned-row controls so they do not reserve text width
- preserve normal right text padding and fade pinned row text aggressively under overlay controls on hover
- add extra bottom margin after the pinned section before folders

Tests:
- pnpm --filter @hubble.md/desktop test -- --run apps/desktop/src/store/actions.test.ts
- pnpm check
- pnpm build:desktop

E2E:
- ran Hubble Dev playground with pinned note
- verified non-hover pinned row has normal right text padding
- verified pinned row controls overlay text with fade and Unpin + Actions appear together
- clicked the new Unpin control and verified the pinned section disappeared

Closes #64