### PR TITLE
Keep command menus within editor viewport

### DIFF
--- a/packages/ui/src/editor/FormatCommandMenu.tsx
+++ b/packages/ui/src/editor/FormatCommandMenu.tsx
@@ -24,6 +24,7 @@ import MingcuteQuoteLeftLine from "~icons/mingcute/quote-left-line";
 import MingcuteStrikethroughLine from "~icons/mingcute/strikethrough-line";
 import MingcuteTextLine from "~icons/mingcute/text-line";
 import { cn } from "../lib/utils";
+import { useCommandMenuPosition } from "./commandMenuPosition";
 
 type FormatCommandKind =
 	| "paragraph"
@@ -174,6 +175,7 @@ export function FormatCommandMenu({
 	const [selectedKind, setSelectedKind] =
 		useState<FormatCommandKind>("paragraph");
 	const inputRef = useRef<HTMLInputElement | null>(null);
+	const menuRef = useRef<HTMLDivElement | null>(null);
 	const visibleCommands = FORMAT_COMMANDS.filter((command) =>
 		matchesCommand(command, query),
 	);
@@ -199,11 +201,11 @@ export function FormatCommandMenu({
 				closeMenu();
 				return;
 			}
-			const nextPosition = positionForSelection(editor, viewportRef);
-			if (!nextPosition) return;
+			const viewport = viewportRef.current;
+			if (!viewport) return;
 			setQuery("");
 			setSelectedKind("paragraph");
-			setPosition(nextPosition);
+			setPosition(null);
 			setOpen(true);
 			requestAnimationFrame(() => inputRef.current?.focus());
 		};
@@ -212,7 +214,15 @@ export function FormatCommandMenu({
 		return () => window.removeEventListener("keydown", handleKeyDown);
 	}, [closeMenu, editor, open, viewportRef]);
 
-	if (!editor || !open || !position) return null;
+	useCommandMenuPosition({
+		editor,
+		floatingRef: menuRef,
+		pos: open ? (editor?.state.selection.from ?? null) : null,
+		setPosition,
+		viewportRef,
+	});
+
+	if (!editor || !open) return null;
 
 	const runCommand = (kind: FormatCommandKind) => {
 		closeMenu();
@@ -221,10 +231,12 @@ export function FormatCommandMenu({
 
 	return (
 		<div
+			ref={menuRef}
 			className="absolute z-[5] w-[250px] overflow-hidden rounded-[var(--radius-popover)] border border-border bg-popover text-popover-foreground shadow-overlay"
 			style={{
-				insetInlineStart: `${position.x}px`,
-				insetBlockStart: `${position.y}px`,
+				insetInlineStart: `${position?.x ?? 0}px`,
+				insetBlockStart: `${position?.y ?? 0}px`,
+				visibility: position ? "visible" : "hidden",
 			}}
 		>
 			<Command
@@ -309,20 +321,6 @@ function renderGroup(
 			})}
 		</Command.Group>
 	);
-}
-
-function positionForSelection(
-	editor: Editor,
-	viewportRef: RefObject<HTMLDivElement | null>,
-): MenuPosition | null {
-	const viewport = viewportRef.current;
-	if (!viewport) return null;
-	const coords = editor.view.coordsAtPos(editor.state.selection.from);
-	const viewportRect = viewport.getBoundingClientRect();
-	return {
-		x: Math.max(8, coords.left - viewportRect.left + viewport.scrollLeft),
-		y: coords.bottom - viewportRect.top + viewport.scrollTop + 6,
-	};
 }
 
 function matchesCommand(command: FormatCommand, query: string) {

--- a/packages/ui/src/editor/SlashCommandMenu.tsx
+++ b/packages/ui/src/editor/SlashCommandMenu.tsx
@@ -18,6 +18,7 @@ import MingcuteQuoteLeftLine from "~icons/mingcute/quote-left-line";
 import MingcuteStrikethroughLine from "~icons/mingcute/strikethrough-line";
 import MingcuteTextLine from "~icons/mingcute/text-line";
 import { cn } from "../lib/utils";
+import { useCommandMenuPosition } from "./commandMenuPosition";
 import {
 	applySlashCommand,
 	findSlashToken,
@@ -123,6 +124,7 @@ export function SlashCommandMenu({
 	const [selectedKind, setSelectedKind] =
 		useState<SlashCommandKind>("paragraph");
 	const suppressedFromRef = useRef<number | null>(null);
+	const menuRef = useRef<HTMLDivElement | null>(null);
 	const visibleCommands = SLASH_COMMANDS.filter((command) =>
 		matchesCommand(command, token?.query ?? ""),
 	);
@@ -153,9 +155,8 @@ export function SlashCommandMenu({
 				setPosition(null);
 				return;
 			}
-			const nextPosition = positionForToken(editor, nextToken, viewportRef);
+			setPosition(null);
 			setToken(nextToken);
-			setPosition(nextPosition);
 		};
 
 		update();
@@ -175,6 +176,14 @@ export function SlashCommandMenu({
 			window.removeEventListener("resize", update);
 		};
 	}, [editor, viewportRef]);
+
+	useCommandMenuPosition({
+		editor,
+		floatingRef: menuRef,
+		pos: token?.from ?? null,
+		setPosition,
+		viewportRef,
+	});
 
 	useEffect(() => {
 		if (!editor) return;
@@ -221,16 +230,18 @@ export function SlashCommandMenu({
 			editor.view.dom.removeEventListener("keydown", handleKeyDown, true);
 	}, [activeKind, editor, token, visibleCommands]);
 
-	if (!editor || !token || !position || visibleCommands.length === 0) {
+	if (!editor || !token || visibleCommands.length === 0) {
 		return null;
 	}
 
 	return (
 		<div
+			ref={menuRef}
 			className="absolute z-[4] w-[250px] overflow-hidden rounded-[var(--radius-popover)] border border-border bg-popover text-popover-foreground shadow-overlay"
 			style={{
-				insetInlineStart: `${position.x}px`,
-				insetBlockStart: `${position.y}px`,
+				insetInlineStart: `${position?.x ?? 0}px`,
+				insetBlockStart: `${position?.y ?? 0}px`,
+				visibility: position ? "visible" : "hidden",
 			}}
 		>
 			<Command
@@ -283,21 +294,6 @@ export function SlashCommandMenu({
 			</Command>
 		</div>
 	);
-}
-
-function positionForToken(
-	editor: Editor,
-	token: SlashToken,
-	viewportRef: RefObject<HTMLDivElement | null>,
-): MenuPosition | null {
-	const viewport = viewportRef.current;
-	if (!viewport) return null;
-	const coords = editor.view.coordsAtPos(token.from);
-	const viewportRect = viewport.getBoundingClientRect();
-	return {
-		x: Math.max(8, coords.left - viewportRect.left + viewport.scrollLeft),
-		y: coords.bottom - viewportRect.top + viewport.scrollTop + 6,
-	};
 }
 
 function matchesCommand(command: SlashCommand, query: string) {

--- a/packages/ui/src/editor/commandMenuPosition.ts
+++ b/packages/ui/src/editor/commandMenuPosition.ts
@@ -1,0 +1,107 @@
+import {
+	computePosition,
+	flip,
+	offset,
+	shift,
+	type VirtualElement,
+} from "@floating-ui/dom";
+import type { Editor } from "@tiptap/core";
+import { type RefObject, useEffect } from "react";
+
+type MenuPosition = {
+	x: number;
+	y: number;
+};
+
+function updateCommandMenuPosition({
+	editor,
+	viewport,
+	floatingEl,
+	pos,
+	setPosition,
+}: {
+	editor: Editor;
+	viewport: HTMLDivElement;
+	floatingEl: HTMLDivElement;
+	pos: number;
+	setPosition: (position: MenuPosition) => void;
+}) {
+	const reference: VirtualElement = {
+		contextElement: viewport,
+		getBoundingClientRect() {
+			const coords = editor.view.coordsAtPos(pos);
+			return {
+				x: coords.left,
+				y: coords.top,
+				left: coords.left,
+				top: coords.top,
+				right: coords.right,
+				bottom: coords.bottom,
+				width: coords.right - coords.left,
+				height: coords.bottom - coords.top,
+				toJSON() {
+					return this;
+				},
+			};
+		},
+	};
+
+	return computePosition(reference, floatingEl, {
+		strategy: "absolute",
+		placement: "bottom-start",
+		middleware: [
+			offset(6),
+			flip({
+				boundary: viewport,
+				fallbackPlacements: ["top-start", "bottom-end", "top-end"],
+				padding: 8,
+			}),
+			shift({
+				boundary: viewport,
+				padding: 8,
+			}),
+		],
+	}).then(({ x, y }) => {
+		setPosition({ x, y });
+	});
+}
+
+export function useCommandMenuPosition({
+	editor,
+	floatingRef,
+	pos,
+	setPosition,
+	viewportRef,
+}: {
+	editor: Editor | null;
+	floatingRef: RefObject<HTMLDivElement | null>;
+	pos: number | null;
+	setPosition: (position: MenuPosition) => void;
+	viewportRef: RefObject<HTMLDivElement | null>;
+}) {
+	useEffect(() => {
+		if (!editor || pos === null) return;
+		const viewport = viewportRef.current;
+		const floatingEl = floatingRef.current;
+		if (!viewport || !floatingEl) return;
+
+		const update = () => {
+			void updateCommandMenuPosition({
+				editor,
+				viewport,
+				floatingEl,
+				pos,
+				setPosition,
+			});
+		};
+
+		update();
+		viewport.addEventListener("scroll", update, { passive: true });
+		window.addEventListener("resize", update);
+
+		return () => {
+			viewport.removeEventListener("scroll", update);
+			window.removeEventListener("resize", update);
+		};
+	}, [editor, floatingRef, pos, setPosition, viewportRef]);
+}


### PR DESCRIPTION
## Summary
- Position slash and format command menus with floating-ui collision handling.
- Flip/shift menus inside the editor viewport on scroll and resize.
- Hide menus until measured so they do not flash at stale coordinates.

## Checks
- pnpm check
- pnpm build:desktop

## E2E
- Ran Hubble Dev playground with CDP enabled.
- Opened project-ideas.md and verified `/` and Cmd+/ menus render visible with no right/bottom overflow and no horizontal document scroll.

Closes #68