### PR TITLE
Add find in editor

### DIFF
--- a/packages/editor/src/FindExtension.test.ts
+++ b/packages/editor/src/FindExtension.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
 import { Schema } from "@tiptap/pm/model";
+import { describe, expect, it } from "vitest";
 import { findMatches } from "./FindExtension";
 
 const schema = new Schema({

--- a/packages/editor/src/FindExtension.test.ts
+++ b/packages/editor/src/FindExtension.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { Schema } from "@tiptap/pm/model";
+import { findMatches } from "./FindExtension";
+
+const schema = new Schema({
+	nodes: {
+		doc: { content: "paragraph+" },
+		paragraph: {
+			content: "text*",
+			group: "block",
+			parseDOM: [{ tag: "p" }],
+			toDOM: () => ["p", 0],
+		},
+		text: { group: "inline" },
+	},
+	marks: {
+		bold: {},
+	},
+});
+
+describe("findMatches", () => {
+	it("finds case-insensitive text-node matches", () => {
+		const doc = schema.node("doc", null, [
+			schema.node("paragraph", null, schema.text("Alpha beta alpha")),
+			schema.node("paragraph", null, schema.text("Alphabet")),
+		]);
+
+		expect(findMatches(doc, "alpha")).toEqual([
+			{ from: 1, to: 6 },
+			{ from: 12, to: 17 },
+			{ from: 19, to: 24 },
+		]);
+	});
+
+	it("finds matches split across inline formatting", () => {
+		const bold = schema.mark("bold");
+		const doc = schema.node("doc", null, [
+			schema.node("paragraph", null, [
+				schema.text("needle", [bold]),
+				schema.text(" top"),
+			]),
+		]);
+
+		expect(findMatches(doc, "needle top")).toEqual([{ from: 1, to: 11 }]);
+	});
+
+	it("does not match across paragraph boundaries", () => {
+		const doc = schema.node("doc", null, [
+			schema.node("paragraph", null, schema.text("needle")),
+			schema.node("paragraph", null, schema.text("top")),
+		]);
+
+		expect(findMatches(doc, "needle top")).toEqual([]);
+	});
+
+	it("returns no matches for an empty query", () => {
+		const doc = schema.node("doc", null, [
+			schema.node("paragraph", null, schema.text("Alpha")),
+		]);
+
+		expect(findMatches(doc, "")).toEqual([]);
+	});
+});

--- a/packages/editor/src/FindExtension.ts
+++ b/packages/editor/src/FindExtension.ts
@@ -1,7 +1,7 @@
 import { Extension } from "@tiptap/core";
 import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
-import { TextSelection, Plugin, PluginKey } from "@tiptap/pm/state";
 import type { EditorState, Transaction } from "@tiptap/pm/state";
+import { Plugin, PluginKey, TextSelection } from "@tiptap/pm/state";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
 
 export type FindMatch = {
@@ -38,7 +38,9 @@ export const FindExtension = Extension.create({
 				(query: string) =>
 				({ state, dispatch }) => {
 					if (!dispatch) return true;
-					dispatch(state.tr.setMeta(findPluginKey, { type: "setQuery", query }));
+					dispatch(
+						state.tr.setMeta(findPluginKey, { type: "setQuery", query }),
+					);
 					return true;
 				},
 			setFindActiveIndex:
@@ -46,7 +48,10 @@ export const FindExtension = Extension.create({
 				({ state, dispatch }) => {
 					if (!dispatch) return true;
 					dispatch(
-						state.tr.setMeta(findPluginKey, { type: "setActiveIndex", activeIndex }),
+						state.tr.setMeta(findPluginKey, {
+							type: "setActiveIndex",
+							activeIndex,
+						}),
 					);
 					return true;
 				},
@@ -146,13 +151,21 @@ export function findMatches(doc: ProseMirrorNode, query: string) {
 	while (matchIndex !== -1) {
 		const from = index.offsets[matchIndex]?.docPos;
 		const to = index.offsets[matchIndex + query.length - 1]?.docPos;
-		if (from !== null && from !== undefined && to !== null && to !== undefined) {
+		if (
+			from !== null &&
+			from !== undefined &&
+			to !== null &&
+			to !== undefined
+		) {
 			matches.push({
 				from,
 				to: to + 1,
 			});
 		}
-		matchIndex = text.indexOf(normalizedQuery, matchIndex + normalizedQuery.length);
+		matchIndex = text.indexOf(
+			normalizedQuery,
+			matchIndex + normalizedQuery.length,
+		);
 	}
 
 	return matches;

--- a/packages/editor/src/FindExtension.ts
+++ b/packages/editor/src/FindExtension.ts
@@ -1,0 +1,241 @@
+import { Extension } from "@tiptap/core";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import { TextSelection, Plugin, PluginKey } from "@tiptap/pm/state";
+import type { EditorState, Transaction } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+
+export type FindMatch = {
+	from: number;
+	to: number;
+};
+
+export type FindState = {
+	query: string;
+	activeIndex: number;
+	matches: FindMatch[];
+};
+
+type FindMeta =
+	| { type: "setQuery"; query: string }
+	| { type: "setActiveIndex"; activeIndex: number }
+	| { type: "clear" };
+type TextOffset = {
+	docPos: number | null;
+};
+type TextIndex = {
+	offsets: TextOffset[];
+	text: string;
+};
+
+export const findPluginKey = new PluginKey<FindState>("hubbleFind");
+
+export const FindExtension = Extension.create({
+	name: "find",
+
+	addCommands() {
+		return {
+			setFindQuery:
+				(query: string) =>
+				({ state, dispatch }) => {
+					if (!dispatch) return true;
+					dispatch(state.tr.setMeta(findPluginKey, { type: "setQuery", query }));
+					return true;
+				},
+			setFindActiveIndex:
+				(activeIndex: number) =>
+				({ state, dispatch }) => {
+					if (!dispatch) return true;
+					dispatch(
+						state.tr.setMeta(findPluginKey, { type: "setActiveIndex", activeIndex }),
+					);
+					return true;
+				},
+			clearFindQuery:
+				() =>
+				({ state, dispatch }) => {
+					if (!dispatch) return true;
+					dispatch(state.tr.setMeta(findPluginKey, { type: "clear" }));
+					return true;
+				},
+		};
+	},
+
+	addProseMirrorPlugins() {
+		return [
+			new Plugin<FindState>({
+				key: findPluginKey,
+				state: {
+					init: () => emptyFindState(),
+					apply: (tr, previous, _oldState, newState) => {
+						const meta = tr.getMeta(findPluginKey) as FindMeta | undefined;
+						if (meta?.type === "clear") return emptyFindState();
+						const query =
+							meta?.type === "setQuery" ? meta.query : previous.query;
+						const matches = query.trim()
+							? findMatches(newState.doc, query)
+							: [];
+						const activeIndex =
+							meta?.type === "setActiveIndex"
+								? normalizeActiveIndex(meta.activeIndex, matches.length)
+								: reconcileActiveIndex(previous.activeIndex, matches.length);
+						return { query, activeIndex, matches };
+					},
+				},
+				props: {
+					decorations: (state) => {
+						const findState = findPluginKey.getState(state);
+						if (!findState || findState.matches.length === 0) {
+							return DecorationSet.empty;
+						}
+						return DecorationSet.create(
+							state.doc,
+							findState.matches.map((match, index) =>
+								Decoration.inline(match.from, match.to, {
+									class:
+										index === findState.activeIndex
+											? "pm-find-match pm-find-match-current"
+											: "pm-find-match",
+								}),
+							),
+						);
+					},
+				},
+			}),
+		];
+	},
+});
+
+export function getFindState(state: EditorState) {
+	return findPluginKey.getState(state) ?? emptyFindState();
+}
+
+export function selectFindMatch(editor: {
+	state: EditorState;
+	view: {
+		coordsAtPos: (pos: number) => { top: number; bottom: number };
+		dispatch: (tr: Transaction) => void;
+		dom: HTMLElement;
+	};
+}) {
+	const findState = getFindState(editor.state);
+	const match = findState.matches[findState.activeIndex];
+	if (!match) return false;
+	const tr = editor.state.tr.setSelection(
+		TextSelection.create(editor.state.doc, match.from, match.to),
+	);
+	editor.view.dispatch(tr);
+	scrollMatchIntoView(editor.view, match.from);
+	return true;
+}
+
+/**
+ * Finds query matches in the document's visible text.
+ *
+ * ProseMirror splits text at mark boundaries, so a phrase like "needle top"
+ * can live across separate text nodes when only "needle" is bold. This searches
+ * a flattened text index, then maps each result back to document positions.
+ */
+export function findMatches(doc: ProseMirrorNode, query: string) {
+	const normalizedQuery = query.toLocaleLowerCase();
+	const matches: FindMatch[] = [];
+	if (!normalizedQuery) return matches;
+	const index = buildTextIndex(doc);
+	const text = index.text.toLocaleLowerCase();
+
+	let matchIndex = text.indexOf(normalizedQuery);
+	while (matchIndex !== -1) {
+		const from = index.offsets[matchIndex]?.docPos;
+		const to = index.offsets[matchIndex + query.length - 1]?.docPos;
+		if (from !== null && from !== undefined && to !== null && to !== undefined) {
+			matches.push({
+				from,
+				to: to + 1,
+			});
+		}
+		matchIndex = text.indexOf(normalizedQuery, matchIndex + normalizedQuery.length);
+	}
+
+	return matches;
+}
+
+/**
+ * Builds the plain-text string used for search and records where each character
+ * came from in the ProseMirror document.
+ *
+ * Block boundaries get unmapped newline separators so searches do not match
+ * across separate paragraphs.
+ */
+function buildTextIndex(doc: ProseMirrorNode): TextIndex {
+	const offsets: TextOffset[] = [];
+	let text = "";
+
+	doc.descendants((node, pos) => {
+		if (node.isText) {
+			if (!node.text) return;
+			text += node.text;
+			for (let index = 0; index < node.text.length; index++) {
+				offsets.push({ docPos: pos + index });
+			}
+			return;
+		}
+		if (!node.isBlock || pos === 0 || text.endsWith("\n")) return;
+		text += "\n";
+		offsets.push({ docPos: null });
+	});
+
+	return { offsets, text };
+}
+
+function emptyFindState() {
+	return {
+		query: "",
+		activeIndex: 0,
+		matches: [],
+	};
+}
+
+function reconcileActiveIndex(activeIndex: number, matchCount: number) {
+	if (matchCount === 0) return 0;
+	return Math.min(activeIndex, matchCount - 1);
+}
+
+function normalizeActiveIndex(activeIndex: number, matchCount: number) {
+	if (matchCount === 0) return 0;
+	return ((activeIndex % matchCount) + matchCount) % matchCount;
+}
+
+function scrollMatchIntoView(
+	view: {
+		coordsAtPos: (pos: number) => { top: number; bottom: number };
+		dom: HTMLElement;
+	},
+	pos: number,
+) {
+	const viewport = view.dom.closest(".editorViewport") as HTMLElement | null;
+	if (!viewport) return;
+
+	const matchRect = view.coordsAtPos(pos);
+	const viewportRect = viewport.getBoundingClientRect();
+	// The find bar floats over the editor, so keep matches below it without
+	// using ProseMirror's broader scrollIntoView behavior.
+	const topPadding = 48;
+	const bottomPadding = 24;
+	const visibleTop = viewportRect.top + topPadding;
+	const visibleBottom = viewportRect.bottom - bottomPadding;
+
+	if (matchRect.top < visibleTop) {
+		viewport.scrollTop += matchRect.top - visibleTop;
+	} else if (matchRect.bottom > visibleBottom) {
+		viewport.scrollTop += matchRect.bottom - visibleBottom;
+	}
+}
+
+declare module "@tiptap/core" {
+	interface Commands<ReturnType> {
+		find: {
+			setFindQuery: (query: string) => ReturnType;
+			setFindActiveIndex: (activeIndex: number) => ReturnType;
+			clearFindQuery: () => ReturnType;
+		};
+	}
+}

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -1,5 +1,13 @@
 export { FakeSelectionExtension } from "./FakeSelectionExtension";
 export {
+	FindExtension,
+	findMatches,
+	getFindState,
+	selectFindMatch,
+	type FindMatch,
+	type FindState,
+} from "./FindExtension";
+export {
 	combineMarkdownFrontMatter,
 	detectFilePropertyType,
 	type FileProperty,

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -1,11 +1,11 @@
 export { FakeSelectionExtension } from "./FakeSelectionExtension";
 export {
 	FindExtension,
+	type FindMatch,
+	type FindState,
 	findMatches,
 	getFindState,
 	selectFindMatch,
-	type FindMatch,
-	type FindState,
 } from "./FindExtension";
 export {
 	combineMarkdownFrontMatter,

--- a/packages/ui/src/editor/EditorView.css
+++ b/packages/ui/src/editor/EditorView.css
@@ -243,6 +243,16 @@
 	border-radius: 2px;
 }
 
+[data-hubble-editor] .pm-find-match {
+	background: color-mix(in oklab, var(--brand) 22%, transparent);
+	border-radius: 2px;
+}
+
+[data-hubble-editor] .pm-find-match-current {
+	background: color-mix(in oklab, var(--brand) 38%, transparent);
+	box-shadow: 0 0 0 1px color-mix(in oklab, var(--brand) 45%, transparent);
+}
+
 [data-hubble-editor]
 	:is(.pm-md-delimiter, .ProseMirror code, .ProseMirror pre) {
 	font-family:

--- a/packages/ui/src/editor/EditorView.tsx
+++ b/packages/ui/src/editor/EditorView.tsx
@@ -1,6 +1,7 @@
 import {
 	combineMarkdownFrontMatter,
 	HeadingExtension,
+	FindExtension,
 	LinkExtension,
 	listExtensions,
 	MarkdownRolloverExtension,
@@ -31,6 +32,7 @@ import {
 	FilePropertiesPanel,
 	frontMatterStateFromMarkdown,
 } from "./FilePropertiesPanel";
+import { FindBar } from "./FindBar";
 import { FormatCommandMenu } from "./FormatCommandMenu";
 import { FormattingStatusBar } from "./FormattingStatusBar";
 import type { VirtualCursorMode } from "./virtualCursorMode";
@@ -135,6 +137,7 @@ export function EditorView({
 			SmartLinkExtension,
 			LinkClickExtension.configure({ onOpenExternalLink, onOpenWikiLink }),
 			LinkCreationGhostExtension,
+			FindExtension,
 			HeadingExtension,
 			MarkdownRolloverExtension,
 			StrikethroughShortcutExtension,
@@ -279,6 +282,7 @@ export function EditorView({
 				<SlashCommandMenu editor={editor} viewportRef={editorViewportRef} />
 				<FormatCommandMenu editor={editor} viewportRef={editorViewportRef} />
 			</div>
+			<FindBar editor={editor} />
 			<FormattingStatusBar editor={editor} scrollContainer={editorViewportEl} />
 		</div>
 	);

--- a/packages/ui/src/editor/EditorView.tsx
+++ b/packages/ui/src/editor/EditorView.tsx
@@ -1,7 +1,7 @@
 import {
 	combineMarkdownFrontMatter,
-	HeadingExtension,
 	FindExtension,
+	HeadingExtension,
 	LinkExtension,
 	listExtensions,
 	MarkdownRolloverExtension,

--- a/packages/ui/src/editor/FindBar.tsx
+++ b/packages/ui/src/editor/FindBar.tsx
@@ -1,11 +1,17 @@
 import {
+	type FindState,
 	getFindState,
 	selectFindMatch,
-	type FindState,
 } from "@hubble.md/editor";
 import type { Editor } from "@tiptap/core";
 import { keymatch } from "keymatch";
-import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import {
+	type ReactNode,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
 import MingcuteCloseLine from "~icons/mingcute/close-line";
 import MingcuteDownLine from "~icons/mingcute/down-line";
 import MingcuteSearchLine from "~icons/mingcute/search-line";

--- a/packages/ui/src/editor/FindBar.tsx
+++ b/packages/ui/src/editor/FindBar.tsx
@@ -1,0 +1,171 @@
+import {
+	getFindState,
+	selectFindMatch,
+	type FindState,
+} from "@hubble.md/editor";
+import type { Editor } from "@tiptap/core";
+import { keymatch } from "keymatch";
+import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import MingcuteCloseLine from "~icons/mingcute/close-line";
+import MingcuteDownLine from "~icons/mingcute/down-line";
+import MingcuteSearchLine from "~icons/mingcute/search-line";
+import MingcuteUpLine from "~icons/mingcute/up-line";
+import { cn } from "../lib/utils";
+
+export function FindBar({ editor }: { editor: Editor | null }) {
+	const [open, setOpen] = useState(false);
+	const [findState, setFindState] = useState<FindState>({
+		query: "",
+		activeIndex: 0,
+		matches: [],
+	});
+	const inputRef = useRef<HTMLInputElement | null>(null);
+
+	const syncFindState = useCallback(() => {
+		if (!editor) return;
+		setFindState(getFindState(editor.state));
+	}, [editor]);
+
+	const close = useCallback(() => {
+		setOpen(false);
+		editor?.commands.clearFindQuery();
+		editor?.commands.focus(undefined, { scrollIntoView: false });
+	}, [editor]);
+
+	const openFind = useCallback(() => {
+		if (!editor) return;
+		const selectedText = editor.state.selection.empty
+			? ""
+			: editor.state.doc.textBetween(
+					editor.state.selection.from,
+					editor.state.selection.to,
+					"\n",
+				);
+		setOpen(true);
+		if (selectedText) editor.commands.setFindQuery(selectedText);
+		requestAnimationFrame(() => {
+			inputRef.current?.focus();
+			inputRef.current?.select();
+		});
+	}, [editor]);
+
+	useEffect(() => {
+		if (!editor) return;
+		syncFindState();
+		editor.on("transaction", syncFindState);
+		return () => {
+			editor.off("transaction", syncFindState);
+		};
+	}, [editor, syncFindState]);
+
+	useEffect(() => {
+		const handleKeyDown = (event: KeyboardEvent) => {
+			if (open && event.key === "Escape") {
+				event.preventDefault();
+				close();
+				return;
+			}
+			if (!keymatch(event, "CmdOrCtrl+f")) return;
+			if (!editor?.isFocused && !open) return;
+			event.preventDefault();
+			openFind();
+		};
+		window.addEventListener("keydown", handleKeyDown);
+		return () => window.removeEventListener("keydown", handleKeyDown);
+	}, [close, editor, open, openFind]);
+
+	if (!editor || !open) return null;
+
+	const matchCount = findState.matches.length;
+	const activeLabel =
+		findState.query.trim() && matchCount > 0
+			? `${findState.activeIndex + 1} of ${matchCount}`
+			: findState.query.trim()
+				? "No matches"
+				: "0 of 0";
+
+	const goToMatch = (direction: -1 | 1) => {
+		if (matchCount === 0) return;
+		editor.commands.setFindActiveIndex(findState.activeIndex + direction);
+		requestAnimationFrame(() => selectFindMatch(editor));
+	};
+
+	return (
+		<div
+			className="absolute z-[6] flex w-[min(22rem,calc(100%-1rem))] origin-(--transform-origin) items-center gap-1 rounded-[var(--radius-popover)] border border-border bg-popover p-1 text-[11px] text-popover-foreground shadow-overlay transition-[transform,opacity] data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 [--transform-origin:top_right] [inset-block-start:0.5rem] [inset-inline-end:0.5rem]"
+			data-open
+		>
+			<MingcuteSearchLine className="size-3.5 shrink-0 text-muted-foreground" />
+			<input
+				ref={inputRef}
+				value={findState.query}
+				onChange={(event) => {
+					editor.commands.setFindQuery(event.target.value);
+					requestAnimationFrame(() => selectFindMatch(editor));
+				}}
+				onKeyDown={(event) => {
+					if (event.key === "Escape") {
+						event.preventDefault();
+						close();
+						return;
+					}
+					if (event.key === "Enter") {
+						event.preventDefault();
+						goToMatch(event.shiftKey ? -1 : 1);
+					}
+				}}
+				placeholder="Find"
+				className="h-6 min-w-0 flex-1 border-0 bg-transparent px-1 text-[11px] text-foreground outline-hidden placeholder:text-muted-foreground"
+			/>
+			<span className="shrink-0 tabular-nums text-muted-foreground">
+				{activeLabel}
+			</span>
+			<FindButton
+				label="Previous match"
+				disabled={matchCount === 0}
+				onClick={() => goToMatch(-1)}
+			>
+				<MingcuteUpLine className="size-3.5" />
+			</FindButton>
+			<FindButton
+				label="Next match"
+				disabled={matchCount === 0}
+				onClick={() => goToMatch(1)}
+			>
+				<MingcuteDownLine className="size-3.5" />
+			</FindButton>
+			<FindButton label="Close find" onClick={close}>
+				<MingcuteCloseLine className="size-3.5" />
+			</FindButton>
+		</div>
+	);
+}
+
+function FindButton({
+	children,
+	disabled,
+	label,
+	onClick,
+}: {
+	children: ReactNode;
+	disabled?: boolean;
+	label: string;
+	onClick: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			aria-label={label}
+			title={label}
+			disabled={disabled}
+			onMouseDown={(event) => event.preventDefault()}
+			onClick={onClick}
+			className={cn(
+				"inline-flex size-6 shrink-0 items-center justify-center rounded-[var(--radius-inner)] text-muted-foreground outline-hidden hover:bg-accent hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring/40",
+				"disabled:pointer-events-none disabled:opacity-40",
+			)}
+		>
+			{children}
+		</button>
+	);
+}


### PR DESCRIPTION
Closes #84

## Summary
- add ProseMirror find state + match decorations
- add in-editor find bar with Cmd/Ctrl+F, Enter/Shift+Enter, Esc
- add match count and current-match styling

## Checks
- pnpm --filter @hubble.md/editor test -- FindExtension.test.ts
- pnpm --filter @hubble.md/editor typecheck
- pnpm --filter @hubble.md/ui typecheck
- pnpm build:desktop

## E2E
- Ran `HUBBLE_DESKTOP_ENABLE_CDP=1 pnpm dev:desktop`
- Opened playground README in Electron
- Verified Cmd+F opens Find, query highlights 2 matches, Enter advances to `2 of 2`, Esc closes and clears highlights