### PR TITLE
Test new folder sidebar flow

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -61,6 +61,7 @@
 	"devDependencies": {
 		"@iconify-json/mingcute": "^1.2.7",
 		"@types/react": "^19.1.8",
+		"@types/react-dom": "^19.2.3",
 		"happy-dom": "^20.10.3",
 		"typescript": "~5.8.3",
 		"unplugin-icons": "^23.0.1",

--- a/packages/ui/src/components/Sidebar.test.tsx
+++ b/packages/ui/src/components/Sidebar.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Sidebar, type SidebarFolder } from "./Sidebar";
+
+(
+	globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+afterEach(() => {
+	if (root) {
+		act(() => root?.unmount());
+	}
+	root = null;
+	container?.remove();
+	container = null;
+	vi.restoreAllMocks();
+});
+
+function renderSidebar({
+	folders = [],
+	onCreateFolder,
+	onDeleteFolder = vi.fn(),
+	onRenameFolder = vi.fn(),
+}: {
+	folders?: SidebarFolder[];
+	onCreateFolder: (folderId: string | null) => Promise<string | null>;
+	onDeleteFolder?: (folderId: string) => void;
+	onRenameFolder?: (
+		folderId: string,
+		nextName: string,
+		targetDisplayPath: string,
+	) => void;
+}) {
+	container = document.createElement("div");
+	document.body.append(container);
+	root = createRoot(container);
+
+	act(() => {
+		root?.render(
+			<Sidebar
+				files={[]}
+				folders={folders}
+				currentPath={null}
+				sortMode="alpha"
+				getDisplayPath={(path) => path.replace("/workspace/", "")}
+				onCreateFolder={onCreateFolder}
+				onDeleteFolder={onDeleteFolder}
+				onRenameFolder={onRenameFolder}
+				onSelectFile={vi.fn()}
+				onSortModeChange={vi.fn()}
+			/>,
+		);
+	});
+
+	return { container };
+}
+
+async function click(element: Element) {
+	await act(async () => {
+		element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+	});
+}
+
+async function change(input: HTMLInputElement, value: string) {
+	const valueSetter = Object.getOwnPropertyDescriptor(
+		HTMLInputElement.prototype,
+		"value",
+	)?.set;
+	await act(async () => {
+		valueSetter?.call(input, value);
+		input.dispatchEvent(new Event("input", { bubbles: true }));
+	});
+}
+
+async function keyDown(input: HTMLInputElement, key: string) {
+	await act(async () => {
+		input.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key }));
+	});
+}
+
+function renameInput() {
+	expect(document.activeElement).toBeInstanceOf(HTMLInputElement);
+	return document.activeElement as HTMLInputElement;
+}
+
+describe("Sidebar new folder", () => {
+	it("creates a folder from the header and commits inline naming", async () => {
+		const onCreateFolder = vi.fn(async () => "/workspace/new-folder");
+		const onRenameFolder = vi.fn();
+
+		const { container } = renderSidebar({
+			folders: [{ path: "/workspace/new-folder", modifiedAt: 1 }],
+			onCreateFolder,
+			onRenameFolder,
+		});
+
+		const newFolderButton = container.querySelector(
+			'button[aria-label="New folder"]',
+		);
+		expect(newFolderButton).toBeInstanceOf(HTMLButtonElement);
+
+		await click(newFolderButton as HTMLButtonElement);
+
+		const input = renameInput();
+		expect(input.value).toBe("new-folder");
+
+		await change(input, "Plans");
+		await keyDown(input, "Enter");
+
+		expect(onCreateFolder).toHaveBeenCalledWith(null);
+		expect(onRenameFolder).toHaveBeenCalledWith(
+			"new-folder/",
+			"Plans",
+			"Plans",
+		);
+	});
+
+	it("deletes the new empty folder when header inline naming is canceled", async () => {
+		const onCreateFolder = vi.fn(async () => "/workspace/new-folder");
+		const onDeleteFolder = vi.fn();
+
+		const { container } = renderSidebar({
+			folders: [{ path: "/workspace/new-folder", modifiedAt: 1 }],
+			onCreateFolder,
+			onDeleteFolder,
+		});
+
+		const newFolderButton = container.querySelector(
+			'button[aria-label="New folder"]',
+		);
+		expect(newFolderButton).toBeInstanceOf(HTMLButtonElement);
+
+		await click(newFolderButton as HTMLButtonElement);
+
+		const input = renameInput();
+
+		await keyDown(input, "Escape");
+
+		expect(onDeleteFolder).toHaveBeenCalledWith("new-folder/");
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -446,6 +446,9 @@ importers:
       '@types/react':
         specifier: ^19.1.8
         version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
       happy-dom:
         specifier: ^20.10.3
         version: 20.10.3


### PR DESCRIPTION
Closes #91

## Summary
- Add UI coverage for sidebar header New folder inline naming commit
- Add UI coverage for Escape discard using existing delete-on-cancel path
- Add @types/react-dom for UI package test typecheck

## Checks
- pnpm check
- pnpm --filter @hubble.md/ui exec vitest run src/components/Sidebar.test.tsx
- pnpm --filter @hubble.md/desktop test -- src/store/actions.test.ts
- pnpm build:desktop

## E2E
- Ran HUBBLE_DESKTOP_ENABLE_CDP=1 pnpm dev:desktop
- Verified header New folder creates and inline-renames a real playground directory
- Verified Escape discards the fresh empty folder from disk