### PR TITLE
feat(desktop): add Linux desktop support and native window controls

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -72,3 +72,45 @@ jobs:
           else
             echo "No CHANGELOG section for $VERSION; leaving release notes as-is."
           fi
+
+  release-linux:
+    name: Build and publish desktop app (Linux)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.9.0
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.12.0
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify tag matches desktop version
+        run: |
+          VERSION="$(node -p "require('./apps/desktop/package.json').version")"
+          TAG="${GITHUB_REF_NAME#desktop-v}"
+          if [ "$VERSION" != "$TAG" ]; then
+            echo "Tag desktop-v$TAG does not match apps/desktop package version $VERSION"
+            exit 1
+          fi
+
+      - name: Build and publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          pnpm --filter @hubble.md/desktop... --if-present build
+          pnpm --filter @hubble.md/desktop exec electron-builder --linux --publish always

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -75,8 +75,16 @@ jobs:
           gh release edit "$GITHUB_REF_NAME" --draft=false --latest
 
   release-linux:
-    name: Build and publish desktop app (Linux)
-    runs-on: ubuntu-latest
+    name: Build and publish desktop app (Linux ${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     permissions:
       contents: write
 
@@ -114,4 +122,4 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           pnpm --filter @hubble.md/desktop... --if-present build
-          pnpm --filter @hubble.md/desktop exec electron-builder --linux --publish always
+          pnpm --filter @hubble.md/desktop exec electron-builder --linux --${{ matrix.arch }} --publish always

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-node-linker=hoisted

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+node-linker=hoisted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 ## [Unreleased]
 
 ### Added
+- Linux desktop builds (AppImage and Debian package)
+- Native window controls (minimize, maximize, close) on Windows and Linux
 
 ### Changed
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -651,8 +651,6 @@ function buildMenu() {
 							{ role: "reload" },
 							{ role: "forceReload" },
 							{ type: "separator" },
-							// On Linux/Windows the hidden menu bar swallows this
-							// accelerator, so the key is also bound in createWindow.
 							{ role: "toggleDevTools" },
 						] satisfies Electron.MenuItemConstructorOptions[])
 					: []),

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -13,6 +13,7 @@ import {
 	dialog,
 	ipcMain,
 	Menu,
+	nativeTheme,
 	protocol,
 	screen,
 	shell,
@@ -89,6 +90,8 @@ const updateFeedUrl = process.env.HUBBLE_DESKTOP_UPDATE_URL;
 const supportsAutoUpdates = !isDev && process.platform === "darwin";
 // Check every 4 hours after the initial packaged-app update check.
 const updateCheckIntervalMs = 4 * 60 * 60 * 1000;
+
+nativeTheme.themeSource = "light";
 
 app.setName(appName);
 if (devAppName) {
@@ -923,7 +926,9 @@ async function createWindow() {
 		height: windowState.height,
 		show: false,
 		titleBarStyle: "hidden",
-		...(process.platform !== "darwin" ? { titleBarOverlay: true } : {}),
+		...(process.platform !== "darwin"
+			? { titleBarOverlay: { color: "#ffffff", symbolColor: "#454545" } }
+			: {}),
 		trafficLightPosition: trafficLightPositionForZoom(zoomFactor),
 		webPreferences: {
 			contextIsolation: true,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -651,6 +651,8 @@ function buildMenu() {
 							{ role: "reload" },
 							{ role: "forceReload" },
 							{ type: "separator" },
+							// On Linux/Windows the hidden menu bar swallows this
+							// accelerator, so the key is also bound in createWindow.
 							{ role: "toggleDevTools" },
 						] satisfies Electron.MenuItemConstructorOptions[])
 					: []),
@@ -955,6 +957,18 @@ async function createWindow() {
 	});
 
 	window.on("focus", () => sendToRenderer("desktop:window-focus"));
+
+	// On Linux/Windows the menu bar is hidden by the custom title bar, so menu
+	// accelerators (incl. DevTools) don't fire. Bind the DevTools toggle directly.
+	if (isDev && process.platform !== "darwin") {
+		window.webContents.on("before-input-event", (_event, input) => {
+			if (input.type !== "keyDown") return;
+			const key = input.key.toLowerCase();
+			if (key === "f12" || (input.control && input.shift && key === "i")) {
+				window.webContents.toggleDevTools();
+			}
+		});
+	}
 	window.on("enter-full-screen", () =>
 		sendToRenderer("desktop:fullscreen-change", true),
 	);

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1178,17 +1178,32 @@ function registerIpc() {
 	});
 
 	ipcMain.handle("desktop:create-folder-picker", async () => {
-		const result = await dialog.showSaveDialog(mainWindow ?? undefined, {
+		// macOS save dialog supports naming a new folder inline via createDirectory.
+		if (process.platform === "darwin") {
+			const result = await dialog.showSaveDialog(mainWindow ?? undefined, {
+				title: "New Folder",
+				nameFieldLabel: "Folder name:",
+				buttonLabel: "Create",
+				properties: ["createDirectory"],
+			});
+			if (result.canceled || !result.filePath) return null;
+			const folderPath = result.filePath;
+			await fs.mkdir(folderPath, { recursive: true });
+			grantRoot(folderPath);
+			return folderPath;
+		}
+		// Linux/Windows: the native directory picker has a "New Folder" button,
+		// so create + select happen there and the path opens as the workspace.
+		const result = await dialog.showOpenDialog(mainWindow ?? undefined, {
 			title: "New Folder",
-			nameFieldLabel: "Folder name:",
 			buttonLabel: "Create",
-			properties: ["createDirectory"],
+			properties: ["openDirectory", "createDirectory"],
 		});
-		if (result.canceled || !result.filePath) return null;
-		const folderPath = result.filePath;
-		await fs.mkdir(folderPath, { recursive: true });
-		grantRoot(folderPath);
-		return folderPath;
+		const selected = result.filePaths[0] ?? null;
+		if (!selected) return null;
+		await fs.mkdir(selected, { recursive: true });
+		grantRoot(selected);
+		return selected;
 	});
 
 	ipcMain.handle(

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -923,6 +923,7 @@ async function createWindow() {
 		height: windowState.height,
 		show: false,
 		titleBarStyle: "hidden",
+		...(process.platform !== "darwin" ? { titleBarOverlay: true } : {}),
 		trafficLightPosition: trafficLightPositionForZoom(zoomFactor),
 		webPreferences: {
 			contextIsolation: true,

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -108,6 +108,9 @@
 				"deb"
 			]
 		},
+		"appImage": {
+			"artifactName": "hubble_${version}_${arch}.${ext}"
+		},
 		"deb": {
 			"packageName": "hubble.md",
 			"artifactName": "hubble_${version}_${arch}.${ext}"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -115,21 +115,11 @@
 			{
 				"name": "Markdown Document",
 				"description": "Markdown text file",
-				"ext": "md",
-				"role": "Editor",
-				"rank": "Owner"
-			},
-			{
-				"name": "Markdown Document",
-				"description": "Markdown text file",
-				"ext": "markdown",
-				"role": "Editor",
-				"rank": "Owner"
-			},
-			{
-				"name": "Markdown Document",
-				"description": "Markdown text file",
-				"ext": "mdown",
+				"ext": [
+					"md",
+					"markdown",
+					"mdown"
+				],
 				"role": "Editor",
 				"rank": "Owner"
 			}

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,6 +20,7 @@
 		"build": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.node.json --noEmit && electron-vite build",
 		"bundle": "pnpm build && electron-builder --mac",
 		"bundle:linux": "pnpm build && electron-builder --linux",
+		"bundle:linux:arm64": "pnpm build && electron-builder --linux --arm64",
 		"bundle:publish": "pnpm build && electron-builder --mac --publish always",
 		"preview": "vite preview",
 		"sync:playground": "node scripts/sync-playground.mjs",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -100,6 +100,7 @@
 		},
 		"linux": {
 			"executableName": "hubble.md",
+			"category": "Office",
 			"target": [
 				"AppImage",
 				"deb"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -19,6 +19,7 @@
 		"dev:debug": "HUBBLE_DESKTOP_ENABLE_CDP=1 node scripts/dev.mjs",
 		"build": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.node.json --noEmit && electron-vite build",
 		"bundle": "pnpm build && electron-builder --mac",
+		"bundle:linux": "pnpm build && electron-builder --linux",
 		"bundle:publish": "pnpm build && electron-builder --mac --publish always",
 		"preview": "vite preview",
 		"sync:playground": "node scripts/sync-playground.mjs",
@@ -97,15 +98,34 @@
 			],
 			"category": "public.app-category.productivity"
 		},
+		"linux": {
+			"target": [
+				"AppImage",
+				"deb"
+			]
+		},
+		"deb": {
+			"packageName": "hubble.md"
+		},
 		"fileAssociations": [
 			{
 				"name": "Markdown Document",
 				"description": "Markdown text file",
-				"ext": [
-					"md",
-					"markdown",
-					"mdown"
-				],
+				"ext": "md",
+				"role": "Editor",
+				"rank": "Owner"
+			},
+			{
+				"name": "Markdown Document",
+				"description": "Markdown text file",
+				"ext": "markdown",
+				"role": "Editor",
+				"rank": "Owner"
+			},
+			{
+				"name": "Markdown Document",
+				"description": "Markdown text file",
+				"ext": "mdown",
 				"role": "Editor",
 				"rank": "Owner"
 			}

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -99,6 +99,7 @@
 			"category": "public.app-category.productivity"
 		},
 		"linux": {
+			"executableName": "hubble.md",
 			"target": [
 				"AppImage",
 				"deb"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -105,7 +105,8 @@
 			]
 		},
 		"deb": {
-			"packageName": "hubble.md"
+			"packageName": "hubble.md",
+			"artifactName": "hubble_${version}_${arch}.${ext}"
 		},
 		"fileAssociations": [
 			{

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"build": "pnpm check && pnpm -r --if-present build && pnpm typecheck",
 		"build:desktop": "pnpm --filter @hubble.md/desktop... --if-present build && pnpm --filter @hubble.md/desktop... --if-present typecheck",
 		"bundle:desktop": "pnpm --filter @hubble.md/desktop... --if-present build && pnpm --filter @hubble.md/desktop bundle",
+		"bundle:desktop:linux": "pnpm --filter @hubble.md/desktop... --if-present build && pnpm --filter @hubble.md/desktop bundle:linux",
 		"postinstall": "pnpm --filter @hubble.md/desktop exec install-electron",
 		"dev:desktop": "pnpm -r --parallel --stream --filter @hubble.md/desktop... --if-present dev",
 		"dev:desktop:debug": "HUBBLE_DESKTOP_ENABLE_CDP=1 pnpm -r --parallel --stream --filter @hubble.md/desktop... --if-present dev",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"build:desktop": "pnpm --filter @hubble.md/desktop... --if-present build && pnpm --filter @hubble.md/desktop... --if-present typecheck",
 		"bundle:desktop": "pnpm --filter @hubble.md/desktop... --if-present build && pnpm --filter @hubble.md/desktop bundle",
 		"bundle:desktop:linux": "pnpm --filter @hubble.md/desktop... --if-present build && pnpm --filter @hubble.md/desktop bundle:linux",
+		"bundle:desktop:linux:arm64": "pnpm --filter @hubble.md/desktop... --if-present build && pnpm --filter @hubble.md/desktop bundle:linux:arm64",
 		"postinstall": "pnpm --filter @hubble.md/desktop exec install-electron",
 		"dev:desktop": "pnpm -r --parallel --stream --filter @hubble.md/desktop... --if-present dev",
 		"dev:desktop:debug": "HUBBLE_DESKTOP_ENABLE_CDP=1 pnpm -r --parallel --stream --filter @hubble.md/desktop... --if-present dev",

--- a/packages/ui/src/components/Toolbar.tsx
+++ b/packages/ui/src/components/Toolbar.tsx
@@ -11,10 +11,10 @@ import MingcuteLayoutLeftLine from "~icons/mingcute/layout-left-line";
 import { fileNameFromPath } from "../lib/filePath";
 import { Button } from "../primitives/button";
 
-const START_INSET = isMac()
-	? "var(--hubble-traffic-light-inset, 70px)"
-	: "8px";
-const END_INSET = isMac() ? "0px" : "138px";
+const START_INSET = isMac() ? "var(--hubble-traffic-light-inset, 70px)" : "8px";
+const END_INSET = isMac()
+	? "0px"
+	: "calc(100vw - env(titlebar-area-width, calc(100vw - 138px)))";
 const ACTIONS_BASIS = "114px";
 const NO_DRAG_STYLE = {
 	WebkitAppRegion: "no-drag",
@@ -161,7 +161,7 @@ export function Toolbar({
 				)}
 			</div>
 			<ToolbarActions>
-				<div 
+				<div
 					className="flex items-center justify-end"
 					style={{ paddingInlineEnd: platformInset ? END_INSET : 0 }}
 				>

--- a/packages/ui/src/components/Toolbar.tsx
+++ b/packages/ui/src/components/Toolbar.tsx
@@ -11,9 +11,10 @@ import MingcuteLayoutLeftLine from "~icons/mingcute/layout-left-line";
 import { fileNameFromPath } from "../lib/filePath";
 import { Button } from "../primitives/button";
 
-const TOOLBAR_INSET = isMac()
+const START_INSET = isMac()
 	? "var(--hubble-traffic-light-inset, 70px)"
 	: "8px";
+const END_INSET = isMac() ? "0px" : "138px";
 const ACTIONS_BASIS = "114px";
 const NO_DRAG_STYLE = {
 	WebkitAppRegion: "no-drag",
@@ -109,7 +110,7 @@ export function Toolbar({
 			<ToolbarActions>
 				<div
 					className="flex items-center gap-1"
-					style={{ paddingInlineStart: platformInset ? TOOLBAR_INSET : 0 }}
+					style={{ paddingInlineStart: platformInset ? START_INSET : 0 }}
 				>
 					{onToggleSidebar && (
 						<Button
@@ -160,7 +161,12 @@ export function Toolbar({
 				)}
 			</div>
 			<ToolbarActions>
-				<div className="flex items-center justify-end">{rightSlot}</div>
+				<div 
+					className="flex items-center justify-end"
+					style={{ paddingInlineEnd: platformInset ? END_INSET : 0 }}
+				>
+					{rightSlot}
+				</div>
 			</ToolbarActions>
 		</div>
 	);

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,11 +2,8 @@ packages:
   - apps/*
   - packages/*
 
-allowBuilds:
-  electron-winstaller: true
-  esbuild: true
-  msw: true
-  sharp: true
-
 onlyBuiltDependencies:
+  - electron-winstaller
   - esbuild
+  - msw
+  - sharp

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,5 +2,11 @@ packages:
   - apps/*
   - packages/*
 
+allowBuilds:
+  electron-winstaller: true
+  esbuild: true
+  msw: true
+  sharp: true
+
 onlyBuiltDependencies:
   - esbuild


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->
Adds support for generating Linux desktop artifacts (AppImage and deb) and properly handles native window controls (minimize/maximize/close) for Windows and Linux users.

Includes the following changes:
- Adds a `bundle:desktop:linux` build script and a new `release-linux` GitHub Actions job running on `ubuntu-latest`.
- Sets the `electron-builder` Linux target to `AppImage` and `deb` (with `category: "Office"` and `executableName: "hubble.md"`).
- Splits the `fileAssociations.ext` array in `package.json` to fix non-macOS validation issues.
- Enables `titleBarOverlay` with explicit colors in the Electron `main.ts` for non-darwin platforms and forces `nativeTheme.themeSource = "light"` to prevent OS dark mode clashes.
- Adjusts the `Toolbar` component padding to respect `START_INSET` (macOS traffic lights) vs `END_INSET` (Windows/Linux native window controls).

*(Note: Reaching out with this PR following our chat on Bluesky where you pointed me to these issues!)*

<!-- Link to any related issues using #issue-number. This is **required** for feature requests! -->

Closes #94
Closes #97

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update

## Testing
<!-- Describe the tests you ran to verify your changes -->

- [x] Existing tests pass
- [ ] Added new tests for changes
- [x] Tested manually (describe below)

**Manual Testing Details:**
<!-- If applicable, describe how you manually tested these changes. Include screenshots if applicable -->
- Verified local builds of `.AppImage` and `.deb` via `pnpm bundle:desktop:linux`.
- Tested the built `.AppImage` directly on Arch Linux.
- Successfully installed the `.deb` package and ran the application on a separate Ubuntu 24.04.4 LTS machine.
- Verified that `pnpm dev:desktop` on Linux correctly displays the native window controls on the right side of the toolbar with proper light mode colors.

## Checklist

- [ ] I discussed this change in a GitHub issue before submitting this PR *(Discussed directly with maintainer on Bluesky instead)*
- [x] I have run the linter, formatter, and tests to ensure my code is ready for review