### PR TITLE
Fix task list split checkbox state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 ### Changed
 
 ### Fixed
+- New task-list items created with Enter now start unchecked
 
 ## [0.1.13] - 2026-06-24
 

--- a/packages/editor/src/List.ts
+++ b/packages/editor/src/List.ts
@@ -1,7 +1,7 @@
 import { Extension } from "@tiptap/core";
 import { ListItem } from "@tiptap/extension-list";
 import type { Node as PMNode } from "@tiptap/pm/model";
-import type { EditorState, Selection, Transaction } from "@tiptap/pm/state";
+import type { EditorState, Transaction } from "@tiptap/pm/state";
 import { Plugin, PluginKey, TextSelection } from "@tiptap/pm/state";
 import { canJoin } from "@tiptap/pm/transform";
 import { isSelectionAtStartOfNode, nearestSharedParentOfType } from "./utils";
@@ -216,8 +216,18 @@ export const ListToggleExtension = Extension.create({
 				return false;
 			},
 			Enter: ({ editor }) => {
-				if (isSelectionAtStartOfNode(editor.view.state.selection)) {
+				const { selection } = editor.view.state;
+				if (isSelectionAtStartOfNode(selection)) {
 					return editor.commands.liftListItem("listItem");
+				}
+				// Splitting a task item should always start the new item unchecked
+				const { $from } = selection;
+				for (let depth = $from.depth; depth > 0; depth--) {
+					if (isTaskItem($from.node(depth))) {
+						return editor.commands.splitListItem("listItem", {
+							checked: false,
+						});
+					}
 				}
 				return false;
 			},
@@ -225,28 +235,11 @@ export const ListToggleExtension = Extension.create({
 	},
 
 	addProseMirrorPlugins() {
-		const clearNumberedListTasksKey = new PluginKey(
-			"ClearTaskItemsForNumberedLists",
-		);
-		const resetSplitTaskItemsKey = new PluginKey("ResetSplitTaskItems");
+		const key = new PluginKey("ClearTaskItemsForNumberedLists");
 
 		return [
 			new Plugin({
-				key: resetSplitTaskItemsKey,
-				appendTransaction(
-					transactions: readonly Transaction[],
-					oldState: EditorState,
-					newState: EditorState,
-				) {
-					return resetSplitTaskItemTransaction(
-						transactions,
-						oldState,
-						newState,
-					);
-				},
-			}),
-			new Plugin({
-				key: clearNumberedListTasksKey,
+				key,
 				appendTransaction(
 					transactions: readonly Transaction[],
 					_oldState: EditorState,
@@ -378,53 +371,6 @@ function isListItem(node: PMNode) {
 
 function isTaskItem(node: PMNode) {
 	return isListItem(node) && node.attrs.checked !== null;
-}
-
-function nearestTaskItemPos(selection: Selection) {
-	const { $from } = selection;
-	for (let depth = $from.depth; depth > 0; depth--) {
-		const node = $from.node(depth);
-		if (isTaskItem(node)) return $from.before(depth);
-	}
-	return null;
-}
-
-function resetSplitTaskItemTransaction(
-	transactions: readonly Transaction[],
-	oldState: EditorState,
-	newState: EditorState,
-) {
-	const hasDocChanges = transactions.some((tr) => tr.docChanged);
-	if (!hasDocChanges) return null;
-
-	const oldTaskItemPos = nearestTaskItemPos(oldState.selection);
-	if (oldTaskItemPos === null) return null;
-
-	const newTaskItemPos = nearestTaskItemPos(newState.selection);
-	if (newTaskItemPos === null) return null;
-
-	// A split leaves the original item at the mapped old position and moves
-	// the selection into the inserted item.
-	const mappedOldTaskItemPos = mapPosition(transactions, oldTaskItemPos);
-	if (newTaskItemPos === mappedOldTaskItemPos) return null;
-
-	const taskItem = newState.doc.nodeAt(newTaskItemPos);
-	if (!taskItem || !isTaskItem(taskItem) || taskItem.attrs.checked !== true) {
-		return null;
-	}
-
-	return newState.tr.setNodeMarkup(newTaskItemPos, undefined, {
-		...taskItem.attrs,
-		checked: false,
-	});
-}
-
-function mapPosition(transactions: readonly Transaction[], pos: number) {
-	let mapped = pos;
-	for (const tr of transactions) {
-		mapped = tr.mapping.map(mapped, -1);
-	}
-	return mapped;
 }
 
 function itemType(node: PMNode): "task" | "item" {

--- a/packages/editor/src/List.ts
+++ b/packages/editor/src/List.ts
@@ -1,7 +1,7 @@
 import { Extension } from "@tiptap/core";
 import { ListItem } from "@tiptap/extension-list";
 import type { Node as PMNode } from "@tiptap/pm/model";
-import type { EditorState, Transaction } from "@tiptap/pm/state";
+import type { EditorState, Selection, Transaction } from "@tiptap/pm/state";
 import { Plugin, PluginKey, TextSelection } from "@tiptap/pm/state";
 import { canJoin } from "@tiptap/pm/transform";
 import { isSelectionAtStartOfNode, nearestSharedParentOfType } from "./utils";
@@ -225,11 +225,28 @@ export const ListToggleExtension = Extension.create({
 	},
 
 	addProseMirrorPlugins() {
-		const key = new PluginKey("ClearTaskItemsForNumberedLists");
+		const clearNumberedListTasksKey = new PluginKey(
+			"ClearTaskItemsForNumberedLists",
+		);
+		const resetSplitTaskItemsKey = new PluginKey("ResetSplitTaskItems");
 
 		return [
 			new Plugin({
-				key,
+				key: resetSplitTaskItemsKey,
+				appendTransaction(
+					transactions: readonly Transaction[],
+					oldState: EditorState,
+					newState: EditorState,
+				) {
+					return resetSplitTaskItemTransaction(
+						transactions,
+						oldState,
+						newState,
+					);
+				},
+			}),
+			new Plugin({
+				key: clearNumberedListTasksKey,
 				appendTransaction(
 					transactions: readonly Transaction[],
 					_oldState: EditorState,
@@ -361,6 +378,53 @@ function isListItem(node: PMNode) {
 
 function isTaskItem(node: PMNode) {
 	return isListItem(node) && node.attrs.checked !== null;
+}
+
+function nearestTaskItemPos(selection: Selection) {
+	const { $from } = selection;
+	for (let depth = $from.depth; depth > 0; depth--) {
+		const node = $from.node(depth);
+		if (isTaskItem(node)) return $from.before(depth);
+	}
+	return null;
+}
+
+function resetSplitTaskItemTransaction(
+	transactions: readonly Transaction[],
+	oldState: EditorState,
+	newState: EditorState,
+) {
+	const hasDocChanges = transactions.some((tr) => tr.docChanged);
+	if (!hasDocChanges) return null;
+
+	const oldTaskItemPos = nearestTaskItemPos(oldState.selection);
+	if (oldTaskItemPos === null) return null;
+
+	const newTaskItemPos = nearestTaskItemPos(newState.selection);
+	if (newTaskItemPos === null) return null;
+
+	// A split leaves the original item at the mapped old position and moves
+	// the selection into the inserted item.
+	const mappedOldTaskItemPos = mapPosition(transactions, oldTaskItemPos);
+	if (newTaskItemPos === mappedOldTaskItemPos) return null;
+
+	const taskItem = newState.doc.nodeAt(newTaskItemPos);
+	if (!taskItem || !isTaskItem(taskItem) || taskItem.attrs.checked !== true) {
+		return null;
+	}
+
+	return newState.tr.setNodeMarkup(newTaskItemPos, undefined, {
+		...taskItem.attrs,
+		checked: false,
+	});
+}
+
+function mapPosition(transactions: readonly Transaction[], pos: number) {
+	let mapped = pos;
+	for (const tr of transactions) {
+		mapped = tr.mapping.map(mapped, -1);
+	}
+	return mapped;
 }
 
 function itemType(node: PMNode): "task" | "item" {

--- a/packages/ui/src/editor/taskListSplit.test.ts
+++ b/packages/ui/src/editor/taskListSplit.test.ts
@@ -25,95 +25,13 @@ describe("task list splitting", () => {
 			taskItem({ checked: false }),
 		]);
 	});
-
-	it("keeps unchecked task items unchecked when split", () => {
-		const editor = createEditor(
-			taskListDoc([{ checked: false, text: "todo" }]),
-		);
-
-		expect(editor.commands.keyboardShortcut("Enter")).toBe(true);
-
-		expect(listItems(editor)).toMatchObject([
-			taskItem({ checked: false, text: "todo" }),
-			taskItem({ checked: false }),
-		]);
-	});
-
-	it("creates unchecked nested task items", () => {
-		const editor = createEditor(
-			{
-				type: "doc",
-				content: [
-					{
-						type: "bulletList",
-						content: [
-							{
-								type: "listItem",
-								attrs: { checked: false },
-								content: [
-									{
-										type: "paragraph",
-										content: [{ type: "text", text: "parent" }],
-									},
-									{
-										type: "bulletList",
-										content: [taskItem({ checked: true, text: "nested" })],
-									},
-								],
-							},
-						],
-					},
-				],
-			},
-			"nested",
-		);
-
-		expect(editor.commands.keyboardShortcut("Enter")).toBe(true);
-
-		const parentItem = listItems(editor)[0] as JSONContent;
-		const nestedList = parentItem.content?.find(
-			(node: JSONContent) => node.type === "bulletList",
-		) as JSONContent | undefined;
-		expect(parentItem.content?.[0]).toMatchObject({
-			type: "paragraph",
-			content: [{ type: "text", text: "parent" }],
-		});
-		expect(nestedList?.content).toMatchObject([
-			taskItem({ checked: true, text: "nested" }),
-			taskItem({ checked: false }),
-		]);
-	});
-
-	it("keeps plain bullet list splitting unchanged", () => {
-		const editor = createEditor(plainListDoc("bulletList", "plain"));
-
-		expect(editor.commands.keyboardShortcut("Enter")).toBe(true);
-
-		expect(listItems(editor)).toMatchObject([
-			taskItem({ checked: null, text: "plain" }),
-			taskItem({ checked: null }),
-		]);
-	});
-
-	it("keeps ordered list splitting unchanged", () => {
-		const editor = createEditor(plainListDoc("orderedList", "first"));
-
-		expect(editor.commands.keyboardShortcut("Enter")).toBe(true);
-
-		expect(listItems(editor, "orderedList")).toMatchObject([
-			taskItem({ checked: null, text: "first" }),
-			taskItem({ checked: null }),
-		]);
-	});
 });
 
-function createEditor(content: JSONContent, cursorText?: string) {
+function createEditor(content: JSONContent) {
 	const editor = new Editor({
 		element: document.createElement("div"),
 		extensions: [
-			StarterKit.configure({
-				listItem: false,
-			}),
+			StarterKit.configure({ listItem: false }),
 			...listExtensions,
 			TaskItem.configure({ nested: true }),
 		],
@@ -121,16 +39,15 @@ function createEditor(content: JSONContent, cursorText?: string) {
 	});
 	editors.push(editor);
 	Object.defineProperty(editor, "isFocused", { value: true });
-	placeCursorAfterText(editor, cursorText ?? firstText(content));
+	placeCursorAfterText(editor, firstText(content));
 	return editor;
 }
 
-function listItems(
-	editor: Editor,
-	type: "bulletList" | "orderedList" = "bulletList",
-) {
-	const list = editor.getJSON().content?.find((node) => node.type === type);
-	if (!list) throw new Error(`Expected ${type}`);
+function listItems(editor: Editor) {
+	const list = editor
+		.getJSON()
+		.content?.find((node) => node.type === "bulletList");
+	if (!list) throw new Error("Expected bulletList");
 	return list.content ?? [];
 }
 
@@ -166,9 +83,7 @@ function taskItem({
 	checked: boolean | null;
 	text?: string;
 }): JSONContent {
-	const paragraph: JSONContent = {
-		type: "paragraph",
-	};
+	const paragraph: JSONContent = { type: "paragraph" };
 	if (text) {
 		paragraph.content = [{ type: "text", text }];
 	}
@@ -182,23 +97,6 @@ function taskItem({
 function taskListDoc(items: Array<{ checked: boolean; text: string }>) {
 	return {
 		type: "doc",
-		content: [
-			{
-				type: "bulletList",
-				content: items.map(taskItem),
-			},
-		],
-	} satisfies JSONContent;
-}
-
-function plainListDoc(type: "bulletList" | "orderedList", text: string) {
-	return {
-		type: "doc",
-		content: [
-			{
-				type,
-				content: [taskItem({ checked: null, text })],
-			},
-		],
+		content: [{ type: "bulletList", content: items.map(taskItem) }],
 	} satisfies JSONContent;
 }

--- a/packages/ui/src/editor/taskListSplit.test.ts
+++ b/packages/ui/src/editor/taskListSplit.test.ts
@@ -1,0 +1,204 @@
+// @vitest-environment happy-dom
+
+import { listExtensions } from "@hubble.md/editor";
+import { Editor, type JSONContent } from "@tiptap/core";
+import { TaskItem } from "@tiptap/extension-list";
+import { TextSelection } from "@tiptap/pm/state";
+import StarterKit from "@tiptap/starter-kit";
+import { afterEach, describe, expect, it } from "vitest";
+
+const editors: Editor[] = [];
+
+afterEach(() => {
+	for (const editor of editors) editor.destroy();
+	editors.length = 0;
+});
+
+describe("task list splitting", () => {
+	it("creates an unchecked task item after a checked task item", () => {
+		const editor = createEditor(taskListDoc([{ checked: true, text: "done" }]));
+
+		expect(editor.commands.keyboardShortcut("Enter")).toBe(true);
+
+		expect(listItems(editor)).toMatchObject([
+			taskItem({ checked: true, text: "done" }),
+			taskItem({ checked: false }),
+		]);
+	});
+
+	it("keeps unchecked task items unchecked when split", () => {
+		const editor = createEditor(
+			taskListDoc([{ checked: false, text: "todo" }]),
+		);
+
+		expect(editor.commands.keyboardShortcut("Enter")).toBe(true);
+
+		expect(listItems(editor)).toMatchObject([
+			taskItem({ checked: false, text: "todo" }),
+			taskItem({ checked: false }),
+		]);
+	});
+
+	it("creates unchecked nested task items", () => {
+		const editor = createEditor(
+			{
+				type: "doc",
+				content: [
+					{
+						type: "bulletList",
+						content: [
+							{
+								type: "listItem",
+								attrs: { checked: false },
+								content: [
+									{
+										type: "paragraph",
+										content: [{ type: "text", text: "parent" }],
+									},
+									{
+										type: "bulletList",
+										content: [taskItem({ checked: true, text: "nested" })],
+									},
+								],
+							},
+						],
+					},
+				],
+			},
+			"nested",
+		);
+
+		expect(editor.commands.keyboardShortcut("Enter")).toBe(true);
+
+		const parentItem = listItems(editor)[0] as JSONContent;
+		const nestedList = parentItem.content?.find(
+			(node: JSONContent) => node.type === "bulletList",
+		) as JSONContent | undefined;
+		expect(parentItem.content?.[0]).toMatchObject({
+			type: "paragraph",
+			content: [{ type: "text", text: "parent" }],
+		});
+		expect(nestedList?.content).toMatchObject([
+			taskItem({ checked: true, text: "nested" }),
+			taskItem({ checked: false }),
+		]);
+	});
+
+	it("keeps plain bullet list splitting unchanged", () => {
+		const editor = createEditor(plainListDoc("bulletList", "plain"));
+
+		expect(editor.commands.keyboardShortcut("Enter")).toBe(true);
+
+		expect(listItems(editor)).toMatchObject([
+			taskItem({ checked: null, text: "plain" }),
+			taskItem({ checked: null }),
+		]);
+	});
+
+	it("keeps ordered list splitting unchanged", () => {
+		const editor = createEditor(plainListDoc("orderedList", "first"));
+
+		expect(editor.commands.keyboardShortcut("Enter")).toBe(true);
+
+		expect(listItems(editor, "orderedList")).toMatchObject([
+			taskItem({ checked: null, text: "first" }),
+			taskItem({ checked: null }),
+		]);
+	});
+});
+
+function createEditor(content: JSONContent, cursorText?: string) {
+	const editor = new Editor({
+		element: document.createElement("div"),
+		extensions: [
+			StarterKit.configure({
+				listItem: false,
+			}),
+			...listExtensions,
+			TaskItem.configure({ nested: true }),
+		],
+		content,
+	});
+	editors.push(editor);
+	Object.defineProperty(editor, "isFocused", { value: true });
+	placeCursorAfterText(editor, cursorText ?? firstText(content));
+	return editor;
+}
+
+function listItems(
+	editor: Editor,
+	type: "bulletList" | "orderedList" = "bulletList",
+) {
+	const list = editor.getJSON().content?.find((node) => node.type === type);
+	if (!list) throw new Error(`Expected ${type}`);
+	return list.content ?? [];
+}
+
+function placeCursorAfterText(editor: Editor, text: string) {
+	let position: number | null = null;
+	editor.state.doc.descendants((node, pos) => {
+		if (node.isText && node.text === text) {
+			position = pos + node.nodeSize;
+			return false;
+		}
+	});
+	if (position === null) throw new Error(`Text not found: ${text}`);
+	editor.view.dispatch(
+		editor.state.tr.setSelection(
+			TextSelection.create(editor.state.doc, position),
+		),
+	);
+}
+
+function firstText(content: JSONContent): string {
+	if (typeof content.text === "string") return content.text;
+	for (const child of content.content ?? []) {
+		const text = firstText(child);
+		if (text) return text;
+	}
+	return "";
+}
+
+function taskItem({
+	checked,
+	text,
+}: {
+	checked: boolean | null;
+	text?: string;
+}): JSONContent {
+	const paragraph: JSONContent = {
+		type: "paragraph",
+	};
+	if (text) {
+		paragraph.content = [{ type: "text", text }];
+	}
+	return {
+		type: "listItem",
+		attrs: { checked },
+		content: [paragraph],
+	};
+}
+
+function taskListDoc(items: Array<{ checked: boolean; text: string }>) {
+	return {
+		type: "doc",
+		content: [
+			{
+				type: "bulletList",
+				content: items.map(taskItem),
+			},
+		],
+	} satisfies JSONContent;
+}
+
+function plainListDoc(type: "bulletList" | "orderedList", text: string) {
+	return {
+		type: "doc",
+		content: [
+			{
+				type,
+				content: [taskItem({ checked: null, text })],
+			},
+		],
+	} satisfies JSONContent;
+}


### PR DESCRIPTION
## Description
Fixes task-list splitting so pressing Enter from a checked task item creates a new unchecked task item, while leaving the original item checked.

This keeps normal bullet and ordered list splitting unchanged.

Closes #87

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update

## Testing
- [x] Existing tests pass
- [x] Added new tests for changes
- [x] Tested manually (describe below)

**Manual Testing Details:**
Created a real to-do list item in the desktop app, checked the item, placed the cursor at the end, and pressed Enter. Confirmed the original item stayed checked and the new task item started unchecked.

Also ran:
- `./node_modules/.bin/vitest run src/editor/taskListSplit.test.ts` in `packages/ui`
- `./node_modules/.bin/vitest run` in `packages/editor`
- `./node_modules/.bin/biome check CHANGELOG.md packages/editor/src/List.ts packages/ui/src/editor/taskListSplit.test.ts`

Note: top-level `pnpm` scripts were blocked locally by pnpm’s dependency-status/install prompt in this sandbox, so the underlying package checks were run directly.

## Checklist
- [x] I discussed this change in a GitHub issue before submitting this PR
- [x] I have run the linter, formatter, and tests to ensure my code is ready for review