### PR TITLE
[codex] Add copy as Markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 ## [Unreleased]
 
 ### Added
-- Copy selected editor content as Markdown from the Edit menu or editor context menu
+- Copy selected editor content as Markdown from the Edit menu or editor context menu, thanks to [@jambronner](https://github.com/jambronner) in [#122](https://github.com/bholmesdev/hubble.md/pull/122)
 - Terminal panel in the desktop app: toggle with Cmd+J to run shell commands in your workspace, with tabs, drag resize, and double click to rename
 - Chat about the open note with your agent CLI: pick it from the note's ⋯ menu or press Cmd+Shift+J, and customize the command in Settings
 - Add table support. Markdown tables now render as expected, and you can create new tables using `/table`. There are still editing features left to add, like adding and removing rows. Track progress on GitHub: [#99](https://github.com/bholmesdev/hubble.md/issues/99)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 ## [Unreleased]
 
 ### Added
+- Copy selected editor content as Markdown from the Edit menu or editor context menu
 - Terminal panel in the desktop app: toggle with Cmd+J to run shell commands in your workspace, with tabs, drag resize, and double click to rename
 - Chat about the open note with your agent CLI: pick it from the note's ⋯ menu or press Cmd+Shift+J, and customize the command in Settings
 - Add table support. Markdown tables now render as expected, and you can create new tables using `/table`. There are still editing features left to add, like adding and removing rows. Track progress on GitHub: [#99](https://github.com/bholmesdev/hubble.md/issues/99)

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -655,6 +655,7 @@ type TextContextMenuItem =
 	| {
 			id: "copy-as-markdown";
 			label: string;
+			accelerator?: string;
 			flag: keyof Electron.EditFlags;
 			click: (webContents: Electron.WebContents) => void;
 	  };
@@ -665,6 +666,7 @@ const textContextMenuItems: TextContextMenuItem[] = [
 	{
 		id: "copy-as-markdown",
 		label: "Copy as Markdown",
+		accelerator: "Alt+CmdOrCtrl+C",
 		flag: "canCopy",
 		click: (webContents) => {
 			webContents.send("desktop:menu-copy-as-markdown");
@@ -688,6 +690,7 @@ function buildTextContextMenu(
 				: {
 						id: item.id,
 						label: item.label,
+						accelerator: item.accelerator,
 						enabled: params.editFlags[item.flag],
 						click: () => item.click(webContents),
 					},
@@ -761,6 +764,7 @@ function buildMenu() {
 				{
 					id: "copy-as-markdown",
 					label: "Copy as Markdown",
+					accelerator: "Alt+CmdOrCtrl+C",
 					click: () => sendToRenderer("desktop:menu-copy-as-markdown"),
 				},
 				{ role: "paste" },

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -647,24 +647,51 @@ function responseForAsset(filePath: string) {
 	});
 }
 
-type TextContextMenuItem = {
-	role: "cut" | "copy" | "paste" | "selectAll";
-	flag: keyof Electron.EditFlags;
-};
+type TextContextMenuItem =
+	| {
+			role: "cut" | "copy" | "paste" | "selectAll";
+			flag: keyof Electron.EditFlags;
+	  }
+	| {
+			id: "copy-as-markdown";
+			label: string;
+			flag: keyof Electron.EditFlags;
+			click: (webContents: Electron.WebContents) => void;
+	  };
 
 const textContextMenuItems: TextContextMenuItem[] = [
 	{ role: "cut", flag: "canCut" },
 	{ role: "copy", flag: "canCopy" },
+	{
+		id: "copy-as-markdown",
+		label: "Copy as Markdown",
+		flag: "canCopy",
+		click: (webContents) => {
+			webContents.send("desktop:menu-copy-as-markdown");
+		},
+	},
 	{ role: "paste", flag: "canPaste" },
 	{ role: "selectAll", flag: "canSelectAll" },
 ];
 
-function buildTextContextMenu(params: Electron.ContextMenuParams) {
+function buildTextContextMenu(
+	webContents: Electron.WebContents,
+	params: Electron.ContextMenuParams,
+) {
 	const template: Electron.MenuItemConstructorOptions[] =
-		textContextMenuItems.map((item) => ({
-			role: item.role,
-			enabled: params.editFlags[item.flag],
-		}));
+		textContextMenuItems.map((item) =>
+			"role" in item
+				? {
+						role: item.role,
+						enabled: params.editFlags[item.flag],
+					}
+				: {
+						id: item.id,
+						label: item.label,
+						enabled: params.editFlags[item.flag],
+						click: () => item.click(webContents),
+					},
+		);
 
 	return Menu.buildFromTemplate(template);
 }
@@ -672,7 +699,7 @@ function buildTextContextMenu(params: Electron.ContextMenuParams) {
 function registerTextContextMenu(window: BrowserWindow) {
 	window.webContents.on("context-menu", (_event, params) => {
 		if (!params.isEditable) return;
-		buildTextContextMenu(params).popup({ window });
+		buildTextContextMenu(window.webContents, params).popup({ window });
 	});
 }
 
@@ -731,6 +758,11 @@ function buildMenu() {
 				{ type: "separator" },
 				{ role: "cut" },
 				{ role: "copy" },
+				{
+					id: "copy-as-markdown",
+					label: "Copy as Markdown",
+					click: () => sendToRenderer("desktop:menu-copy-as-markdown"),
+				},
 				{ role: "paste" },
 				{ role: "selectAll" },
 			],

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -101,6 +101,8 @@ const desktopApi = {
 		subscribe("desktop:menu-open-folder", callback),
 	onMenuOpenSettings: (callback) =>
 		subscribe("desktop:menu-open-settings", callback),
+	onMenuCopyAsMarkdown: (callback) =>
+		subscribe("desktop:menu-copy-as-markdown", callback),
 	onMenuShowWorkspaceSwitcher: (callback) =>
 		subscribe("desktop:menu-show-workspace-switcher", callback),
 	onMenuSyncWorkspace: (callback) =>

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -100,6 +100,7 @@ function App() {
 	const [scrollContainerEl, setScrollContainerEl] =
 		useState<HTMLDivElement | null>(null);
 	const [settingsOpen, setSettingsOpen] = useState(false);
+	const [copyAsMarkdownRequest, setCopyAsMarkdownRequest] = useState(0);
 	const [updateState, setUpdateState] = useState<DesktopUpdateState | null>(
 		null,
 	);
@@ -275,6 +276,9 @@ function App() {
 			desktopApi.onMenuOpenFile(() => void openFilePicker()),
 			desktopApi.onMenuOpenFolder(() => void openWorkspaceWithSidebar()),
 			desktopApi.onMenuOpenSettings(() => openSettings()),
+			desktopApi.onMenuCopyAsMarkdown(() =>
+				setCopyAsMarkdownRequest((request) => request + 1),
+			),
 			desktopApi.onMenuShowWorkspaceSwitcher(() =>
 				setWorkspaceSwitcherOpen(true),
 			),
@@ -389,6 +393,7 @@ function App() {
 								<DocumentViewer
 									path={state.currentPath}
 									content={state.content}
+									copyAsMarkdownRequest={copyAsMarkdownRequest}
 									onScrollContainerChange={setScrollContainerEl}
 								/>
 							</div>
@@ -437,10 +442,12 @@ function ChatAboutNoteSettingsSection() {
 function DocumentViewer({
 	path,
 	content,
+	copyAsMarkdownRequest,
 	onScrollContainerChange,
 }: {
 	path: string;
 	content: string;
+	copyAsMarkdownRequest: number;
 	onScrollContainerChange?: (el: HTMLDivElement | null) => void;
 }) {
 	if (hasHtmlExtension(path)) {
@@ -461,6 +468,7 @@ function DocumentViewer({
 			key={`${path}:${HMR_REV}`}
 			path={path}
 			initialMarkdown={content}
+			copyAsMarkdownRequest={copyAsMarkdownRequest}
 			onScrollContainerChange={onScrollContainerChange}
 		/>
 	);
@@ -538,10 +546,12 @@ function ExternalChangeBanner({
 function MarkdownEditor({
 	path,
 	initialMarkdown,
+	copyAsMarkdownRequest,
 	onScrollContainerChange,
 }: {
 	path: string;
 	initialMarkdown: string;
+	copyAsMarkdownRequest: number;
 	onScrollContainerChange?: (el: HTMLDivElement | null) => void;
 }) {
 	const workspace = useStoreValue(workspaceStore);
@@ -604,6 +614,7 @@ function MarkdownEditor({
 			onLocalChange={updateEditorContent}
 			onSave={savePathContent}
 			onScrollContainerChange={onScrollContainerChange}
+			copyAsMarkdownRequest={copyAsMarkdownRequest}
 			onOpenExternalLink={openExternalLink}
 			onOpenWikiLink={(target) =>
 				void loadPath(

--- a/apps/desktop/src/desktopApi/types.ts
+++ b/apps/desktop/src/desktopApi/types.ts
@@ -130,6 +130,7 @@ export type DesktopApi = {
 	onMenuOpenFile(callback: () => void): Unsubscribe;
 	onMenuOpenFolder(callback: () => void): Unsubscribe;
 	onMenuOpenSettings(callback: () => void): Unsubscribe;
+	onMenuCopyAsMarkdown(callback: () => void): Unsubscribe;
 	onMenuShowWorkspaceSwitcher(callback: () => void): Unsubscribe;
 	onMenuSyncWorkspace(callback: () => void): Unsubscribe;
 	onMenuToggleTerminal(callback: () => void): Unsubscribe;

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -46,7 +46,10 @@ export {
 	withMarkdownExtension,
 } from "./markdownPath";
 export { markdownToTiptapDoc } from "./markdownToProsemirror";
-export { tiptapDocToMarkdown } from "./prosemirrorToMarkdown";
+export {
+	selectionToMarkdown,
+	tiptapDocToMarkdown,
+} from "./prosemirrorToMarkdown";
 export { StoredMarksDecorationExtension } from "./StoredMarksDecorationExtension";
 export { StrikethroughShortcutExtension } from "./StrikethroughShortcutExtension";
 export {

--- a/packages/editor/src/prosemirrorToMarkdown.ts
+++ b/packages/editor/src/prosemirrorToMarkdown.ts
@@ -1,4 +1,6 @@
 import type { JSONContent } from "@tiptap/core";
+import type { Fragment } from "@tiptap/pm/model";
+import type { Selection } from "@tiptap/pm/state";
 import type { LinkAttrs } from "./Link";
 import { wikiDisplayNameForTarget } from "./markdownPath";
 
@@ -13,6 +15,16 @@ export function tiptapDocToMarkdown(doc: JSONContent): string {
 
 	const blocks = doc.content.map(blockToMarkdown);
 	return blocks.join("\n\n");
+}
+
+export function selectionToMarkdown(selection: Selection): string {
+	return fragmentToMarkdown(selection.content().content);
+}
+
+function fragmentToMarkdown(fragment: Fragment): string {
+	const content = fragment.toJSON();
+	if (!Array.isArray(content)) return "";
+	return tiptapDocToMarkdown({ type: "doc", content });
 }
 
 function blockToMarkdown(node: JSONContent): string {

--- a/packages/ui/src/editor/CodeBlockExtension.tsx
+++ b/packages/ui/src/editor/CodeBlockExtension.tsx
@@ -37,8 +37,10 @@ lowlight.registerAlias({
 
 export const HubbleCodeBlock = CodeBlockLowlight.extend({
 	addKeyboardShortcuts() {
+		const { "Mod-Alt-c": _toggleCodeBlock, ...shortcuts } =
+			this.parent?.() ?? {};
 		return {
-			...this.parent?.(),
+			...shortcuts,
 			Tab: ({ editor }) => {
 				const { state } = editor;
 				const { selection } = state;

--- a/packages/ui/src/editor/EditorView.tsx
+++ b/packages/ui/src/editor/EditorView.tsx
@@ -25,6 +25,7 @@ import {
 import StarterKit from "@tiptap/starter-kit";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CODE_BLOCK_COPY_EVENT, HubbleCodeBlock } from "./CodeBlockExtension";
+import { copySelectionAsMarkdown } from "./copyAsMarkdown";
 import { LinkClickExtension } from "./LinkClickExtension";
 import { LinkCreationGhostExtension } from "./LinkCreationGhostExtension";
 import { LinkPopover, type WikiTarget } from "./LinkPopover";
@@ -63,6 +64,7 @@ export type EditorViewProps = {
 	onLocalChange: (path: string, markdown: string) => void;
 	onSave: (path: string, markdown: string) => void | Promise<void>;
 	onScrollContainerChange?: (el: HTMLDivElement | null) => void;
+	copyAsMarkdownRequest?: number;
 	onOpenExternalLink: (href: string) => void | Promise<void>;
 	onOpenWikiLink: (target: string) => void | Promise<void>;
 	onMessage?: (message: string, type: "success" | "error") => void;
@@ -80,6 +82,7 @@ export function EditorView({
 	onLocalChange,
 	onSave,
 	onScrollContainerChange,
+	copyAsMarkdownRequest = 0,
 	onOpenExternalLink,
 	onOpenWikiLink,
 	onMessage,
@@ -102,6 +105,7 @@ export function EditorView({
 	const saveTimerRef = useRef<number | null>(null);
 	const editorRootRef = useRef<HTMLDivElement | null>(null);
 	const editorViewportRef = useRef<HTMLDivElement | null>(null);
+	const lastCopyAsMarkdownRequestRef = useRef(copyAsMarkdownRequest);
 	const [editorViewportEl, setEditorViewportEl] =
 		useState<HTMLDivElement | null>(null);
 	const [cursorModeOverride, setCursorModeOverride] =
@@ -251,6 +255,16 @@ export function EditorView({
 		return () =>
 			window.removeEventListener(CODE_BLOCK_COPY_EVENT, handleCopyMessage);
 	}, [onMessage]);
+
+	useEffect(() => {
+		if (!editor || copyAsMarkdownRequest === 0) return;
+		if (copyAsMarkdownRequest === lastCopyAsMarkdownRequestRef.current) return;
+		lastCopyAsMarkdownRequestRef.current = copyAsMarkdownRequest;
+		void copySelectionAsMarkdown({
+			editor,
+			onCopied: () => onMessage?.("Markdown copied", "success"),
+		});
+	}, [copyAsMarkdownRequest, editor, onMessage]);
 
 	return (
 		<div

--- a/packages/ui/src/editor/copyAsMarkdown.ts
+++ b/packages/ui/src/editor/copyAsMarkdown.ts
@@ -1,0 +1,31 @@
+import { selectionToMarkdown } from "@hubble.md/editor";
+import type { Editor } from "@tiptap/core";
+
+type CopySelectionAsMarkdownOptions = {
+	editor: Editor;
+	writeText?: (text: string) => Promise<void>;
+	onCopied?: () => void;
+};
+
+export async function copySelectionAsMarkdown({
+	editor,
+	writeText = (text) => navigator.clipboard.writeText(text),
+	onCopied,
+}: CopySelectionAsMarkdownOptions): Promise<boolean> {
+	if (editor.state.selection.empty) {
+		return false;
+	}
+
+	const markdown = selectionToMarkdown(editor.state.selection).trimEnd();
+	if (markdown.length === 0) {
+		return false;
+	}
+
+	try {
+		await writeText(markdown);
+		onCopied?.();
+		return true;
+	} catch {
+		return false;
+	}
+}


### PR DESCRIPTION
## Summary

- add Copy as Markdown for selected editor content
- expose the action from the desktop Edit menu and editor right-click context menu
- serialize ProseMirror selections through the existing Markdown serializer

## Why

This gives desktop users a direct way to copy selected rendered Markdown back out as Markdown source, while keeping the normal Copy action available for default clipboard behavior.

## Testing

- `pnpm build`
- `pnpm --filter @hubble.md/editor test`
- `pnpm --filter @hubble.md/ui test -- copyAsMarkdown.test.ts`
- `pnpm --filter @hubble.md/desktop test -- editorContextMenu.test.ts`

Related to #121
