### PR TITLE
Desktop window zoom (Cmd +/-/0)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -29,6 +29,14 @@ import {
 	markdownAssetFolderPath,
 	withMarkdownExtension,
 } from "../src/lib/filePath";
+import {
+	loadZoomFactor,
+	resetWindowZoom,
+	setTrafficLightInset,
+	stepWindowZoom,
+	trafficLightPositionForZoom,
+	zoomStep,
+} from "./zoom";
 
 type FileEntry = {
 	path: string;
@@ -616,19 +624,39 @@ function buildMenu() {
 				{ role: "selectAll" },
 			],
 		},
-	];
-
-	if (isDev) {
-		template.push({
+		{
 			label: "View",
 			submenu: [
-				{ role: "reload" },
-				{ role: "forceReload" },
-				{ type: "separator" },
-				{ role: "toggleDevTools" },
+				{
+					id: "zoom-in",
+					label: "Zoom In",
+					accelerator: "CmdOrCtrl+=",
+					click: () => stepWindowZoom(mainWindow, zoomStep),
+				},
+				{
+					id: "zoom-out",
+					label: "Zoom Out",
+					accelerator: "CmdOrCtrl+-",
+					click: () => stepWindowZoom(mainWindow, -zoomStep),
+				},
+				{
+					id: "reset-zoom",
+					label: "Reset Zoom",
+					accelerator: "CmdOrCtrl+0",
+					click: () => resetWindowZoom(mainWindow),
+				},
+				...(isDev
+					? ([
+							{ type: "separator" },
+							{ role: "reload" },
+							{ role: "forceReload" },
+							{ type: "separator" },
+							{ role: "toggleDevTools" },
+						] satisfies Electron.MenuItemConstructorOptions[])
+					: []),
 			],
-		});
-	}
+		},
+	];
 
 	if (process.platform === "darwin") {
 		template.unshift({
@@ -885,6 +913,7 @@ function matchesGlob(relativePath: string, glob: string): boolean {
 
 async function createWindow() {
 	const windowState = await loadWindowState();
+	const zoomFactor = loadZoomFactor();
 	const window = new BrowserWindow({
 		title: appName,
 		...(windowState.x !== undefined && windowState.y !== undefined
@@ -894,7 +923,7 @@ async function createWindow() {
 		height: windowState.height,
 		show: false,
 		titleBarStyle: "hidden",
-		trafficLightPosition: { x: 12, y: 10 },
+		trafficLightPosition: trafficLightPositionForZoom(zoomFactor),
 		webPreferences: {
 			contextIsolation: true,
 			nodeIntegration: false,
@@ -908,7 +937,13 @@ async function createWindow() {
 	} else if (windowState.isMaximized) {
 		window.maximize();
 	}
-	window.once("ready-to-show", () => window.show());
+	// Apply persisted zoom while hidden so the first visible paint is already scaled.
+	window.webContents.once("did-finish-load", async () => {
+		window.webContents.setZoomFactor(zoomFactor);
+		await setTrafficLightInset(window, zoomFactor);
+		if (window.isDestroyed()) return;
+		window.show();
+	});
 
 	window.on("focus", () => sendToRenderer("desktop:window-focus"));
 	window.on("resize", () => queueSaveWindowState(window));

--- a/apps/desktop/electron/zoom.ts
+++ b/apps/desktop/electron/zoom.ts
@@ -1,0 +1,109 @@
+import fsSync from "node:fs";
+import path from "node:path";
+import { app, type BrowserWindow } from "electron";
+import { z } from "zod/v4";
+
+const defaultZoomFactor = 1;
+export const zoomStep = 0.1;
+const minZoomFactor = 0.5;
+const maxZoomFactor = 3;
+const trafficLightX = 12;
+const trafficLightWidth = 54;
+const trafficLightGap = 4;
+const trafficLightHeight = 14;
+const trafficLightYOffset = -1;
+const toolbarHeight = 36;
+
+const zoomStateSchema = z.object({
+	factor: z.number().min(minZoomFactor).max(maxZoomFactor),
+});
+
+function zoomStatePath(): string {
+	return path.join(app.getPath("userData"), "zoom-factor.json");
+}
+
+export function loadZoomFactor() {
+	try {
+		const raw = fsSync.readFileSync(zoomStatePath(), "utf8");
+		const parsed = zoomStateSchema.safeParse(JSON.parse(raw));
+		if (parsed.success) return parsed.data.factor;
+	} catch {
+		// Missing or malformed zoom state should not block launch.
+	}
+	return defaultZoomFactor;
+}
+
+function saveZoomFactor(factor: number) {
+	const parsed = zoomStateSchema.safeParse({ factor });
+	if (!parsed.success) return;
+	try {
+		fsSync.mkdirSync(path.dirname(zoomStatePath()), { recursive: true });
+		fsSync.writeFileSync(zoomStatePath(), JSON.stringify(parsed.data, null, 2));
+	} catch {
+		// Best-effort zoom state should not interrupt menu actions.
+	}
+}
+
+function normalizeZoom(factor: number) {
+	const stepped = Number(factor.toFixed(1));
+	return Math.min(maxZoomFactor, Math.max(minZoomFactor, stepped));
+}
+
+function setWindowZoomFactor(window: BrowserWindow, factor: number) {
+	const nextFactor = normalizeZoom(factor);
+	window.webContents.setZoomFactor(nextFactor);
+	setTrafficLightPosition(window, nextFactor);
+	void setTrafficLightInset(window, nextFactor);
+	saveZoomFactor(nextFactor);
+}
+
+export function trafficLightPositionForZoom(zoomFactor: number) {
+	return {
+		x: Math.round(trafficLightX * zoomFactor),
+		y: Math.max(
+			0,
+			Math.round(
+				(toolbarHeight * zoomFactor - trafficLightHeight) / 2 +
+					trafficLightYOffset,
+			),
+		),
+	};
+}
+
+function trafficLightInsetForZoom(zoomFactor: number) {
+	const { x } = trafficLightPositionForZoom(zoomFactor);
+	return (x + trafficLightWidth + trafficLightGap) / zoomFactor;
+}
+
+function setTrafficLightPosition(window: BrowserWindow, zoomFactor: number) {
+	if (process.platform !== "darwin" || window.isDestroyed()) return;
+	window.setWindowButtonPosition(trafficLightPositionForZoom(zoomFactor));
+}
+
+export async function setTrafficLightInset(
+	window: BrowserWindow,
+	zoomFactor: number,
+) {
+	if (window.isDestroyed()) return;
+	const inset = trafficLightInsetForZoom(zoomFactor);
+	try {
+		await window.webContents.executeJavaScript(
+			`document.documentElement.style.setProperty("--hubble-traffic-light-inset", "${inset}px")`,
+		);
+	} catch {
+		// The fallback inset still works if the renderer is navigating or destroyed.
+	}
+}
+
+export function stepWindowZoom(window: BrowserWindow | null, delta: number) {
+	if (!window || window.isDestroyed()) return;
+	const current = window.webContents.getZoomFactor();
+	const nextFactor = normalizeZoom(current + delta);
+	if (nextFactor === current) return;
+	setWindowZoomFactor(window, nextFactor);
+}
+
+export function resetWindowZoom(window: BrowserWindow | null) {
+	if (!window || window.isDestroyed()) return;
+	setWindowZoomFactor(window, defaultZoomFactor);
+}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -259,9 +259,6 @@ function App() {
 				if (opening) {
 					requestAnimationFrame(() => focusSidebarNav());
 				}
-			} else if (keymatch(event, "CmdOrCtrl+0")) {
-				event.preventDefault();
-				focusSidebarNav();
 			}
 		};
 		window.addEventListener("keydown", onKeyDown);

--- a/packages/ui/src/components/Toolbar.tsx
+++ b/packages/ui/src/components/Toolbar.tsx
@@ -11,7 +11,9 @@ import MingcuteLayoutLeftLine from "~icons/mingcute/layout-left-line";
 import { fileNameFromPath } from "../lib/filePath";
 import { Button } from "../primitives/button";
 
-const TOOLBAR_INSET = isMac() ? 70 : 8;
+const TOOLBAR_INSET = isMac()
+	? "var(--hubble-traffic-light-inset, 70px)"
+	: "8px";
 const ACTIONS_BASIS = "114px";
 const NO_DRAG_STYLE = {
 	WebkitAppRegion: "no-drag",


### PR DESCRIPTION
## Description

Resolves #96 

Adds zoom controls to the desktop app: **Cmd+= / Cmd+- / Cmd+0** for zoom in / out / reset, exposed under a new **View** menu. The zoom factor persists across launches (`zoom-factor.json` in userData) and is applied while the window is hidden so the first paint is already scaled.

On macOS, the traffic-light buttons and the toolbar inset (`--hubble-traffic-light-inset`) track the zoom factor so the window chrome stays aligned at any zoom level.

All zoom logic lives in a dedicated `apps/desktop/electron/zoom.ts` module; `main.ts` just wires it into the menu and window creation. `Cmd+0` in `App.tsx` previously focused the sidebar nav; that binding was removed in favor of reset-zoom.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update

## Testing

- [x] Existing tests pass
- [ ] Added new tests for changes
- [x] Tested manually (describe below)

**Manual Testing Details:**
Electron typecheck (`tsconfig.node.json`) and Biome pass. Verified zoom in/out/reset via menu + accelerators, persistence across relaunch, and traffic-light/toolbar alignment at min/default/max zoom on macOS.

## Checklist

- [ ] I discussed this change in a GitHub issue before submitting this PR
- [x] I have run the linter, formatter, and tests to ensure my code is ready for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)