### PR TITLE
Add Tailwind HTML embed build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 ## [Unreleased]
 
 ### Added
+- HTML iframe embeds can now be built into `.dist.html` files with pruned Tailwind v4 CSS.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,22 @@ pnpm check            # run Biome
 pnpm typecheck        # typecheck all packages
 ```
 
+## HTML App Tailwind builds
+
+For local HTML Apps or iframe Embeds that use Tailwind utilities, build a static artifact instead of loading Tailwind at runtime:
+
+```sh
+pnpm --filter @hubble.md/desktop build:html-embed path/to/file-index.html
+```
+
+The default output is `path/to/file-index.dist.html`. Point Markdown embeds at the built file:
+
+```html
+<iframe src="./file-index.dist.html"></iframe>
+```
+
+The builder scans the source HTML class attributes, compiles Tailwind v4 CSS for those candidates only, and inlines the result into the output HTML.
+
 ## Documentation
 
 - [`CONTRIBUTING.md`](./CONTRIBUTING.md) covers the contribution flow, local setup, and pre-PR checks.

--- a/apps/desktop/fixtures/playground/README.md
+++ b/apps/desktop/fixtures/playground/README.md
@@ -3,3 +3,9 @@
 This workspace is copied into `.dev-electron/playground` for local Electron dev runs.
 
 Open `file-index.html` or `todo-demo.html` in Hubble to test full-screen HTML Apps.
+
+`tailwind-card.html` is the source file for a Tailwind-built iframe Embed. Rebuild it with:
+
+```sh
+pnpm --filter @hubble.md/desktop build:html-embed apps/desktop/fixtures/playground/tailwind-card.html
+```

--- a/apps/desktop/fixtures/playground/project-ideas.md
+++ b/apps/desktop/fixtures/playground/project-ideas.md
@@ -12,4 +12,6 @@ Use this note to test **bold text**, *italic text*, `inline code`, [[effective-l
 
 Open `file-index.html` or `todo-demo.html` from the sidebar to try full-screen HTML Apps. See [[samples/interview-prep]] for prompts.
 
+<iframe src="./tailwind-card.dist.html"></iframe>
+
 ![Project sketch](project-ideas.assets/project-sketch.jpg)

--- a/apps/desktop/fixtures/playground/tailwind-card.dist.html
+++ b/apps/desktop/fixtures/playground/tailwind-card.dist.html
@@ -1,0 +1,382 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Tailwind embed card</title>
+	<style data-hubble-built-tailwind="v4" data-hubble-tailwind-classes="23">
+/*! tailwindcss v4.1.18 | MIT License | https://tailwindcss.com */
+@layer properties;
+@layer theme, base, components, utilities;
+@layer theme {
+  :root, :host {
+    --font-sans: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
+      "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+      "Courier New", monospace;
+    --color-emerald-700: oklch(50.8% 0.118 165.612);
+    --color-slate-100: oklch(96.8% 0.007 247.896);
+    --color-slate-200: oklch(92.9% 0.013 255.508);
+    --color-slate-600: oklch(44.6% 0.043 257.281);
+    --color-slate-950: oklch(12.9% 0.042 264.695);
+    --color-white: #fff;
+    --spacing: 0.25rem;
+    --text-xs: 0.75rem;
+    --text-xs--line-height: calc(1 / 0.75);
+    --text-sm: 0.875rem;
+    --text-sm--line-height: calc(1.25 / 0.875);
+    --text-lg: 1.125rem;
+    --text-lg--line-height: calc(1.75 / 1.125);
+    --font-weight-semibold: 600;
+    --font-weight-bold: 700;
+    --tracking-wide: 0.025em;
+    --leading-tight: 1.25;
+    --radius-lg: 0.5rem;
+    --default-font-family: var(--font-sans);
+    --default-mono-font-family: var(--font-mono);
+  }
+}
+@layer base {
+  *, ::after, ::before, ::backdrop, ::file-selector-button {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    border: 0 solid;
+  }
+  html, :host {
+    line-height: 1.5;
+    -webkit-text-size-adjust: 100%;
+    tab-size: 4;
+    font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji");
+    font-feature-settings: var(--default-font-feature-settings, normal);
+    font-variation-settings: var(--default-font-variation-settings, normal);
+    -webkit-tap-highlight-color: transparent;
+  }
+  hr {
+    height: 0;
+    color: inherit;
+    border-top-width: 1px;
+  }
+  abbr:where([title]) {
+    -webkit-text-decoration: underline dotted;
+    text-decoration: underline dotted;
+  }
+  h1, h2, h3, h4, h5, h6 {
+    font-size: inherit;
+    font-weight: inherit;
+  }
+  a {
+    color: inherit;
+    -webkit-text-decoration: inherit;
+    text-decoration: inherit;
+  }
+  b, strong {
+    font-weight: bolder;
+  }
+  code, kbd, samp, pre {
+    font-family: var(--default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace);
+    font-feature-settings: var(--default-mono-font-feature-settings, normal);
+    font-variation-settings: var(--default-mono-font-variation-settings, normal);
+    font-size: 1em;
+  }
+  small {
+    font-size: 80%;
+  }
+  sub, sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+  sub {
+    bottom: -0.25em;
+  }
+  sup {
+    top: -0.5em;
+  }
+  table {
+    text-indent: 0;
+    border-color: inherit;
+    border-collapse: collapse;
+  }
+  :-moz-focusring {
+    outline: auto;
+  }
+  progress {
+    vertical-align: baseline;
+  }
+  summary {
+    display: list-item;
+  }
+  ol, ul, menu {
+    list-style: none;
+  }
+  img, svg, video, canvas, audio, iframe, embed, object {
+    display: block;
+    vertical-align: middle;
+  }
+  img, video {
+    max-width: 100%;
+    height: auto;
+  }
+  button, input, select, optgroup, textarea, ::file-selector-button {
+    font: inherit;
+    font-feature-settings: inherit;
+    font-variation-settings: inherit;
+    letter-spacing: inherit;
+    color: inherit;
+    border-radius: 0;
+    background-color: transparent;
+    opacity: 1;
+  }
+  :where(select:is([multiple], [size])) optgroup {
+    font-weight: bolder;
+  }
+  :where(select:is([multiple], [size])) optgroup option {
+    padding-inline-start: 20px;
+  }
+  ::file-selector-button {
+    margin-inline-end: 4px;
+  }
+  ::placeholder {
+    opacity: 1;
+  }
+  @supports (not (-webkit-appearance: -apple-pay-button))  or (contain-intrinsic-size: 1px) {
+    ::placeholder {
+      color: currentcolor;
+      @supports (color: color-mix(in lab, red, red)) {
+        color: color-mix(in oklab, currentcolor 50%, transparent);
+      }
+    }
+  }
+  textarea {
+    resize: vertical;
+  }
+  ::-webkit-search-decoration {
+    -webkit-appearance: none;
+  }
+  ::-webkit-date-and-time-value {
+    min-height: 1lh;
+    text-align: inherit;
+  }
+  ::-webkit-datetime-edit {
+    display: inline-flex;
+  }
+  ::-webkit-datetime-edit-fields-wrapper {
+    padding: 0;
+  }
+  ::-webkit-datetime-edit, ::-webkit-datetime-edit-year-field, ::-webkit-datetime-edit-month-field, ::-webkit-datetime-edit-day-field, ::-webkit-datetime-edit-hour-field, ::-webkit-datetime-edit-minute-field, ::-webkit-datetime-edit-second-field, ::-webkit-datetime-edit-millisecond-field, ::-webkit-datetime-edit-meridiem-field {
+    padding-block: 0;
+  }
+  ::-webkit-calendar-picker-indicator {
+    line-height: 1;
+  }
+  :-moz-ui-invalid {
+    box-shadow: none;
+  }
+  button, input:where([type="button"], [type="reset"], [type="submit"]), ::file-selector-button {
+    appearance: button;
+  }
+  ::-webkit-inner-spin-button, ::-webkit-outer-spin-button {
+    height: auto;
+  }
+  [hidden]:where(:not([hidden="until-found"])) {
+    display: none !important;
+  }
+}
+@layer utilities {
+  .m-0 {
+    margin: calc(var(--spacing) * 0);
+  }
+  .gap-3 {
+    gap: calc(var(--spacing) * 3);
+  }
+  .rounded-lg {
+    border-radius: var(--radius-lg);
+  }
+  .border-slate-200 {
+    border-color: var(--color-slate-200);
+  }
+  .bg-slate-100 {
+    background-color: var(--color-slate-100);
+  }
+  .bg-transparent {
+    background-color: transparent;
+  }
+  .bg-white {
+    background-color: var(--color-white);
+  }
+  .p-4 {
+    padding: calc(var(--spacing) * 4);
+  }
+  .px-1 {
+    padding-inline: calc(var(--spacing) * 1);
+  }
+  .py-0\.5 {
+    padding-block: calc(var(--spacing) * 0.5);
+  }
+  .font-sans {
+    font-family: var(--font-sans);
+  }
+  .text-lg {
+    font-size: var(--text-lg);
+    line-height: var(--tw-leading, var(--text-lg--line-height));
+  }
+  .text-sm {
+    font-size: var(--text-sm);
+    line-height: var(--tw-leading, var(--text-sm--line-height));
+  }
+  .text-xs {
+    font-size: var(--text-xs);
+    line-height: var(--tw-leading, var(--text-xs--line-height));
+  }
+  .leading-6 {
+    --tw-leading: calc(var(--spacing) * 6);
+    line-height: calc(var(--spacing) * 6);
+  }
+  .leading-tight {
+    --tw-leading: var(--leading-tight);
+    line-height: var(--leading-tight);
+  }
+  .font-bold {
+    --tw-font-weight: var(--font-weight-bold);
+    font-weight: var(--font-weight-bold);
+  }
+  .font-semibold {
+    --tw-font-weight: var(--font-weight-semibold);
+    font-weight: var(--font-weight-semibold);
+  }
+  .tracking-wide {
+    --tw-tracking: var(--tracking-wide);
+    letter-spacing: var(--tracking-wide);
+  }
+  .text-emerald-700 {
+    color: var(--color-emerald-700);
+  }
+  .text-slate-600 {
+    color: var(--color-slate-600);
+  }
+  .text-slate-950 {
+    color: var(--color-slate-950);
+  }
+  .shadow-sm {
+    --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+}
+@property --tw-leading {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-font-weight {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-tracking {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+@property --tw-shadow-color {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-shadow-alpha {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 100%;
+}
+@property --tw-inset-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+@property --tw-inset-shadow-color {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-inset-shadow-alpha {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 100%;
+}
+@property --tw-ring-color {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-ring-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+@property --tw-inset-ring-color {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-inset-ring-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+@property --tw-ring-inset {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-ring-offset-width {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 0px;
+}
+@property --tw-ring-offset-color {
+  syntax: "*";
+  inherits: false;
+  initial-value: #fff;
+}
+@property --tw-ring-offset-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+@layer properties {
+  @supports ((-webkit-hyphens: none) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color:rgb(from red r g b)))) {
+    *, ::before, ::after, ::backdrop {
+      --tw-leading: initial;
+      --tw-font-weight: initial;
+      --tw-tracking: initial;
+      --tw-shadow: 0 0 #0000;
+      --tw-shadow-color: initial;
+      --tw-shadow-alpha: 100%;
+      --tw-inset-shadow: 0 0 #0000;
+      --tw-inset-shadow-color: initial;
+      --tw-inset-shadow-alpha: 100%;
+      --tw-ring-color: initial;
+      --tw-ring-shadow: 0 0 #0000;
+      --tw-inset-ring-color: initial;
+      --tw-inset-ring-shadow: 0 0 #0000;
+      --tw-ring-inset: initial;
+      --tw-ring-offset-width: 0px;
+      --tw-ring-offset-color: #fff;
+      --tw-ring-offset-shadow: 0 0 #0000;
+    }
+  }
+}
+
+</style>
+	</head>
+	<body class="m-0 bg-transparent font-sans text-slate-950">
+		<main class="grid gap-3 rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+			<p class="m-0 text-xs font-semibold uppercase tracking-wide text-emerald-700">
+				Built iframe embed
+			</p>
+			<h1 class="m-0 text-lg font-bold leading-tight">Tailwind utilities, static CSS</h1>
+			<p class="m-0 text-sm leading-6 text-slate-600">
+				This file builds to <code class="rounded bg-slate-100 px-1 py-0.5">tailwind-card.dist.html</code>
+				so Hubble can embed it without loading Tailwind in the iframe.
+			</p>
+		</main>
+	</body>
+</html>

--- a/apps/desktop/fixtures/playground/tailwind-card.html
+++ b/apps/desktop/fixtures/playground/tailwind-card.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Tailwind embed card</title>
+	</head>
+	<body class="m-0 bg-transparent font-sans text-slate-950">
+		<main class="grid gap-3 rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+			<p class="m-0 text-xs font-semibold uppercase tracking-wide text-emerald-700">
+				Built iframe embed
+			</p>
+			<h1 class="m-0 text-lg font-bold leading-tight">Tailwind utilities, static CSS</h1>
+			<p class="m-0 text-sm leading-6 text-slate-600">
+				This file builds to <code class="rounded bg-slate-100 px-1 py-0.5">tailwind-card.dist.html</code>
+				so Hubble can embed it without loading Tailwind in the iframe.
+			</p>
+		</main>
+	</body>
+</html>

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -24,6 +24,7 @@
 		"bundle:linux": "pnpm build && electron-builder --linux",
 		"bundle:linux:arm64": "pnpm build && electron-builder --linux --arm64",
 		"preview": "vite preview",
+		"build:html-embed": "node scripts/build-html-embed.mjs",
 		"sync:playground": "node scripts/sync-playground.mjs",
 		"test": "vitest run"
 	},

--- a/apps/desktop/scripts/build-html-embed.mjs
+++ b/apps/desktop/scripts/build-html-embed.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { compile } from "tailwindcss";
+
+const require = createRequire(import.meta.url);
+
+const sourceArg = process.argv[2];
+const outputArg = process.argv[3];
+const callerCwd = process.env.INIT_CWD ?? process.cwd();
+
+if (
+	!sourceArg ||
+	process.argv.includes("--help") ||
+	process.argv.includes("-h")
+) {
+	console.log(`Usage: pnpm --filter @hubble.md/desktop build:html-embed <source.html> [output.html]
+
+Builds a local HTML App or iframe Embed with Tailwind v4 utilities inlined.
+Default output: <source>.dist.html`);
+	process.exit(sourceArg ? 0 : 1);
+}
+
+const sourcePath = path.resolve(callerCwd, sourceArg);
+const outputPath = outputArg
+	? path.resolve(callerCwd, outputArg)
+	: sourcePath.replace(/\.html$/i, ".dist.html");
+
+if (sourcePath === outputPath) {
+	throw new Error("Output path must differ from source path.");
+}
+
+const html = await readFile(sourcePath, "utf8");
+const classNames = extractClassNames(html);
+const compiler = await compile('@import "tailwindcss";', {
+	base: path.dirname(sourcePath),
+	loadStylesheet,
+});
+const css = compiler.build(classNames);
+const builtHtml = injectBuiltCss(html, css, classNames.length);
+
+await writeFile(outputPath, builtHtml);
+console.log(`Built ${path.relative(process.cwd(), outputPath)}`);
+
+function extractClassNames(html) {
+	const classes = new Set();
+	const attributePattern =
+		/(?:class|:class|x-bind:class)\s*=\s*(?:"([^"]*)"|'([^']*)')/gi;
+	for (const match of html.matchAll(attributePattern)) {
+		const value = match[1] ?? match[2] ?? "";
+		for (const token of value.matchAll(/[A-Za-z0-9_:/![\].%#()@-]+/g)) {
+			const className = token[0];
+			if (isTailwindCandidate(className)) classes.add(className);
+		}
+	}
+	return [...classes].sort();
+}
+
+function isTailwindCandidate(value) {
+	if (!value || value === "true" || value === "false") return false;
+	if (/^\d+$/.test(value)) return false;
+	return /[-:[\]/]/.test(value) || /^[mp][trblxyise]?-\d/.test(value);
+}
+
+async function loadStylesheet(id, base) {
+	const filePath = stylesheetPath(id, base);
+	return {
+		content: await readFile(filePath, "utf8"),
+		base: path.dirname(filePath),
+	};
+}
+
+function stylesheetPath(id, base) {
+	if (id === "tailwindcss") return require.resolve("tailwindcss/index.css");
+	if (id.startsWith("tailwindcss/")) return require.resolve(id);
+	return path.resolve(base, id);
+}
+
+function injectBuiltCss(html, css, classCount) {
+	const withoutTailwindRuntime = html
+		.replace(
+			/<script\b[^>]*\bsrc=(["'])https:\/\/cdn\.tailwindcss\.com\/?\1[^>]*><\/script>\s*/gi,
+			"",
+		)
+		.replace(
+			/<script\b[^>]*\bsrc=(["'])https:\/\/unpkg\.com\/@tailwindcss\/browser[^>]*><\/script>\s*/gi,
+			"",
+		);
+	const style = `<style data-hubble-built-tailwind="v4" data-hubble-tailwind-classes="${classCount}">
+${css}
+</style>`;
+	if (/<\/head\s*>/i.test(withoutTailwindRuntime)) {
+		return withoutTailwindRuntime.replace(
+			/<\/head\s*>/i,
+			`${style}\n\t</head>`,
+		);
+	}
+	return `${style}\n${withoutTailwindRuntime}`;
+}

--- a/biome.json
+++ b/biome.json
@@ -54,6 +54,16 @@
 					}
 				}
 			}
+		},
+		{
+			"includes": ["**/*.dist.html"],
+			"linter": {
+				"rules": {
+					"complexity": {
+						"noImportantStyles": "off"
+					}
+				}
+			}
 		}
 	]
 }


### PR DESCRIPTION
Closes #55

Summary:
- add `build:html-embed` for compiling Tailwind v4 utilities into local HTML embed artifacts
- add a playground `tailwind-card.html` source and generated `tailwind-card.dist.html` embed
- document the source/output convention for agents and contributors

Validation:
- `pnpm --filter @hubble.md/desktop build:html-embed apps/desktop/fixtures/playground/tailwind-card.html`
- `pnpm check`
- `pnpm build:desktop`
- `git diff --check`

E2E:
- Not run; this is build tooling plus a static playground embed artifact. The generated `.dist.html` was smoke-built and linked from the playground note.

Notes:
- Build logs include the existing apps/web Node 22.x engine warning under the current runtime.