### PR TITLE
Run initial sync after Cloud Sync connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 ### Added
 
 ### Changed
+- Cloud Sync create/connect commands now run an initial sync
 
 ### Fixed
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -176,6 +176,9 @@ async function writeCloudConnection(
 	console.log(`Cloud Sync connected: ${opts.label}`);
 	console.log(`  workspace: ${config.cloudSync?.workspaceId}`);
 	console.log(`  device: ${config.cloudSync?.deviceId}`);
+	if (config.cloudSync) {
+		await syncOnce(workspacePath, config.cloudSync, "initial");
+	}
 }
 
 function getDeploymentUrl(opts: Pick<CliArgs, "deploymentUrl">): string {
@@ -416,6 +419,8 @@ function printCreateHelp() {
 	console.log("Usage:");
 	console.log("  hubble [--cwd path] cloud create --name name [--url url]");
 	console.log("");
+	console.log("Creates, links, and runs the initial sync.");
+	console.log("");
 	console.log("Options:");
 	console.log("  --name name  Remote workspace name to create");
 	console.log("  --url url    Convex deployment URL");
@@ -426,6 +431,8 @@ function printConnectHelp() {
 	console.log(
 		"  hubble [--cwd path] cloud connect (--name name|--id id) [--url url]",
 	);
+	console.log("");
+	console.log("Links and runs the initial sync.");
 	console.log("");
 	console.log("Options:");
 	console.log("  --name name  Existing remote workspace name");


### PR DESCRIPTION
Closes #39

Summary:
- Run the existing sync engine immediately after `hubble cloud create` or `hubble cloud connect` writes the Cloud Sync linkage.
- Update command help and changelog to reflect that create/connect now backfill local files/assets right away.

Checks:
- `pnpm --filter @hubble.md/cli... build`
- `pnpm exec biome check packages/cli/src/index.ts CHANGELOG.md`
- `pnpm check`
- `pnpm build:desktop`

E2E:
- CLI help smoke: `node packages/cli/dist/index.js cloud create --help && node packages/cli/dist/index.js cloud connect --help`.
- No desktop UI e2e needed; this is CLI Cloud Sync behavior.

Notes:
- `pnpm --filter @hubble.md/cli build` alone still fails because workspace dependencies are not built in isolation; `@hubble.md/cli...` passes and matches the monorepo dependency build pattern.
- Build logs include the existing apps/web Node 22.x engine warning under current Node v24.14.0.
- No `codex` / `codex-automation` labels exist in this repo.