### PR TITLE
Show real directories in desktop sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 ### Changed
 
 ### Fixed
+- Pressing Enter at the end of a link no longer carries the link onto the next line
 
 ## [0.1.11] - 2026-06-21
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -26,11 +26,17 @@ import type {
 } from "../src/desktopApi/types";
 import {
 	hasDocumentExtension,
+	isMarkdownAssetFolderName,
 	markdownAssetFolderPath,
 	withMarkdownExtension,
 } from "../src/lib/filePath";
 
 type FileEntry = {
+	path: string;
+	modified_at: number;
+};
+
+type FolderEntry = {
 	path: string;
 	modified_at: number;
 };
@@ -808,7 +814,7 @@ function fileAssetsDir(filePath: string): string {
 
 async function collectDocumentFiles(
 	dir: string,
-	out: FileEntry[],
+	out: { files: FileEntry[]; folders: FolderEntry[] },
 	inheritedRules: IgnoreRule[] = [],
 ) {
 	const rules = await rulesForDir(dir, inheritedRules);
@@ -817,10 +823,16 @@ async function collectDocumentFiles(
 		const entryPath = path.join(dir, entry.name);
 		if (isIgnoredByRules(entryPath, rules)) continue;
 		if (entry.isDirectory()) {
+			if (isMarkdownAssetFolderName(entry.name)) continue;
+			const stat = await fs.stat(entryPath);
+			out.folders.push({
+				path: entryPath,
+				modified_at: Math.floor(stat.mtimeMs / 1000),
+			});
 			await collectDocumentFiles(entryPath, out, rules);
 		} else if (isDocumentPath(entry.name)) {
 			const stat = await fs.stat(entryPath);
-			out.push({
+			out.files.push({
 				path: entryPath,
 				modified_at: Math.floor(stat.mtimeMs / 1000),
 			});
@@ -938,9 +950,12 @@ function registerIpc() {
 			const root = assertGrantedRoot(dirPath);
 			const stat = await fs.stat(root);
 			if (!stat.isDirectory()) throw new Error(`Not a directory: ${dirPath}`);
-			const entries: FileEntry[] = [];
-			await collectDocumentFiles(root, entries);
-			return entries;
+			const listing = {
+				files: [] as FileEntry[],
+				folders: [] as FolderEntry[],
+			};
+			await collectDocumentFiles(root, listing);
+			return listing;
 		},
 	);
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -27,7 +27,7 @@ import type {
 } from "../src/desktopApi/types";
 import {
 	hasDocumentExtension,
-	isMarkdownAssetFolderName,
+	isHiddenSidebarFolderName,
 	markdownAssetFolderPath,
 	withMarkdownExtension,
 } from "../src/lib/filePath";
@@ -814,7 +814,7 @@ async function collectDocumentFiles(
 		const entryPath = path.join(dir, entry.name);
 		if (isIgnoredByRules(entryPath, rules)) continue;
 		if (entry.isDirectory()) {
-			if (isMarkdownAssetFolderName(entry.name)) continue;
+			if (isHiddenSidebarFolderName(entry.name)) continue;
 			const stat = await fs.stat(entryPath);
 			out.folders.push({
 				path: entryPath,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -22,6 +22,7 @@ import ignore from "ignore";
 import { z } from "zod/v4";
 import type {
 	DesktopUpdateState,
+	DirectoryListing,
 	WorkspaceConfig,
 } from "../src/desktopApi/types";
 import {
@@ -30,16 +31,6 @@ import {
 	markdownAssetFolderPath,
 	withMarkdownExtension,
 } from "../src/lib/filePath";
-
-type FileEntry = {
-	path: string;
-	modified_at: number;
-};
-
-type FolderEntry = {
-	path: string;
-	modified_at: number;
-};
 
 type HtmlAppFileEntry = {
 	name: string;
@@ -814,7 +805,7 @@ function fileAssetsDir(filePath: string): string {
 
 async function collectDocumentFiles(
 	dir: string,
-	out: { files: FileEntry[]; folders: FolderEntry[] },
+	out: DirectoryListing,
 	inheritedRules: IgnoreRule[] = [],
 ) {
 	const rules = await rulesForDir(dir, inheritedRules);
@@ -950,10 +941,7 @@ function registerIpc() {
 			const root = assertGrantedRoot(dirPath);
 			const stat = await fs.stat(root);
 			if (!stat.isDirectory()) throw new Error(`Not a directory: ${dirPath}`);
-			const listing = {
-				files: [] as FileEntry[],
-				folders: [] as FolderEntry[],
-			};
+			const listing: DirectoryListing = { files: [], folders: [] };
 			await collectDocumentFiles(root, listing);
 			return listing;
 		},

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -38,7 +38,7 @@ export function Sidebar({
 	const workspace = useStoreValue(workspaceStore);
 	const sidebarOpen = useStoreValue(sidebarOpenStore);
 	const currentPath = useStoreValue(currentPathStore);
-	const { workspacePath, files, pinnedNotes, sortMode } = workspace;
+	const { workspacePath, files, folders, pinnedNotes, sortMode } = workspace;
 	const pinnedSet = new Set(pinnedNotes);
 
 	if (!sidebarOpen) return null;
@@ -94,6 +94,10 @@ export function Sidebar({
 				path: file.path,
 				modifiedAt: file.modified_at,
 				pinned: pinnedSet.has(file.path),
+			}))}
+			folders={folders.map((folder) => ({
+				path: folder.path,
+				modifiedAt: folder.modified_at,
 			}))}
 			currentPath={currentPath ?? null}
 			sortMode={sortMode}

--- a/apps/desktop/src/desktopApi/types.ts
+++ b/apps/desktop/src/desktopApi/types.ts
@@ -3,6 +3,16 @@ export type FileEntry = {
 	modified_at: number;
 };
 
+export type FolderEntry = {
+	path: string;
+	modified_at: number;
+};
+
+export type DirectoryListing = {
+	files: FileEntry[];
+	folders: FolderEntry[];
+};
+
 export type HtmlAppFileEntry = {
 	name: string;
 	path: string;
@@ -59,7 +69,7 @@ export type WorkspaceConfig = {
 export type DesktopApi = {
 	platform: DesktopPlatform;
 	homeDir: string;
-	listDirectory(path: string): Promise<FileEntry[]>;
+	listDirectory(path: string): Promise<DirectoryListing>;
 	listHtmlAppFiles(
 		workspacePath: string,
 		glob: string,

--- a/apps/desktop/src/desktopApi/types.ts
+++ b/apps/desktop/src/desktopApi/types.ts
@@ -3,10 +3,7 @@ export type FileEntry = {
 	modified_at: number;
 };
 
-export type FolderEntry = {
-	path: string;
-	modified_at: number;
-};
+export type FolderEntry = FileEntry;
 
 export type DirectoryListing = {
 	files: FileEntry[];

--- a/apps/desktop/src/lib/filePath.test.ts
+++ b/apps/desktop/src/lib/filePath.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { isMarkdownAssetFolderName } from "./filePath";
+
+describe("isMarkdownAssetFolderName", () => {
+	it("matches canonical markdown asset directories", () => {
+		expect(isMarkdownAssetFolderName("note.assets")).toBe(true);
+		expect(isMarkdownAssetFolderName("note.assets.backup")).toBe(false);
+		expect(isMarkdownAssetFolderName("assets")).toBe(false);
+	});
+});

--- a/apps/desktop/src/lib/filePath.test.ts
+++ b/apps/desktop/src/lib/filePath.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { isMarkdownAssetFolderName } from "./filePath";
+import { isHiddenSidebarFolderName } from "./filePath";
 
-describe("isMarkdownAssetFolderName", () => {
-	it("matches canonical markdown asset directories", () => {
-		expect(isMarkdownAssetFolderName("note.assets")).toBe(true);
-		expect(isMarkdownAssetFolderName("note.assets.backup")).toBe(false);
-		expect(isMarkdownAssetFolderName("assets")).toBe(false);
+describe("isHiddenSidebarFolderName", () => {
+	it("matches app-owned directories excluded from the sidebar", () => {
+		expect(isHiddenSidebarFolderName(".hubble")).toBe(true);
+		expect(isHiddenSidebarFolderName("note.assets")).toBe(true);
+		expect(isHiddenSidebarFolderName("note.assets.backup")).toBe(false);
+		expect(isHiddenSidebarFolderName("assets")).toBe(false);
 	});
 });

--- a/apps/desktop/src/lib/filePath.ts
+++ b/apps/desktop/src/lib/filePath.ts
@@ -32,6 +32,10 @@ export function hasDocumentExtension(path: string): boolean {
 	return hasMarkdownExtension(path) || hasHtmlExtension(path);
 }
 
+export function isMarkdownAssetFolderName(name: string): boolean {
+	return name.endsWith(".assets");
+}
+
 export function withMarkdownExtension(path: string): string {
 	return hasMarkdownExtension(path) ? path : `${path}.md`;
 }

--- a/apps/desktop/src/lib/filePath.ts
+++ b/apps/desktop/src/lib/filePath.ts
@@ -32,8 +32,8 @@ export function hasDocumentExtension(path: string): boolean {
 	return hasMarkdownExtension(path) || hasHtmlExtension(path);
 }
 
-export function isMarkdownAssetFolderName(name: string): boolean {
-	return name.endsWith(".assets");
+export function isHiddenSidebarFolderName(name: string): boolean {
+	return name === ".hubble" || name.endsWith(".assets");
 }
 
 export function withMarkdownExtension(path: string): string {

--- a/apps/desktop/src/store/actions.test.ts
+++ b/apps/desktop/src/store/actions.test.ts
@@ -14,7 +14,7 @@ function createDesktopApi(): MockDesktopApi {
 	return {
 		readFileText: vi.fn(async () => "before"),
 		writeFileText: vi.fn(async () => {}),
-		listDirectory: vi.fn(async () => []),
+		listDirectory: vi.fn(async () => ({ files: [], folders: [] })),
 		readWorkspaceConfig: vi.fn(async () => ({ version: 1, pinnedNotes: [] })),
 		writeWorkspaceConfig: vi.fn(async () => {}),
 		renameFile: vi.fn(async () => {}),
@@ -131,9 +131,10 @@ describe("desktop renameMarkdownFile", () => {
 	it("reopens the active file from its renamed path", async () => {
 		const api = createDesktopApi();
 		api.readFileText.mockResolvedValue("embed content");
-		api.listDirectory.mockResolvedValue([
-			{ path: "/workspace/renamed.md", modified_at: 1 },
-		]);
+		api.listDirectory.mockResolvedValue({
+			files: [{ path: "/workspace/renamed.md", modified_at: 1 }],
+			folders: [],
+		});
 		const { appStore, renameMarkdownFile, viewerStore, workspaceStore } =
 			await loadStoreActions(api);
 		const path = "/workspace/original.md";
@@ -196,9 +197,10 @@ describe("desktop renameMarkdownFile", () => {
 
 	it("renames to nested paths relative to the current folder", async () => {
 		const api = createDesktopApi();
-		api.listDirectory.mockResolvedValue([
-			{ path: "/workspace/notes/archive/q1-plan.md", modified_at: 1 },
-		]);
+		api.listDirectory.mockResolvedValue({
+			files: [{ path: "/workspace/notes/archive/q1-plan.md", modified_at: 1 }],
+			folders: [],
+		});
 		const { appStore, renameMarkdownFile, viewerStore } =
 			await loadStoreActions(api);
 
@@ -234,9 +236,12 @@ describe("desktop renameMarkdownFile", () => {
 
 	it("renames to nested paths in Windows workspaces", async () => {
 		const api = createDesktopApi();
-		api.listDirectory.mockResolvedValue([
-			{ path: "C:/workspace/notes/archive/q1-plan.md", modified_at: 1 },
-		]);
+		api.listDirectory.mockResolvedValue({
+			files: [
+				{ path: "C:/workspace/notes/archive/q1-plan.md", modified_at: 1 },
+			],
+			folders: [],
+		});
 		const { appStore, renameMarkdownFile, viewerStore } =
 			await loadStoreActions(api);
 
@@ -451,9 +456,10 @@ describe("desktop moveSidebarItem", () => {
 
 	it("moves a file to a folder and updates opened state", async () => {
 		const api = createDesktopApi();
-		api.listDirectory.mockResolvedValue([
-			{ path: "/workspace/archive/note.md", modified_at: 1 },
-		]);
+		api.listDirectory.mockResolvedValue({
+			files: [{ path: "/workspace/archive/note.md", modified_at: 1 }],
+			folders: [],
+		});
 		const { appStore, moveSidebarItem, viewerStore, workspaceStore } =
 			await loadStoreActions(api);
 
@@ -702,9 +708,10 @@ describe("desktop loadPath", () => {
 		api.readFileText.mockRejectedValue(
 			new Error(`ENOENT: no such file or directory, open '${missingPath}'`),
 		);
-		api.listDirectory.mockResolvedValue([
-			{ path: remainingPath, modified_at: 2 },
-		]);
+		api.listDirectory.mockResolvedValue({
+			files: [{ path: remainingPath, modified_at: 2 }],
+			folders: [],
+		});
 		const { appStore, loadPath, workspaceStore } = await loadStoreActions(api);
 
 		appStore.set((current) => ({
@@ -735,7 +742,7 @@ describe("desktop loadPath", () => {
 			api.readFileText.mockRejectedValue(
 				new Error("ENOENT: no such file or directory"),
 			);
-			api.listDirectory.mockResolvedValue([]);
+			api.listDirectory.mockResolvedValue({ files: [], folders: [] });
 			const { appStore, loadPath } = await loadStoreActions(api);
 
 			appStore.set((current) => ({

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -29,6 +29,7 @@ import {
 	cleanFileState,
 	emptyDoc,
 	type FileEntry,
+	type FolderEntry,
 	getBaseline,
 	isInWorkspace,
 	LOADING_DELAY_MS,
@@ -52,16 +53,20 @@ type SidebarMoveItem =
 export async function refreshFiles(path = workspaceStore.get().workspacePath) {
 	if (!path) return;
 	let files: FileEntry[] = [];
+	let folders: FolderEntry[] = [];
 
 	try {
-		files = await desktopApi.listDirectory(path);
+		const listing = await desktopApi.listDirectory(path);
+		files = listing.files;
+		folders = listing.folders;
 	} catch {
 		files = [];
+		folders = [];
 	}
 
 	workspaceStore.set((state) => {
 		if (state.workspacePath !== path) return state;
-		return { ...state, files };
+		return { ...state, files, folders };
 	});
 }
 

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -52,21 +52,16 @@ type SidebarMoveItem =
 
 export async function refreshFiles(path = workspaceStore.get().workspacePath) {
 	if (!path) return;
-	let files: FileEntry[] = [];
-	let folders: FolderEntry[] = [];
-
-	try {
-		const listing = await desktopApi.listDirectory(path);
-		files = listing.files;
-		folders = listing.folders;
-	} catch {
-		files = [];
-		folders = [];
-	}
+	const listing = await desktopApi
+		.listDirectory(path)
+		.catch((): { files: FileEntry[]; folders: FolderEntry[] } => ({
+			files: [],
+			folders: [],
+		}));
 
 	workspaceStore.set((state) => {
 		if (state.workspacePath !== path) return state;
-		return { ...state, files, folders };
+		return { ...state, files: listing.files, folders: listing.folders };
 	});
 }
 

--- a/apps/desktop/src/store/persistence.ts
+++ b/apps/desktop/src/store/persistence.ts
@@ -6,6 +6,7 @@ type WorkspaceState = {
 	lastOpenedPaths: Record<string, string>;
 	sortMode: SortMode;
 	files: { path: string; modified_at: number }[];
+	folders: { path: string; modified_at: number }[];
 	pinnedNotes: string[];
 };
 
@@ -61,6 +62,7 @@ function hydrateWorkspace(ws: Persisted["workspace"]): WorkspaceState {
 				: {},
 		sortMode: ws?.sortMode === "alpha" ? "alpha" : "recent",
 		files: [],
+		folders: [],
 		pinnedNotes: [],
 	};
 }

--- a/apps/desktop/src/store/state.ts
+++ b/apps/desktop/src/store/state.ts
@@ -15,6 +15,11 @@ export type FileEntry = {
 	modified_at: number;
 };
 
+export type FolderEntry = {
+	path: string;
+	modified_at: number;
+};
+
 type ViewerStatus = "idle" | "loading" | "ready" | "error";
 type ExternalChange =
 	| { kind: "none" }

--- a/apps/desktop/src/store/state.ts
+++ b/apps/desktop/src/store/state.ts
@@ -15,10 +15,7 @@ export type FileEntry = {
 	modified_at: number;
 };
 
-export type FolderEntry = {
-	path: string;
-	modified_at: number;
-};
+export type FolderEntry = FileEntry;
 
 type ViewerStatus = "idle" | "loading" | "ready" | "error";
 type ExternalChange =

--- a/packages/editor/src/Link.ts
+++ b/packages/editor/src/Link.ts
@@ -4,6 +4,7 @@ import type { EditorState } from "@tiptap/pm/state";
 export const LinkExtension = Mark.create({
 	name: "link",
 	inclusive: true,
+	keepOnSplit: false,
 
 	addAttributes() {
 		return {

--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -49,12 +49,13 @@ import { Button } from "../primitives/button";
 import { useSidebarKeyboardNav } from "./useSidebarKeyboardNav";
 import {
 	type SidebarFile,
+	type SidebarFolder,
 	type SidebarRow,
 	type SidebarSortMode,
 	useSidebarTree,
 } from "./useSidebarTree";
 
-export type { SidebarFile, SidebarSortMode };
+export type { SidebarFile, SidebarFolder, SidebarSortMode };
 
 export type SidebarMoveItemInput = {
 	item: { kind: "file"; path: string } | { kind: "folder"; folderId: string };
@@ -113,6 +114,7 @@ const segmentFirstCollision: CollisionDetection = (args) => {
 
 export function Sidebar({
 	files,
+	folders,
 	currentPath,
 	pendingPath,
 	sortMode,
@@ -137,6 +139,7 @@ export function Sidebar({
 	onMoveItem,
 }: {
 	files: SidebarFile[];
+	folders?: SidebarFolder[];
 	currentPath: string | null;
 	pendingPath?: string | null;
 	sortMode: SidebarSortMode;
@@ -180,6 +183,7 @@ export function Sidebar({
 	const highlightPath = pendingPath ?? currentPath;
 	const { collapseFolder, expandFolder, rows, toggleFolder } = useSidebarTree({
 		files,
+		folders,
 		getDisplayPath,
 		highlightPath,
 		sortMode,

--- a/packages/ui/src/components/useSidebarTree.test.ts
+++ b/packages/ui/src/components/useSidebarTree.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { buildFileTree } from "./useSidebarTree";
+
+function folderNames(node: ReturnType<typeof buildFileTree>) {
+	return [...node.folders.values()].map((folder) => folder.name);
+}
+
+describe("buildFileTree", () => {
+	it("includes empty folders from directory entries", () => {
+		const tree = buildFileTree(
+			[],
+			[{ path: "/workspace/empty", modifiedAt: 3 }],
+			(path) => path.replace("/workspace/", ""),
+		);
+
+		expect(folderNames(tree)).toEqual(["empty"]);
+		expect(tree.folders.get("empty")?.files).toEqual([]);
+	});
+
+	it("includes folder-only nested hierarchies from directory entries", () => {
+		const tree = buildFileTree(
+			[],
+			[
+				{ path: "/workspace/parent", modifiedAt: 1 },
+				{ path: "/workspace/parent/child", modifiedAt: 2 },
+			],
+			(path) => path.replace("/workspace/", ""),
+		);
+
+		const parent = tree.folders.get("parent");
+		expect(parent?.folders.get("child")?.files).toEqual([]);
+	});
+
+	it("does not render asset folders when listing omits them", () => {
+		const tree = buildFileTree(
+			[{ path: "/workspace/note.md", modifiedAt: 1 }],
+			[],
+			(path) => path.replace("/workspace/", ""),
+		);
+
+		expect(folderNames(tree)).toEqual([]);
+	});
+});

--- a/packages/ui/src/components/useSidebarTree.ts
+++ b/packages/ui/src/components/useSidebarTree.ts
@@ -9,6 +9,11 @@ export type SidebarFile = {
 	pinned?: boolean;
 };
 
+export type SidebarFolder = {
+	path: string;
+	modifiedAt?: number;
+};
+
 type FolderNode = {
 	id: string;
 	name: string;
@@ -53,12 +58,14 @@ const expandedFoldersSchema = z.array(z.string());
 
 export function useSidebarTree({
 	files,
+	folders = [],
 	getDisplayPath,
 	highlightPath,
 	sortMode,
 	storageScope,
 }: {
 	files: SidebarFile[];
+	folders?: SidebarFolder[];
 	getDisplayPath: (path: string) => string;
 	highlightPath: string | null;
 	sortMode: SidebarSortMode;
@@ -91,8 +98,8 @@ export function useSidebarTree({
 	}, [storageKey, expandedState]);
 
 	const tree = useMemo(
-		() => buildFileTree(files, getDisplayPath),
-		[files, getDisplayPath],
+		() => buildFileTree(files, folders, getDisplayPath),
+		[files, folders, getDisplayPath],
 	);
 	const activeAncestorIds = useMemo(
 		() =>
@@ -175,11 +182,25 @@ function makeFolder(id: string, name: string): FolderNode {
 	};
 }
 
-function buildFileTree(
+export function buildFileTree(
 	files: SidebarFile[],
+	folders: SidebarFolder[],
 	getDisplayPath: (path: string) => string,
 ): FolderNode {
 	const root = makeFolder("", "");
+
+	for (const folderEntry of folders) {
+		const displayPath = normalizeDisplayPath(getDisplayPath(folderEntry.path));
+		if (!displayPath) continue;
+		const segments = displayPath.split("/").filter(Boolean);
+		let parent = root;
+		const modifiedAt = folderEntry.modifiedAt ?? 0;
+		for (const segment of segments) {
+			const folder = ensureFolder(parent, segment);
+			folder.modifiedAt = Math.max(folder.modifiedAt, modifiedAt);
+			parent = folder;
+		}
+	}
 
 	for (const file of files) {
 		const displayPath = normalizeDisplayPath(getDisplayPath(file.path));

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,6 +3,7 @@ export {
 	Sidebar,
 	type SidebarFile,
 	type SidebarFocusedItem,
+	type SidebarFolder,
 	SidebarFrame,
 	type SidebarMoveItemInput,
 	type SidebarSortMode,


### PR DESCRIPTION
## Summary
- Return real folder entries from desktop directory listing alongside document files
- Seed sidebar tree from real folders so empty and folder-only directories render
- Exclude canonical `*.assets` directories from sidebar folders

## Checks
- `pnpm --filter @hubble.md/ui test -- useSidebarTree`
- `pnpm --filter @hubble.md/desktop test -- actions filePath`
- `pnpm exec biome check <touched files>`
- `pnpm build:desktop`

## E2E
- Ran Electron dev app with CDP enabled
- Added `empty-folder`, `folder-only/nested`, and `project-ideas.assets` in dev playground
- Verified sidebar rendered empty/folder-only directories and did not render `.assets`

Closes #90