### PR TITLE
Align pnpm package manager policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,13 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.9.0
+          version: 11.9.0
           run_install: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.12.0
+          node-version: 22.13.0
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
@@ -50,13 +50,13 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.9.0
+          version: 11.9.0
           run_install: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.12.0
+          node-version: 22.13.0
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -19,13 +19,13 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.9.0
+          version: 11.9.0
           run_install: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.12.0
+          node-version: 22.13.0
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
@@ -95,13 +95,13 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.9.0
+          version: 11.9.0
           run_install: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.12.0
+          node-version: 22.13.0
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
@@ -143,13 +143,13 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.9.0
+          version: 11.9.0
           run_install: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.12.0
+          node-version: 22.13.0
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"name": "hubble-md",
 	"private": true,
 	"version": "0.0.0",
+	"packageManager": "pnpm@11.9.0",
 	"description": "Hubble.md monorepo",
 	"license": "MIT",
 	"author": "Ben Holmes <hey@bholmes.dev>",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,3 +13,9 @@ onlyBuiltDependencies:
   - esbuild
   - msw
   - sharp
+
+allowBuilds:
+  electron-winstaller: true
+  esbuild: true
+  msw: true
+  sharp: true


### PR DESCRIPTION
Closes #118

## Summary
- Pin root package manager to `pnpm@11.9.0`
- Add pnpm 11 `allowBuilds` entries mirroring `onlyBuiltDependencies`
- Update CI and desktop release workflows to pnpm `11.9.0`
- Bump workflow Node from `22.12.0` to `22.13.0`, required by pnpm `11.9.0`

## Validation
- `source ~/.nvm/nvm.sh && nvm use 22.13.0 && CI=true pnpm check`
- `source ~/.nvm/nvm.sh && nvm use 22.13.0 && CI=true pnpm build:desktop`
- `git diff --check`
- Static check: `allowBuilds` mirrors `onlyBuiltDependencies`

## Workflow testing plan
1. Open this PR and confirm CI runs on the PR event.
2. In the CI logs for both jobs, verify `pnpm/action-setup` installs pnpm `11.9.0` and `actions/setup-node` uses Node `22.13.0`.
3. Confirm the CI `pnpm install --frozen-lockfile`, `pnpm check`, package build, and `pnpm test` steps pass.
4. Before the next desktop release, create a temporary tag in a fork or dry-run branch matching `desktop-v<apps/desktop version>` and verify all desktop release jobs start with pnpm `11.9.0`/Node `22.13.0` across macOS, Linux x64/arm64, and Windows x64/arm64.
5. Delete the temporary tag/release artifacts after the dry run.

## Notes
- Local validation needed Node `22.13.0`; pnpm `11.9.0` refuses Node `22.12.0`.
