### PR TITLE
Fix HTML Apps dialog video path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 ### Changed
 
 ### Fixed
+- The HTML Apps walkthrough video now loads in the packaged desktop dialog
 - New task-list items created with Enter now start unchecked
 
 ## [0.1.13] - 2026-06-24

--- a/apps/desktop/src/components/HtmlAppsCallout.tsx
+++ b/apps/desktop/src/components/HtmlAppsCallout.tsx
@@ -117,7 +117,7 @@ export function HtmlAppsDialog({
 				</div>
 				<video
 					className="w-full rounded-[12px]"
-					src="/html-apps-preview.mp4"
+					src="./html-apps-preview.mp4"
 					autoPlay
 					loop
 					muted


### PR DESCRIPTION
## Description

Closes #101

This updates the HTML Apps dialog walkthrough video to use a relative renderer asset URL. In the packaged Electron app, the renderer is loaded from `file://.../out/renderer/index.html`, so the previous root-relative URL resolved to `file:///html-apps-preview.mp4` instead of the bundled `out/renderer/html-apps-preview.mp4` file.

The PR also adds a changelog entry for the user-visible fix.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update

## Testing
- [x] Existing tests pass
- [ ] Added new tests for changes
- [x] Tested manually (describe below)

**Manual Testing Details:**
- Ran `pnpm build:desktop`
- Ran `pnpm build`
- Confirmed the built desktop renderer references `./html-apps-preview.mp4`
- Confirmed `apps/desktop/out/renderer/html-apps-preview.mp4` is emitted next to the renderer entry

## Checklist
- [x] I discussed this change in a GitHub issue before submitting this PR
- [x] I have run the linter, formatter, and tests to ensure my code is ready for review
