### PR TITLE
Fix desktop UTF-8 saves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 ### Changed
 
 ### Fixed
+- Desktop saves no longer drop trailing content in notes with multibyte characters
 
 ## [0.1.15] - 2026-06-27
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1083,10 +1083,16 @@ function registerIpc() {
 
 	ipcMain.handle(
 		"desktop:write-file-text",
-		async (_event, { path: filePath, content }) => {
+		async (_event, { path: filePath, bytes }) => {
 			const resolved = assertGranted(filePath);
+			if (!Array.isArray(bytes)) {
+				throw new Error("write-file-text requires encoded bytes");
+			}
 			await fs.mkdir(path.dirname(resolved), { recursive: true });
-			await fs.writeFile(resolved, String(content));
+			// Text is encoded in preload. Main only writes bytes so it cannot
+			// accidentally shorten UTF-8 content while crossing string encoders.
+			// See https://github.com/bholmesdev/hubble.md/issues/126 for the repro.
+			await fs.writeFile(resolved, Uint8Array.from(bytes));
 		},
 	);
 

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -30,8 +30,15 @@ const desktopApi = {
 		}),
 	readFileText: (path) =>
 		ipcRenderer.invoke("desktop:read-file-text", { path }),
-	writeFileText: (path, content) =>
-		ipcRenderer.invoke("desktop:write-file-text", { path, content }),
+	writeFileText: (path, content) => {
+		// Encode in the renderer before IPC. Main should write these bytes as-is,
+		// because re-encoding the string there has truncated multibyte characters.
+		const bytes = Array.from(new TextEncoder().encode(String(content)));
+		return ipcRenderer.invoke("desktop:write-file-text", {
+			path,
+			bytes,
+		});
+	},
 	createFolder: (path) => ipcRenderer.invoke("desktop:create-folder", { path }),
 	renameFile: (fromPath, toPath) =>
 		ipcRenderer.invoke("desktop:rename-file", { fromPath, toPath }),

--- a/apps/desktop/src/store/actions.test.ts
+++ b/apps/desktop/src/store/actions.test.ts
@@ -94,6 +94,57 @@ describe("desktop savePathContent", () => {
 		expect(viewerStore.get().externalChange).toEqual({ kind: "none" });
 	});
 
+	it("does not treat an in-flight self-save watcher event as an external conflict", async () => {
+		const api = createDesktopApi();
+		let finishWrite: () => void = () => {};
+		api.writeFileText.mockImplementation(
+			() =>
+				new Promise<void>((resolve) => {
+					finishWrite = resolve;
+				}),
+		);
+		const {
+			appStore,
+			handleExternalFileChange,
+			savePathContent,
+			updateEditorContent,
+			viewerStore,
+		} = await loadStoreActions(api);
+		const path = "/workspace/note.md";
+
+		appStore.set((current) => ({
+			...current,
+			document: {
+				...current.document,
+				currentPath: path,
+				lastOpenedPath: path,
+				content: "draft 1",
+				diskContent: "before",
+				externalChange: { kind: "none" },
+				status: "ready",
+				error: null,
+			},
+		}));
+
+		const save = savePathContent(path, "draft 1");
+		await Promise.resolve();
+		expect(api.writeFileText).toHaveBeenCalledWith(path, "draft 1");
+
+		updateEditorContent(path, "draft 2");
+		handleExternalFileChange(path, "draft 1");
+
+		expect(viewerStore.get().content).toBe("draft 2");
+		expect(viewerStore.get().diskContent).toBe("draft 1");
+		expect(viewerStore.get().externalChange).toEqual({ kind: "none" });
+
+		finishWrite();
+		await save;
+
+		expect(viewerStore.get().content).toBe("draft 2");
+		expect(viewerStore.get().diskContent).toBe("draft 1");
+		expect(viewerStore.get().externalChange).toEqual({ kind: "none" });
+	});
+
 	it("uses latest editor content when classifying disk changes", async () => {
 		const api = createDesktopApi();
 		// The file now matches what the user just typed, even though the save

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -43,8 +43,13 @@ import {
 } from "./state";
 
 const REFRESH_FILES_DEBOUNCE_MS = 250;
+const SELF_SAVE_TTL_MS = 5000;
 const missingPathErrorPattern = /\bENOENT\b|\bENOTDIR\b/;
 let refreshFilesTimer: ReturnType<typeof setTimeout> | null = null;
+// The active-file watcher also sees Hubble's own writes. If save A reaches disk
+// after the editor already has draft B, that watcher event is not an external
+// conflict; it is just the disk baseline catching up to a save we started.
+const selfSaves = new Map<string, Map<string, number>>();
 
 type SidebarMoveItem =
 	| { kind: "file"; path: string }
@@ -97,6 +102,41 @@ function handleFileError(err: unknown) {
 	const message = errorMessage(err);
 	refreshFilesAfterMissingPath(message);
 	return message;
+}
+
+function pruneSelfSaves(path: string, now = Date.now()) {
+	const contents = selfSaves.get(path);
+	if (!contents) return;
+	for (const [content, expiresAt] of contents) {
+		if (expiresAt <= now) contents.delete(content);
+	}
+	if (contents.size === 0) selfSaves.delete(path);
+}
+
+function rememberSelfSave(path: string, content: string) {
+	pruneSelfSaves(path);
+	const contents = selfSaves.get(path) ?? new Map<string, number>();
+	contents.set(content, Date.now() + SELF_SAVE_TTL_MS);
+	selfSaves.set(path, contents);
+}
+
+function isSelfSave(path: string, content: string) {
+	pruneSelfSaves(path);
+	return selfSaves.get(path)?.has(content) ?? false;
+}
+
+function selfSaveState(editorContent: string, diskContent: string) {
+	if (editorContent === diskContent) {
+		return cleanFileState(diskContent);
+	}
+	// Keep newer editor text intact while acknowledging that an older self-save
+	// is now the latest content known to be on disk.
+	return {
+		diskContent,
+		externalChange: { kind: "none" as const },
+		status: "ready" as const,
+		error: null,
+	};
 }
 
 function pathStartsWithFolder(filePath: string, folderPath: string): boolean {
@@ -412,17 +452,27 @@ export async function savePathContent(
 			const currentDiskContent = await desktopApi.readFileText(path);
 			const nextCurrent = viewerStore.get();
 			if (nextCurrent.currentPath !== path) return;
-			const action = classifyFileChange({
-				editorContent: nextCurrent.content,
-				baseline: getBaseline(nextCurrent),
-				diskContent: currentDiskContent,
-			});
-			if (action !== "none") {
+			if (isSelfSave(path, currentDiskContent)) {
 				viewerStore.set((state) => {
 					if (state.currentPath !== path) return state;
-					return applyFileAction(state, currentDiskContent, action);
+					return {
+						...state,
+						...selfSaveState(state.content, currentDiskContent),
+					};
 				});
-				return;
+			} else {
+				const action = classifyFileChange({
+					editorContent: nextCurrent.content,
+					baseline: getBaseline(nextCurrent),
+					diskContent: currentDiskContent,
+				});
+				if (action !== "none") {
+					viewerStore.set((state) => {
+						if (state.currentPath !== path) return state;
+						return applyFileAction(state, currentDiskContent, action);
+					});
+					return;
+				}
 			}
 		} catch {
 			// Fall through to the write path if the file cannot be read during preflight.
@@ -430,7 +480,9 @@ export async function savePathContent(
 	}
 
 	try {
+		rememberSelfSave(path, content);
 		await desktopApi.writeFileText(path, content);
+		rememberSelfSave(path, content);
 		touchFile(path);
 		viewerStore.set((state) => {
 			if (state.currentPath !== path) return state;
@@ -902,6 +954,12 @@ export function handleExternalFileChange(
 ) {
 	viewerStore.set((state) => {
 		if (state.currentPath !== path) return state;
+		if (isSelfSave(path, nextDiskContent)) {
+			return {
+				...state,
+				...selfSaveState(state.content, nextDiskContent),
+			};
+		}
 		const action = classifyFileChange({
 			editorContent: state.content,
 			baseline: getBaseline(state),


### PR DESCRIPTION
## Description
Fixes desktop saves for Markdown files containing multibyte characters by sending renderer-encoded UTF-8 bytes to Electron main for writing. Also prevents active-file watcher events from Hubble's own in-flight saves from being treated as external conflicts.

Closes #126

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update

## Testing
- [x] Existing tests pass
- [x] Added new tests for changes
- [x] Tested manually (describe below)

**Manual Testing Details:**
Reproduced the playground transcript save issue while debugging and verified the byte-write path stopped the consistent truncation. Follow-up rapid typing showed a separate self-save watcher race, covered by the added store regression test.

Commands run:
- `pnpm exec biome check CHANGELOG.md apps/desktop/electron/main.ts apps/desktop/electron/preload.ts apps/desktop/src/store/actions.ts --write`
- `pnpm --filter @hubble.md/desktop test -- src/store/actions.test.ts`
- `pnpm build:desktop`

## Checklist
- [x] I discussed this change in a GitHub issue before submitting this PR
- [x] I have run the linter, formatter, and tests to ensure my code is ready for review
