### PR TITLE
Add inline folder creation

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1052,6 +1052,13 @@ function registerIpc() {
 		},
 	);
 
+	ipcMain.handle("desktop:create-folder", async (_event, { path: dirPath }) => {
+		const resolved = resolvePath(dirPath);
+		assertGranted(path.dirname(resolved));
+		await fs.mkdir(resolved);
+		grantRoot(resolved);
+	});
+
 	ipcMain.handle(
 		"desktop:rename-file",
 		async (_event, { fromPath, toPath }) => {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1130,9 +1130,25 @@ function registerIpc() {
 	ipcMain.handle(
 		"desktop:delete-file",
 		async (_event, { path: filePath, options }) => {
-			await fs.rm(assertGranted(filePath), {
-				recursive: options?.recursive === true,
-			});
+			const resolved = assertGranted(filePath);
+			if (options?.recursive === true) {
+				await fs.rm(resolved, { recursive: true });
+				return;
+			}
+			try {
+				await fs.rm(resolved);
+			} catch (err) {
+				if (
+					err &&
+					typeof err === "object" &&
+					"code" in err &&
+					(err.code === "EISDIR" || err.code === "ERR_FS_EISDIR")
+				) {
+					await fs.rmdir(resolved);
+					return;
+				}
+				throw err;
+			}
 		},
 	);
 

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -32,6 +32,7 @@ const desktopApi = {
 		ipcRenderer.invoke("desktop:read-file-text", { path }),
 	writeFileText: (path, content) =>
 		ipcRenderer.invoke("desktop:write-file-text", { path, content }),
+	createFolder: (path) => ipcRenderer.invoke("desktop:create-folder", { path }),
 	renameFile: (fromPath, toPath) =>
 		ipcRenderer.invoke("desktop:rename-file", { fromPath, toPath }),
 	pathExists: (path) => ipcRenderer.invoke("desktop:path-exists", { path }),

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -10,12 +10,14 @@ import { toast } from "sonner";
 import { desktopApi } from "../desktopApi";
 import { revealFileLabel } from "../lib/revealFile";
 import {
+	createFolderInFolder,
 	createMarkdownFileInFolder,
 	deleteFolder,
 	deleteMarkdownFile,
 	loadPath,
 	moveSidebarItem,
 	openWorkspace,
+	renameFolder,
 	renameMarkdownFile,
 	setSidebarOpen,
 	setSortMode,
@@ -124,10 +126,20 @@ export function Sidebar({
 			}}
 			revealLabel={revealFileLabel(desktopApi.platform)}
 			onRenameFile={(path, nextName) => void renameMarkdownFile(path, nextName)}
+			onRenameFolder={(folderId, nextName, targetDisplayPath) =>
+				void renameFolder(
+					absolutePath(folderId),
+					nextName,
+					absolutePath(targetDisplayPath),
+				)
+			}
 			onDeleteFile={(path) => void deleteMarkdownFile(path)}
 			onTogglePinnedFile={(path) => void togglePinnedNote(path)}
 			onCreateFile={(folderId) =>
 				createMarkdownFileInFolder(absolutePath(folderId))
+			}
+			onCreateFolder={(folderId) =>
+				createFolderInFolder(absolutePath(folderId))
 			}
 			onDeleteFolder={(folderId) => void deleteFolder(absolutePath(folderId))}
 			onMoveItem={({ item, targetFolderId }) =>

--- a/apps/desktop/src/desktopApi/types.ts
+++ b/apps/desktop/src/desktopApi/types.ts
@@ -78,6 +78,7 @@ export type DesktopApi = {
 	): Promise<void>;
 	readFileText(path: string): Promise<string>;
 	writeFileText(path: string, content: string): Promise<void>;
+	createFolder(path: string): Promise<void>;
 	renameFile(fromPath: string, toPath: string): Promise<void>;
 	pathExists(path: string): Promise<boolean>;
 	persistPastedImage(

--- a/apps/desktop/src/store/actions.test.ts
+++ b/apps/desktop/src/store/actions.test.ts
@@ -6,7 +6,9 @@ type MockDesktopApi = {
 	listDirectory: ReturnType<typeof vi.fn>;
 	readWorkspaceConfig: ReturnType<typeof vi.fn>;
 	writeWorkspaceConfig: ReturnType<typeof vi.fn>;
+	createFolder: ReturnType<typeof vi.fn>;
 	renameFile: ReturnType<typeof vi.fn>;
+	deleteFile: ReturnType<typeof vi.fn>;
 	pathExists: ReturnType<typeof vi.fn>;
 };
 
@@ -17,7 +19,9 @@ function createDesktopApi(): MockDesktopApi {
 		listDirectory: vi.fn(async () => ({ files: [], folders: [] })),
 		readWorkspaceConfig: vi.fn(async () => ({ version: 1, pinnedNotes: [] })),
 		writeWorkspaceConfig: vi.fn(async () => {}),
+		createFolder: vi.fn(async () => {}),
 		renameFile: vi.fn(async () => {}),
+		deleteFile: vi.fn(async () => {}),
 		pathExists: vi.fn(async () => false),
 	};
 }
@@ -446,6 +450,148 @@ describe("desktop renameMarkdownFile", () => {
 		expect(viewerStore.get().content).toBe(
 			"[Target](renamed.md)\nunsaved edit",
 		);
+	});
+});
+
+describe("desktop folder actions", () => {
+	beforeEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("creates a unique folder and adds it to the sidebar snapshot", async () => {
+		const api = createDesktopApi();
+		api.listDirectory.mockResolvedValue({
+			files: [],
+			folders: [{ path: "/workspace/new-folder-2", modified_at: 2 }],
+		});
+		const { appStore, createFolderInFolder, workspaceStore } =
+			await loadStoreActions(api);
+
+		appStore.set((current) => ({
+			...current,
+			workspace: {
+				...current.workspace,
+				workspacePath: "/workspace",
+				folders: [{ path: "/workspace/new-folder", modified_at: 1 }],
+			},
+		}));
+
+		const path = await createFolderInFolder("/workspace");
+
+		expect(path).toBe("/workspace/new-folder-2");
+		expect(api.createFolder).toHaveBeenCalledWith("/workspace/new-folder-2");
+		expect(workspaceStore.get().folders).toEqual([
+			{ path: "/workspace/new-folder-2", modified_at: 2 },
+		]);
+	});
+
+	it("renames folders and rewrites contained workspace paths", async () => {
+		const api = createDesktopApi();
+		api.listDirectory.mockResolvedValue({
+			files: [{ path: "/workspace/archive/plan.md", modified_at: 2 }],
+			folders: [{ path: "/workspace/archive", modified_at: 2 }],
+		});
+		const { appStore, renameFolder, viewerStore, workspaceStore } =
+			await loadStoreActions(api);
+
+		appStore.set((current) => ({
+			...current,
+			workspace: {
+				...current.workspace,
+				workspacePath: "/workspace",
+				files: [{ path: "/workspace/drafts/plan.md", modified_at: 1 }],
+				folders: [{ path: "/workspace/drafts", modified_at: 1 }],
+				pinnedNotes: ["/workspace/drafts/plan.md"],
+				lastOpenedPaths: { "/workspace": "/workspace/drafts/plan.md" },
+			},
+			document: {
+				...current.document,
+				currentPath: "/workspace/drafts/plan.md",
+				lastOpenedPath: "/workspace/drafts/plan.md",
+				content: "[Self](plan.md)",
+				diskContent: "[Self](plan.md)",
+				externalChange: { kind: "none" },
+				status: "ready",
+				error: null,
+			},
+		}));
+
+		await renameFolder("/workspace/drafts", "archive");
+
+		expect(api.renameFile).toHaveBeenCalledWith(
+			"/workspace/drafts",
+			"/workspace/archive",
+		);
+		expect(viewerStore.get().currentPath).toBe("/workspace/archive/plan.md");
+		expect(workspaceStore.get().pinnedNotes).toEqual([
+			"/workspace/archive/plan.md",
+		]);
+		expect(api.writeWorkspaceConfig).toHaveBeenCalledWith("/workspace", {
+			version: 1,
+			pinnedNotes: ["archive/plan.md"],
+		});
+	});
+
+	it("renames compacted nested folders to the requested display path", async () => {
+		const api = createDesktopApi();
+		api.listDirectory.mockResolvedValue({
+			files: [{ path: "/workspace/archive/plan.md", modified_at: 2 }],
+			folders: [{ path: "/workspace/archive", modified_at: 2 }],
+		});
+		const { appStore, renameFolder } = await loadStoreActions(api);
+
+		appStore.set((current) => ({
+			...current,
+			workspace: {
+				...current.workspace,
+				workspacePath: "/workspace",
+				files: [{ path: "/workspace/drafts/current/plan.md", modified_at: 1 }],
+				folders: [
+					{ path: "/workspace/drafts", modified_at: 1 },
+					{ path: "/workspace/drafts/current", modified_at: 1 },
+				],
+			},
+		}));
+
+		await renameFolder(
+			"/workspace/drafts/current",
+			"archive",
+			"/workspace/archive",
+		);
+
+		expect(api.renameFile).toHaveBeenCalledWith(
+			"/workspace/drafts/current",
+			"/workspace/archive",
+		);
+		expect(api.renameFile).not.toHaveBeenCalledWith(
+			"/workspace/drafts/current",
+			"/workspace/drafts/current/archive",
+		);
+		expect(api.deleteFile).toHaveBeenCalledWith("/workspace/drafts");
+	});
+
+	it("deletes a freshly created folder when inline naming is canceled", async () => {
+		const api = createDesktopApi();
+		const { appStore, createFolderInFolder, deleteFolder, workspaceStore } =
+			await loadStoreActions(api);
+
+		appStore.set((current) => ({
+			...current,
+			workspace: {
+				...current.workspace,
+				workspacePath: "/workspace",
+			},
+		}));
+
+		const path = await createFolderInFolder("/workspace");
+		if (!path) throw new Error("Expected created folder path");
+		await deleteFolder(path);
+
+		expect(api.createFolder).toHaveBeenCalledWith("/workspace/new-folder");
+		expect(api.deleteFile).toHaveBeenCalledWith("/workspace/new-folder", {
+			recursive: true,
+		});
+		expect(workspaceStore.get().folders).toEqual([]);
 	});
 });
 

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -187,27 +187,33 @@ async function updateMovedLinks(movedFiles: MovedFile[], files: FileEntry[]) {
 	}
 }
 
-function folderPathsFromFiles(files: FileEntry[]) {
-	const folders = new Set<string>();
+function folderPathsFromEntries(
+	files: FileEntry[],
+	folderEntries: FolderEntry[] = [],
+) {
+	const folderPaths = new Set<string>();
+	for (const folder of folderEntries) {
+		folderPaths.add(folder.path.toLocaleLowerCase());
+	}
 	for (const file of files) {
 		let parent = dirname(file.path);
 		while (parent) {
-			folders.add(parent.toLocaleLowerCase());
+			folderPaths.add(parent.toLocaleLowerCase());
 			const nextParent = dirname(parent);
 			parent = nextParent === parent ? null : nextParent;
 		}
 	}
-	return folders;
+	return folderPaths;
 }
 
 function uniqueMovePath(parent: string, sourcePath: string, isFolder: boolean) {
 	const sourceName = basename(sourcePath);
 	const extension = isFolder ? "" : extname(sourceName);
 	const stem = extension ? sourceName.slice(0, -extension.length) : sourceName;
-	const files = workspaceStore.get().files;
+	const { files, folders } = workspaceStore.get();
 	const existing = new Set([
 		...files.map((file) => file.path.toLocaleLowerCase()),
-		...folderPathsFromFiles(files),
+		...folderPathsFromEntries(files, folders),
 	]);
 	for (let index = 0; ; index++) {
 		const name = index === 0 ? sourceName : `${stem} ${index}${extension}`;
@@ -268,6 +274,19 @@ function uniqueMarkdownPath(parent: string): string {
 	const existing = new Set(files.map((file) => file.path.toLocaleLowerCase()));
 	for (let index = 1; ; index++) {
 		const name = index === 1 ? "new-file.md" : `new-file-${index}.md`;
+		const candidate = joinPath(parent, name);
+		if (!existing.has(candidate.toLocaleLowerCase())) return candidate;
+	}
+}
+
+function uniqueFolderPath(parent: string): string {
+	const { files, folders } = workspaceStore.get();
+	const existing = new Set([
+		...files.map((file) => file.path.toLocaleLowerCase()),
+		...folderPathsFromEntries(files, folders),
+	]);
+	for (let index = 1; ; index++) {
+		const name = index === 1 ? "new-folder" : `new-folder-${index}`;
 		const candidate = joinPath(parent, name);
 		if (!existing.has(candidate.toLocaleLowerCase())) return candidate;
 	}
@@ -529,6 +548,117 @@ export async function renameCurrentMarkdownFile(nextName: string) {
 	await renameMarkdownFile(current.currentPath, nextName);
 }
 
+async function deleteEmptySourceAncestors(
+	sourcePath: string,
+	targetPath: string,
+	workspacePath: string | null,
+) {
+	if (!workspacePath) return;
+	let parent = dirname(sourcePath);
+	while (parent && !pathEquals(parent, workspacePath)) {
+		if (pathEquals(parent, targetPath) || pathInFolder(targetPath, parent)) {
+			return;
+		}
+		try {
+			await desktopApi.deleteFile(parent);
+		} catch (err) {
+			const message = errorMessage(err);
+			if (
+				!missingPathErrorPattern.test(message) &&
+				!/\bENOTEMPTY\b/.test(message)
+			) {
+				throw err;
+			}
+			return;
+		}
+		const nextParent = dirname(parent);
+		parent = nextParent === parent ? null : nextParent;
+	}
+}
+
+export async function renameFolder(
+	path: string,
+	nextName: string,
+	targetPath?: string,
+) {
+	const { files: filesBeforeRename, workspacePath } = workspaceStore.get();
+	const trimmedName = nextName.trim();
+	if (trimmedName.length === 0) return;
+
+	const parent = dirname(path);
+	if (!parent) return;
+
+	const nextPath = normalizePath(targetPath ?? joinPath(parent, trimmedName));
+	if (
+		targetPath &&
+		workspacePath &&
+		!pathInFolder(nextPath, normalizePath(workspacePath))
+	) {
+		return;
+	}
+	if (!isSafeRelativeRenamePath(trimmedName, nextPath, workspacePath)) return;
+	if (nextPath === path) return;
+
+	const current = viewerStore.get();
+	const currentPath = current.currentPath;
+	const currentAffected = currentPath && pathInFolder(currentPath, path);
+	const movedFiles = movedMarkdownFiles(
+		filesBeforeRename,
+		path,
+		nextPath,
+		true,
+	);
+
+	try {
+		if (currentAffected && currentPath) {
+			await savePathContent(currentPath, current.content, { force: true });
+		}
+		await desktopApi.renameFile(path, nextPath);
+		await deleteEmptySourceAncestors(path, nextPath, workspacePath);
+		appStore.set((state) => ({
+			...state,
+			workspace: {
+				...state.workspace,
+				files: state.workspace.files.map((file) => ({
+					...file,
+					path: replacePathPrefix(file.path, path, nextPath),
+				})),
+				folders: state.workspace.folders.map((folder) => ({
+					...folder,
+					path: replacePathPrefix(folder.path, path, nextPath),
+				})),
+				pinnedNotes: state.workspace.pinnedNotes.map((pinnedPath) =>
+					replacePathPrefix(pinnedPath, path, nextPath),
+				),
+				lastOpenedPaths: Object.fromEntries(
+					Object.entries(state.workspace.lastOpenedPaths).map(
+						([workspace, openedPath]) => [
+							workspace,
+							replacePathPrefix(openedPath, path, nextPath),
+						],
+					),
+				),
+			},
+			document: {
+				...state.document,
+				currentPath: state.document.currentPath
+					? replacePathPrefix(state.document.currentPath, path, nextPath)
+					: null,
+				lastOpenedPath: state.document.lastOpenedPath
+					? replacePathPrefix(state.document.lastOpenedPath, path, nextPath)
+					: null,
+			},
+		}));
+		await updateMovedLinks(movedFiles, filesBeforeRename);
+		await syncPinnedNotes();
+		await refreshFiles();
+	} catch (err) {
+		const message = handleFileError(err);
+		toast.error("Failed to rename folder", { description: message });
+		await refreshFiles();
+	}
+}
+
 function isSafeRelativeRenamePath(
 	name: string,
 	nextPath: string,
@@ -655,6 +785,24 @@ export async function createMarkdownFileInFolder(parentPath: string) {
 	} catch (err) {
 		const message = handleFileError(err);
 		toast.error("Failed to create file", { description: message });
+		return null;
+	}
+}
+
+export async function createFolderInFolder(parentPath: string) {
+	const path = uniqueFolderPath(parentPath);
+	try {
+		await desktopApi.createFolder(path);
+		const modified_at = Math.floor(Date.now() / 1000);
+		workspaceStore.set((state) => ({
+			...state,
+			folders: [...state.folders, { path, modified_at }],
+		}));
+		await refreshFiles();
+		return path;
+	} catch (err) {
+		const message = handleFileError(err);
+		toast.error("Failed to create folder", { description: message });
 		return null;
 	}
 }

--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -69,7 +69,12 @@ export type SidebarFocusedItem =
 
 type RenameItem =
 	| { kind: "file"; path: string }
-	| { kind: "folder"; path: string; displayPath: string };
+	| {
+			kind: "folder";
+			path: string;
+			displayPath: string;
+			parentDisplayPath: string;
+	  };
 
 const sidebarActionClass =
 	"flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-start text-[11px] font-normal outline-hidden select-none";
@@ -251,7 +256,12 @@ export function Sidebar({
 			const displayPath = normalizeDisplayPath(getDisplayPath(path));
 			const id = displayPath.endsWith("/") ? displayPath : `${displayPath}/`;
 			beginRename(
-				{ kind: "folder", path: id, displayPath },
+				{
+					kind: "folder",
+					path: id,
+					displayPath,
+					parentDisplayPath: dirname(displayPath),
+				},
 				fileNameFromPath(displayPath),
 				{
 					deleteOnUnchangedCancel: true,
@@ -273,7 +283,12 @@ export function Sidebar({
 				beginRename({ kind: "file", path: row.file.path }, row.label);
 			else if (row.kind === "folder" && onRenameFolder)
 				beginRename(
-					{ kind: "folder", path: row.id, displayPath: folderDisplayPath(row) },
+					{
+						kind: "folder",
+						path: row.id,
+						displayPath: folderDisplayPath(row),
+						parentDisplayPath: folderRenameParentDisplayPath(row),
+					},
 					row.label,
 				);
 			else if (row.kind === "section") return;
@@ -651,6 +666,8 @@ export function Sidebar({
 																		kind: "folder",
 																		path: row.id,
 																		displayPath: folderDisplayPath(row),
+																		parentDisplayPath:
+																			folderRenameParentDisplayPath(row),
 																	},
 																	value,
 																),
@@ -741,6 +758,8 @@ export function Sidebar({
 																			kind: "folder",
 																			path: id,
 																			displayPath: folderDisplayPath(row),
+																			parentDisplayPath:
+																				folderRenameParentDisplayPath(row),
 																		},
 																		label,
 																	)
@@ -1131,6 +1150,14 @@ function folderDisplayPath(row: Extract<SidebarRow, { kind: "folder" }>) {
 	const firstSegmentId = row.segments[0]?.id ?? row.id;
 	const parent = parentFolderId(firstSegmentId);
 	return normalizeDisplayPath(parent ? `${parent}${row.label}` : row.label);
+}
+
+function folderRenameParentDisplayPath(
+	row: Extract<SidebarRow, { kind: "folder" }>,
+) {
+	const firstSegmentId = row.segments[0]?.id ?? row.id;
+	const parent = parentFolderId(firstSegmentId);
+	return parent ? normalizeDisplayPath(parent).replace(/\/+$/, "") : "";
 }
 
 function rowDropGroup({
@@ -1709,7 +1736,10 @@ function renameTargetDisplayPath(
 	const sourceName = fileNameFromPath(sourceDisplayPath);
 	const { extension } =
 		item.kind === "file" ? splitFileName(sourceName) : { extension: "" };
-	const parent = dirname(sourceDisplayPath);
+	const parent =
+		item.kind === "folder"
+			? item.parentDisplayPath
+			: dirname(sourceDisplayPath);
 	const targetName = stripMatchingExtension(nextName.trim(), extension);
 	return normalizeDisplayPath(
 		parent

--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -33,6 +33,7 @@ import MingcuteDeleteLine from "~icons/mingcute/delete-line";
 import MingcuteEditLine from "~icons/mingcute/edit-line";
 import MingcuteFolderOpenLine from "~icons/mingcute/folder-open-line";
 import MingcuteMore2Line from "~icons/mingcute/more-2-line";
+import MingcuteNewFolderLine from "~icons/mingcute/new-folder-line";
 import MingcutePinFill from "~icons/mingcute/pin-fill";
 import MingcutePinLine from "~icons/mingcute/pin-line";
 import MingcuteRightLine from "~icons/mingcute/right-line";
@@ -199,6 +200,8 @@ export function Sidebar({
 	const [activeDragLabel, setActiveDragLabel] = useState<string | null>(null);
 	const [dropTarget, setDropTarget] = useState<DropTarget | null>(null);
 	const highlightPath = pendingPath ?? currentPath;
+	const uncompactFolderId =
+		deleteOnCancel?.kind === "folder" ? deleteOnCancel.path : null;
 	const { collapseFolder, expandFolder, rows, toggleFolder } = useSidebarTree({
 		files,
 		folders,
@@ -206,6 +209,7 @@ export function Sidebar({
 		highlightPath,
 		sortMode,
 		storageScope,
+		uncompactFolderId,
 	});
 	const sensors = useSensors(
 		useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
@@ -857,7 +861,7 @@ export function Sidebar({
 							title="New folder"
 							onClick={() => void createFolder(null)}
 						>
-							<MingcuteFolderOpenLine className="size-3.5" />
+							<MingcuteNewFolderLine className="size-3.5" />
 						</Button>
 					)}
 					<Select.Root
@@ -1422,7 +1426,7 @@ function FolderActionsMenu({
 			)}
 			{onCreateFolder && (
 				<ActionItem
-					icon={<MingcuteFolderOpenLine />}
+					icon={<MingcuteNewFolderLine />}
 					onClick={() => onCreateFolder(id)}
 				>
 					New folder

--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -67,6 +67,10 @@ export type SidebarFocusedItem =
 	| { kind: "folder"; folderId: string }
 	| null;
 
+type RenameItem =
+	| { kind: "file"; path: string }
+	| { kind: "folder"; path: string; displayPath: string };
+
 const sidebarActionClass =
 	"flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-start text-[11px] font-normal outline-hidden select-none";
 const sidebarActionIconClass =
@@ -114,7 +118,7 @@ const segmentFirstCollision: CollisionDetection = (args) => {
 
 export function Sidebar({
 	files,
-	folders,
+	folders = [],
 	currentPath,
 	pendingPath,
 	sortMode,
@@ -132,9 +136,11 @@ export function Sidebar({
 	onFocusedItemChange,
 	revealLabel,
 	onRenameFile,
+	onRenameFolder,
 	onDeleteFile,
 	onTogglePinnedFile,
 	onCreateFile,
+	onCreateFolder,
 	onDeleteFolder,
 	onMoveItem,
 }: {
@@ -158,19 +164,26 @@ export function Sidebar({
 	onFocusedItemChange?: (item: SidebarFocusedItem) => void;
 	revealLabel?: string;
 	onRenameFile?: (path: string, nextName: string) => void;
+	onRenameFolder?: (
+		folderId: string,
+		nextName: string,
+		targetDisplayPath: string,
+	) => void;
 	onDeleteFile?: (path: string) => void;
 	onTogglePinnedFile?: (path: string) => void;
 	onCreateFile?: (folderId: string | null) => Promise<string | null>;
+	onCreateFolder?: (folderId: string | null) => Promise<string | null>;
 	onDeleteFolder?: (folderId: string) => void;
 	onMoveItem?: (input: SidebarMoveItemInput) => Promise<void> | void;
 }) {
 	const navRef = useRef<HTMLDivElement>(null);
 	const renameInputRef = useRef<HTMLInputElement | null>(null);
 	const [openActionsPath, setOpenActionsPath] = useState<string | null>(null);
-	const [renamingPath, setRenamingPath] = useState<string | null>(null);
+	const [renamingItem, setRenamingItem] = useState<RenameItem | null>(null);
 	const [renameDraft, setRenameDraft] = useState("");
 	const [showFooterBorder, setShowFooterBorder] = useState(false);
 	const [deleteOnCancel, setDeleteOnCancel] = useState<{
+		kind: RenameItem["kind"];
 		path: string;
 		draft: string;
 	} | null>(null);
@@ -194,17 +207,17 @@ export function Sidebar({
 	);
 	const beginRename = useCallback(
 		(
-			file: SidebarFile,
+			item: RenameItem,
 			label: string,
 			options?: { deleteOnUnchangedCancel?: boolean },
 		) => {
 			const name = splitFileName(label).name;
 			setOpenActionsPath(null);
-			setRenamingPath(file.path);
+			setRenamingItem(item);
 			setRenameDraft(name);
 			setDeleteOnCancel(
 				options?.deleteOnUnchangedCancel
-					? { path: file.path, draft: name }
+					? { kind: item.kind, path: item.path, draft: name }
 					: null,
 			);
 			setRenameError(null);
@@ -218,11 +231,34 @@ export function Sidebar({
 			if (folderId) expandFolder(folderId);
 			const path = await onCreateFile(folderId);
 			if (!path) return;
-			beginRename({ path }, fileNameFromPath(getDisplayPath(path)), {
-				deleteOnUnchangedCancel: true,
-			});
+			beginRename(
+				{ kind: "file", path },
+				fileNameFromPath(getDisplayPath(path)),
+				{
+					deleteOnUnchangedCancel: true,
+				},
+			);
 		},
 		[beginRename, expandFolder, getDisplayPath, onCreateFile],
+	);
+	const createFolder = useCallback(
+		async (folderId: string | null) => {
+			if (!onCreateFolder) return;
+			setOpenActionsPath(null);
+			if (folderId) expandFolder(folderId);
+			const path = await onCreateFolder(folderId);
+			if (!path) return;
+			const displayPath = normalizeDisplayPath(getDisplayPath(path));
+			const id = displayPath.endsWith("/") ? displayPath : `${displayPath}/`;
+			beginRename(
+				{ kind: "folder", path: id, displayPath },
+				fileNameFromPath(displayPath),
+				{
+					deleteOnUnchangedCancel: true,
+				},
+			);
+		},
+		[beginRename, expandFolder, getDisplayPath, onCreateFolder],
 	);
 	const activateRow = useCallback(
 		(row: SidebarRow) => {
@@ -233,11 +269,17 @@ export function Sidebar({
 	);
 	const enterRowEdit = useCallback(
 		(row: SidebarRow) => {
-			if (row.kind === "file" && onRenameFile) beginRename(row.file, row.label);
+			if (row.kind === "file" && onRenameFile)
+				beginRename({ kind: "file", path: row.file.path }, row.label);
+			else if (row.kind === "folder" && onRenameFolder)
+				beginRename(
+					{ kind: "folder", path: row.id, displayPath: folderDisplayPath(row) },
+					row.label,
+				);
 			else if (row.kind === "section") return;
 			else activateRow(row);
 		},
-		[activateRow, beginRename, onRenameFile],
+		[activateRow, beginRename, onRenameFile, onRenameFolder],
 	);
 	const expandRow = useCallback(
 		(row: SidebarRow) => {
@@ -340,10 +382,10 @@ export function Sidebar({
 	}, [activeDragLabel, dropTarget, expandFolder, rows]);
 
 	useEffect(() => {
-		if (!renamingPath) return;
+		if (!renamingItem) return;
 		renameInputRef.current?.focus();
 		renameInputRef.current?.select();
-	}, [renamingPath]);
+	}, [renamingItem]);
 
 	useEffect(() => {
 		const navEl = navRef.current;
@@ -370,7 +412,7 @@ export function Sidebar({
 	}, []);
 
 	const resetRename = useCallback(() => {
-		setRenamingPath(null);
+		setRenamingItem(null);
 		setRenameDraft("");
 		setDeleteOnCancel(null);
 		setRenameError(null);
@@ -379,35 +421,50 @@ export function Sidebar({
 	const cancelRename = useCallback(() => {
 		const shouldDelete =
 			deleteOnCancel &&
-			deleteOnCancel.path === renamingPath &&
+			renamingItem &&
+			deleteOnCancel.kind === renamingItem.kind &&
+			deleteOnCancel.path === renamingItem.path &&
 			deleteOnCancel.draft === renameDraft;
-		if (shouldDelete && onDeleteFile) onDeleteFile(deleteOnCancel.path);
+		if (shouldDelete) {
+			if (deleteOnCancel.kind === "file" && onDeleteFile)
+				onDeleteFile(deleteOnCancel.path);
+			else if (deleteOnCancel.kind === "folder" && onDeleteFolder)
+				onDeleteFolder(deleteOnCancel.path);
+		}
 		resetRename();
-	}, [deleteOnCancel, onDeleteFile, renameDraft, renamingPath, resetRename]);
+	}, [
+		deleteOnCancel,
+		onDeleteFile,
+		onDeleteFolder,
+		renameDraft,
+		renamingItem,
+		resetRename,
+	]);
 
 	const getRenameError = useCallback(
-		(path: string, draft: string) => {
+		(item: RenameItem, draft: string) => {
 			const nextName = draft.trim();
 			if (!nextName) return null;
-			const targetName = renameTargetName(path, nextName, getDisplayPath);
-			if (!renameTargetExists(path, nextName, files, getDisplayPath))
+			const targetName = renameTargetName(item, nextName, getDisplayPath);
+			if (!renameTargetExists(item, nextName, files, folders, getDisplayPath)) {
 				return null;
-			return `A file ${targetName} already exists at this location.`;
+			}
+			return `A ${item.kind} ${targetName} already exists at this location.`;
 		},
-		[files, getDisplayPath],
+		[files, folders, getDisplayPath],
 	);
 
 	const commitRename = useCallback(
 		(focusTree = false) => {
-			const path = renamingPath;
-			if (!path || !onRenameFile) return;
+			const item = renamingItem;
+			if (!item) return;
 			const nextName = renameDraft.trim();
 			if (!nextName) {
 				resetRename();
 				if (focusTree) requestAnimationFrame(() => navRef.current?.focus());
 				return;
 			}
-			const error = getRenameError(path, nextName);
+			const error = getRenameError(item, nextName);
 			if (error) {
 				setRenameError(error);
 				requestAnimationFrame(() => renameInputRef.current?.focus());
@@ -415,18 +472,25 @@ export function Sidebar({
 			}
 			if (focusTree) {
 				setPendingFocusDisplayPath(
-					renameTargetDisplayPath(path, nextName, getDisplayPath),
+					renameTargetDisplayPath(item, nextName, getDisplayPath),
 				);
 				requestAnimationFrame(() => navRef.current?.focus());
 			}
 			resetRename();
-			onRenameFile(path, nextName);
+			if (item.kind === "file") onRenameFile?.(item.path, nextName);
+			else
+				onRenameFolder?.(
+					item.path,
+					nextName,
+					renameTargetDisplayPath(item, nextName, getDisplayPath),
+				);
 		},
 		[
 			getRenameError,
 			onRenameFile,
+			onRenameFolder,
 			renameDraft,
-			renamingPath,
+			renamingItem,
 			resetRename,
 			getDisplayPath,
 		],
@@ -455,7 +519,12 @@ export function Sidebar({
 						row.kind === "file" && row.file.path === highlightPath;
 					const isFocused = focusedIndex === index;
 					const isRenaming =
-						row.kind === "file" && row.file.path === renamingPath;
+						(row.kind === "file" &&
+							renamingItem?.kind === "file" &&
+							row.file.path === renamingItem.path) ||
+						(row.kind === "folder" &&
+							renamingItem?.kind === "folder" &&
+							row.id === renamingItem.path);
 					const isPinnedFile = row.kind === "file" && row.file.pinned;
 					const canTogglePinnedFile = isPinnedFile && onTogglePinnedFile;
 					const isPinnedSectionEnd =
@@ -546,6 +615,8 @@ export function Sidebar({
 										if (
 											row.kind === "folder" &&
 											!onRevealFolder &&
+											!onCreateFolder &&
+											!onRenameFolder &&
 											!onCreateFile &&
 											!onDeleteFolder
 										)
@@ -571,8 +642,18 @@ export function Sidebar({
 													setRenameDraft(value);
 													setRenameError(
 														row.kind === "file"
-															? getRenameError(row.file.path, value)
-															: null,
+															? getRenameError(
+																	{ kind: "file", path: row.file.path },
+																	value,
+																)
+															: getRenameError(
+																	{
+																		kind: "folder",
+																		path: row.id,
+																		displayPath: folderDisplayPath(row),
+																	},
+																	value,
+																),
 													);
 												}}
 												onCancel={cancelRename}
@@ -597,7 +678,10 @@ export function Sidebar({
 											onDoubleClick={(event) => {
 												if (row.kind !== "file" || !onRenameFile) return;
 												event.preventDefault();
-												beginRename(row.file, row.label);
+												beginRename(
+													{ kind: "file", path: row.file.path },
+													row.label,
+												);
 											}}
 											dragAttributes={attributes}
 											dragListeners={listeners}
@@ -633,7 +717,11 @@ export function Sidebar({
 									)}
 									<div className="absolute inset-y-0 end-0.5 flex items-center gap-0.5">
 										{row.kind === "folder" &&
-											(onRevealFolder || onCreateFile || onDeleteFolder) && (
+											(onRevealFolder ||
+												onCreateFile ||
+												onCreateFolder ||
+												onRenameFolder ||
+												onDeleteFolder) && (
 												<FolderActionsMenu
 													id={row.id}
 													label={row.label}
@@ -644,6 +732,20 @@ export function Sidebar({
 													onRevealFolder={onRevealFolder}
 													revealLabel={revealLabel}
 													onCreateFile={(id) => void createFile(id)}
+													onCreateFolder={(id) => void createFolder(id)}
+													onRenameFolder={
+														onRenameFolder
+															? (id, label) =>
+																	beginRename(
+																		{
+																			kind: "folder",
+																			path: id,
+																			displayPath: folderDisplayPath(row),
+																		},
+																		label,
+																	)
+															: undefined
+													}
 													onDeleteFolder={onDeleteFolder}
 												/>
 											)}
@@ -677,7 +779,12 @@ export function Sidebar({
 													onRevealFile={onRevealFile}
 													onCopyFilePath={onCopyFilePath}
 													revealLabel={revealLabel}
-													onRenameFile={beginRename}
+													onRenameFile={(file, label) =>
+														beginRename(
+															{ kind: "file", path: file.path },
+															label,
+														)
+													}
 													onTogglePinnedFile={onTogglePinnedFile}
 													onDeleteFile={onDeleteFile}
 												/>
@@ -721,6 +828,17 @@ export function Sidebar({
 							onClick={() => void createFile(null)}
 						>
 							<MingcuteEditLine className="size-3.5" />
+						</Button>
+					)}
+					{onCreateFolder && (
+						<Button
+							variant="ghost"
+							size="icon-xs"
+							aria-label="New folder"
+							title="New folder"
+							onClick={() => void createFolder(null)}
+						>
+							<MingcuteFolderOpenLine className="size-3.5" />
 						</Button>
 					)}
 					<Select.Root
@@ -1009,6 +1127,12 @@ function parentFolderId(folderId: string): string | null {
 	return parent ? `${normalizeDisplayPath(parent)}/` : null;
 }
 
+function folderDisplayPath(row: Extract<SidebarRow, { kind: "folder" }>) {
+	const firstSegmentId = row.segments[0]?.id ?? row.id;
+	const parent = parentFolderId(firstSegmentId);
+	return normalizeDisplayPath(parent ? `${parent}${row.label}` : row.label);
+}
+
 function rowDropGroup({
 	getDisplayPath,
 	index,
@@ -1235,6 +1359,8 @@ function FolderActionsMenu({
 	onRevealFolder,
 	revealLabel,
 	onCreateFile,
+	onCreateFolder,
+	onRenameFolder,
 	onDeleteFolder,
 }: {
 	id: string;
@@ -1244,6 +1370,8 @@ function FolderActionsMenu({
 	onRevealFolder?: (id: string) => void;
 	revealLabel?: string;
 	onCreateFile?: (id: string) => void;
+	onCreateFolder?: (id: string) => void;
+	onRenameFolder?: (id: string, label: string) => void;
 	onDeleteFolder?: (id: string) => void;
 }) {
 	return (
@@ -1263,6 +1391,22 @@ function FolderActionsMenu({
 					onClick={() => onCreateFile(id)}
 				>
 					New file
+				</ActionItem>
+			)}
+			{onCreateFolder && (
+				<ActionItem
+					icon={<MingcuteFolderOpenLine />}
+					onClick={() => onCreateFolder(id)}
+				>
+					New folder
+				</ActionItem>
+			)}
+			{onRenameFolder && (
+				<ActionItem
+					icon={<MingcuteEditLine />}
+					onClick={() => onRenameFolder(id, label)}
+				>
+					Rename
 				</ActionItem>
 			)}
 			{onDeleteFolder && (
@@ -1508,44 +1652,63 @@ function writeSidebarWidth(storageKey: string, width: number) {
 }
 
 function renameTargetExists(
-	path: string,
+	item: RenameItem,
 	nextName: string,
 	files: SidebarFile[],
+	folders: SidebarFolder[],
 	getDisplayPath: (path: string) => string,
 ) {
 	const targetDisplayPath = renameTargetDisplayPath(
-		path,
+		item,
 		nextName,
 		getDisplayPath,
 	);
+	const sourceDisplayPath = normalizeDisplayPath(
+		item.kind === "folder" ? item.displayPath : getDisplayPath(item.path),
+	).replace(/\/+$/, "");
 
-	return files.some((file) => {
-		if (file.path === path) return false;
+	const fileExists = files.some((file) => {
+		const displayPath = normalizeDisplayPath(getDisplayPath(file.path));
+		if (item.kind === "file" && file.path === item.path) return false;
 		return (
-			normalizeDisplayPath(getDisplayPath(file.path)).toLocaleLowerCase() ===
-			targetDisplayPath.toLocaleLowerCase()
+			displayPath.toLocaleLowerCase() === targetDisplayPath.toLocaleLowerCase()
+		);
+	});
+	if (fileExists) return true;
+
+	return folders.some((folder) => {
+		const displayPath = normalizeDisplayPath(
+			getDisplayPath(folder.path),
+		).replace(/\/+$/, "");
+		if (item.kind === "folder" && displayPath === sourceDisplayPath)
+			return false;
+		return (
+			displayPath.toLocaleLowerCase() === targetDisplayPath.toLocaleLowerCase()
 		);
 	});
 }
 
 function renameTargetName(
-	path: string,
+	item: RenameItem,
 	nextName: string,
 	getDisplayPath: (path: string) => string,
 ) {
 	return fileNameFromPath(
-		renameTargetDisplayPath(path, nextName, getDisplayPath),
+		renameTargetDisplayPath(item, nextName, getDisplayPath),
 	);
 }
 
 function renameTargetDisplayPath(
-	path: string,
+	item: RenameItem,
 	nextName: string,
 	getDisplayPath: (path: string) => string,
 ) {
-	const sourceDisplayPath = normalizeDisplayPath(getDisplayPath(path));
+	const sourceDisplayPath = normalizeDisplayPath(
+		item.kind === "folder" ? item.displayPath : getDisplayPath(item.path),
+	).replace(/\/+$/, "");
 	const sourceName = fileNameFromPath(sourceDisplayPath);
-	const { extension } = splitFileName(sourceName);
+	const { extension } =
+		item.kind === "file" ? splitFileName(sourceName) : { extension: "" };
 	const parent = dirname(sourceDisplayPath);
 	const targetName = stripMatchingExtension(nextName.trim(), extension);
 	return normalizeDisplayPath(

--- a/packages/ui/src/components/useSidebarTree.test.ts
+++ b/packages/ui/src/components/useSidebarTree.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildFileTree } from "./useSidebarTree";
+import { buildFileTree, flattenRows } from "./useSidebarTree";
 
 function folderNames(node: ReturnType<typeof buildFileTree>) {
 	return [...node.folders.values()].map((folder) => folder.name);
@@ -39,5 +39,52 @@ describe("buildFileTree", () => {
 		);
 
 		expect(folderNames(tree)).toEqual([]);
+	});
+});
+
+describe("flattenRows", () => {
+	it("keeps a newly-created nested folder uncollapsed while naming", () => {
+		const getDisplayPath = (path: string) => path.replace("/workspace/", "");
+		const tree = buildFileTree(
+			[],
+			[
+				{ path: "/workspace/empty", modifiedAt: 1 },
+				{ path: "/workspace/empty/new-folder", modifiedAt: 2 },
+			],
+			getDisplayPath,
+		);
+
+		const rows = flattenRows({
+			files: [],
+			getDisplayPath,
+			tree,
+			sortMode: "alpha",
+			expandedFolders: new Set(["empty/"]),
+			uncompactFolderId: "empty/new-folder/",
+		});
+
+		expect(rows.map((row) => row.label)).toEqual(["empty", "new-folder"]);
+	});
+
+	it("collapses the nested folder chain after naming commits", () => {
+		const getDisplayPath = (path: string) => path.replace("/workspace/", "");
+		const tree = buildFileTree(
+			[],
+			[
+				{ path: "/workspace/empty", modifiedAt: 1 },
+				{ path: "/workspace/empty/new-folder", modifiedAt: 2 },
+			],
+			getDisplayPath,
+		);
+
+		const rows = flattenRows({
+			files: [],
+			getDisplayPath,
+			tree,
+			sortMode: "alpha",
+			expandedFolders: new Set(["empty/"]),
+		});
+
+		expect(rows.map((row) => row.label)).toEqual(["empty/new-folder"]);
 	});
 });

--- a/packages/ui/src/components/useSidebarTree.ts
+++ b/packages/ui/src/components/useSidebarTree.ts
@@ -63,6 +63,7 @@ export function useSidebarTree({
 	highlightPath,
 	sortMode,
 	storageScope,
+	uncompactFolderId = null,
 }: {
 	files: SidebarFile[];
 	folders?: SidebarFolder[];
@@ -70,6 +71,7 @@ export function useSidebarTree({
 	highlightPath: string | null;
 	sortMode: SidebarSortMode;
 	storageScope?: string | null;
+	uncompactFolderId?: string | null;
 }) {
 	const storageKey = storageScope
 		? `hubble-sidebar-expanded-folders:${storageScope}`
@@ -116,8 +118,9 @@ export function useSidebarTree({
 				tree,
 				sortMode,
 				expandedFolders,
+				uncompactFolderId,
 			}),
-		[expandedFolders, files, getDisplayPath, sortMode, tree],
+		[expandedFolders, files, getDisplayPath, sortMode, tree, uncompactFolderId],
 	);
 
 	useEffect(() => {
@@ -238,18 +241,20 @@ function ensureFolder(parent: FolderNode, name: string): FolderNode {
 	return folder;
 }
 
-function flattenRows({
+export function flattenRows({
 	files,
 	getDisplayPath,
 	tree,
 	sortMode,
 	expandedFolders,
+	uncompactFolderId = null,
 }: {
 	files: SidebarFile[];
 	getDisplayPath: (path: string) => string;
 	tree: FolderNode;
 	sortMode: SidebarSortMode;
 	expandedFolders: Set<string>;
+	uncompactFolderId?: string | null;
 }): SidebarRow[] {
 	const rows: SidebarRow[] = [];
 	const pinnedFiles = files
@@ -266,7 +271,14 @@ function flattenRows({
 			});
 		}
 	}
-	appendFolderChildren(tree, 0, sortMode, expandedFolders, rows);
+	appendFolderChildren(
+		tree,
+		0,
+		sortMode,
+		expandedFolders,
+		rows,
+		uncompactFolderId,
+	);
 	return rows;
 }
 
@@ -276,6 +288,7 @@ function appendFolderChildren(
 	sortMode: SidebarSortMode,
 	expandedFolders: Set<string>,
 	rows: SidebarRow[],
+	uncompactFolderId: string | null,
 ) {
 	const folders = [...folder.folders.values()].sort((a, b) =>
 		compareNodes(a, b, sortMode),
@@ -283,7 +296,7 @@ function appendFolderChildren(
 	const files = [...folder.files].sort((a, b) => compareFiles(a, b, sortMode));
 
 	for (const child of folders) {
-		const compacted = compactFolder(child);
+		const compacted = compactFolder(child, uncompactFolderId);
 		const expanded = expandedFolders.has(compacted.folder.id);
 		rows.push({
 			kind: "folder",
@@ -300,6 +313,7 @@ function appendFolderChildren(
 				sortMode,
 				expandedFolders,
 				rows,
+				uncompactFolderId,
 			);
 		}
 	}
@@ -316,7 +330,10 @@ function appendFolderChildren(
 }
 
 /** Collapses chains like `deeply/nested/folder` into one folder row. */
-function compactFolder(folder: FolderNode): {
+function compactFolder(
+	folder: FolderNode,
+	uncompactFolderId: string | null,
+): {
 	folder: FolderNode;
 	label: string;
 	segments: SidebarFolderSegment[];
@@ -329,6 +346,8 @@ function compactFolder(folder: FolderNode): {
 			| FolderNode
 			| undefined;
 		if (!onlyChild) break;
+		// New nested folders stay visible as their own row while the name input is open.
+		if (onlyChild.id === uncompactFolderId) break;
 		names.push(onlyChild.name);
 		segments.push({ id: onlyChild.id, name: onlyChild.name });
 		cursor = onlyChild;


### PR DESCRIPTION
## Summary
- Add a desktop create-folder IPC/API path and store action with unique `new-folder` naming
- Add a New folder sidebar button plus folder rename support through the existing inline rename UI
- Discard freshly-created unchanged folders on Escape via the existing delete-on-cancel flow

## Checks
- `pnpm --filter @hubble.md/desktop test -- actions`
- `pnpm --filter @hubble.md/ui test -- useSidebarTree`
- `pnpm exec biome check apps/desktop/src/desktopApi/types.ts apps/desktop/electron/preload.ts apps/desktop/electron/main.ts apps/desktop/src/store/actions.ts apps/desktop/src/store/actions.test.ts apps/desktop/src/components/Sidebar.tsx packages/ui/src/components/Sidebar.tsx`
- `pnpm build:desktop`

## E2E
- Ran `HUBBLE_DESKTOP_ENABLE_CDP=1 pnpm dev:desktop` against the Electron playground
- Created a folder from the sidebar header, confirmed inline rename mode, renamed it to `daily-agent-folder`, and verified it existed on disk
- Created another fresh folder and pressed Escape while unchanged; verified it disappeared from the sidebar and disk

## Notes
- Stacked on PR #92 because #91 depends on real empty folder rendering from #90.

Closes #89, #91