### PR TITLE
Cross-platform, consistent keyboard shortcut hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 ### Added
 
 ### Changed
+- Keyboard shortcut hints now show the correct keys on Windows and Linux (Ctrl/Alt instead of macOS symbols)
+- More buttons and menus now show their keyboard shortcut, including the format and slash command menus
 
 ### Fixed
 

--- a/apps/desktop/src/components/Toolbar.tsx
+++ b/apps/desktop/src/components/Toolbar.tsx
@@ -1,5 +1,9 @@
 import { Menu } from "@base-ui/react/menu";
-import { Button, Toolbar as SharedToolbar } from "@hubble.md/ui";
+import {
+	Button,
+	formatShortcut,
+	Toolbar as SharedToolbar,
+} from "@hubble.md/ui";
 import { useStoreValue } from "@simplestack/store/react";
 import { type CSSProperties, useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -105,7 +109,7 @@ function NoteActionsMenu({ path }: { path: string }) {
 							<span className="min-w-0 flex-1">
 								{revealFileLabel(desktopApi.platform)}
 							</span>
-							<ShortcutHint>⌘⌥R</ShortcutHint>
+							<ShortcutHint>{formatShortcut("CmdOrCtrl+Alt+R")}</ShortcutHint>
 						</Menu.Item>
 						<Menu.Item
 							className="flex w-full cursor-pointer items-center gap-2 rounded-sm [padding-block:0.375rem] [padding-inline:0.5rem] text-start text-[11px] outline-hidden select-none data-highlighted:bg-accent"
@@ -113,7 +117,7 @@ function NoteActionsMenu({ path }: { path: string }) {
 						>
 							<MingcuteCopy2Line className="size-3 shrink-0" />
 							<span className="min-w-0 flex-1">Copy file path</span>
-							<ShortcutHint>⌘⇧C</ShortcutHint>
+							<ShortcutHint>{formatShortcut("CmdOrCtrl+Shift+C")}</ShortcutHint>
 						</Menu.Item>
 					</Menu.Popup>
 				</Menu.Positioner>

--- a/apps/desktop/src/components/WorkspaceSwitcher.tsx
+++ b/apps/desktop/src/components/WorkspaceSwitcher.tsx
@@ -1,4 +1,4 @@
-import { WorkspaceSwitcherMenu } from "@hubble.md/ui";
+import { formatShortcut, WorkspaceSwitcherMenu } from "@hubble.md/ui";
 import { useStoreValue } from "@simplestack/store/react";
 import MingcuteAddLine from "~icons/mingcute/add-line";
 import { openWorkspace, setWorkspaceSwitcherOpen } from "../store/actions";
@@ -23,7 +23,7 @@ export function WorkspaceSwitcher() {
 	return (
 		<WorkspaceSwitcherMenu
 			label={workspaceName}
-			title={workspacePath}
+			title={`${workspacePath} (${formatShortcut("CmdOrCtrl+Shift+O")})`}
 			open={open}
 			onOpenChange={setWorkspaceSwitcherOpen}
 		>
@@ -43,7 +43,13 @@ export function WorkspaceSwitcher() {
 				icon={<MingcuteAddLine className="size-3 shrink-0" />}
 				onClick={() => void openWorkspace()}
 			>
-				Add folder...
+				<span className="flex-1">Add folder...</span>
+				<span
+					className="ms-auto shrink-0 text-[11px] leading-none text-muted-foreground/60"
+					aria-hidden="true"
+				>
+					{formatShortcut("CmdOrCtrl+Shift+N")}
+				</span>
 			</WorkspaceSwitcherMenu.Item>
 		</WorkspaceSwitcherMenu>
 	);

--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -45,6 +45,7 @@ import {
 	splitFileName,
 } from "../lib/filePath";
 import { shouldShowFooterDivider } from "../lib/scrollOverflow";
+import { formatShortcut } from "../lib/shortcut";
 import { cn } from "../lib/utils";
 import { Button } from "../primitives/button";
 import { useSidebarKeyboardNav } from "./useSidebarKeyboardNav";
@@ -1115,7 +1116,7 @@ export function Sidebar({
 							variant="ghost"
 							size="icon-xs"
 							aria-label="New file"
-							title="New file"
+							title={`New file (${formatShortcut("CmdOrCtrl+N")})`}
 							onClick={() => void createFile(null)}
 						>
 							<MingcuteEditLine className="size-3.5" />
@@ -1685,7 +1686,7 @@ function FolderActionsMenu({
 				<ActionItem
 					icon={<MingcuteFolderOpenLine />}
 					onClick={() => onRevealFolder(id)}
-					shortcut="⌘⌥R"
+					shortcut={formatShortcut("CmdOrCtrl+Alt+R")}
 				>
 					{revealLabel ?? "Reveal in File Manager"}
 				</ActionItem>
@@ -1694,6 +1695,7 @@ function FolderActionsMenu({
 				<ActionItem
 					icon={<MingcuteEditLine />}
 					onClick={() => onCreateFile(id)}
+					shortcut={formatShortcut("CmdOrCtrl+N")}
 				>
 					New file
 				</ActionItem>
@@ -1760,7 +1762,7 @@ function FileActionsMenu({
 				<ActionItem
 					icon={<MingcuteFolderOpenLine />}
 					onClick={() => onRevealFile(file.path)}
-					shortcut="⌘⌥R"
+					shortcut={formatShortcut("CmdOrCtrl+Alt+R")}
 				>
 					{revealLabel ?? "Reveal in File Manager"}
 				</ActionItem>
@@ -1769,7 +1771,7 @@ function FileActionsMenu({
 				<ActionItem
 					icon={<MingcuteCopy2Line />}
 					onClick={() => onCopyFilePath(file.path)}
-					shortcut="⌘⇧C"
+					shortcut={formatShortcut("CmdOrCtrl+Shift+C")}
 				>
 					Copy file path
 				</ActionItem>

--- a/packages/ui/src/components/Toolbar.tsx
+++ b/packages/ui/src/components/Toolbar.tsx
@@ -9,6 +9,7 @@ import {
 import MingcuteAddLine from "~icons/mingcute/add-line";
 import MingcuteLayoutLeftLine from "~icons/mingcute/layout-left-line";
 import { fileNameFromPath } from "../lib/filePath";
+import { formatShortcut } from "../lib/shortcut";
 import { Button } from "../primitives/button";
 
 const START_INSET = isMac() ? "var(--hubble-traffic-light-inset, 70px)" : "8px";
@@ -119,6 +120,7 @@ export function Toolbar({
 							className="relative"
 							onClick={onToggleSidebar}
 							aria-label="Toggle sidebar"
+							title={`Toggle sidebar (${formatShortcut("CmdOrCtrl+Shift+E")})`}
 						>
 							<MingcuteLayoutLeftLine className="size-4" />
 							{sidebarBadge ? (
@@ -179,7 +181,7 @@ export function NewNoteButton({ onClick }: { onClick: () => void }) {
 			size="icon-sm"
 			onClick={onClick}
 			aria-label="New Markdown File"
-			title="New Markdown File (⌘N)"
+			title={`New Markdown File (${formatShortcut("CmdOrCtrl+N")})`}
 		>
 			<MingcuteAddLine className="size-4" />
 		</Button>

--- a/packages/ui/src/editor/FormatCommandMenu.tsx
+++ b/packages/ui/src/editor/FormatCommandMenu.tsx
@@ -23,6 +23,7 @@ import MingcuteListOrderedLine from "~icons/mingcute/list-ordered-line";
 import MingcuteQuoteLeftLine from "~icons/mingcute/quote-left-line";
 import MingcuteStrikethroughLine from "~icons/mingcute/strikethrough-line";
 import MingcuteTextLine from "~icons/mingcute/text-line";
+import { formatShortcut } from "../lib/shortcut";
 import { cn } from "../lib/utils";
 import { useCommandMenuPosition } from "./commandMenuPosition";
 
@@ -48,6 +49,9 @@ type FormatCommand = {
 	aliases: string[];
 	icon: ComponentType<{ className?: string }>;
 	group: "Block" | "Inline";
+	// Platform-agnostic accelerator spec (e.g. "CmdOrCtrl+Shift+8"), rendered
+	// per-platform via formatShortcut. Omit when the command has no shortcut.
+	shortcut?: string;
 };
 
 type MenuPosition = {
@@ -95,6 +99,7 @@ const FORMAT_COMMANDS: FormatCommand[] = [
 		aliases: ["bullet", "bullets", "ul", "list"],
 		icon: MingcuteListCheckLine,
 		group: "Block",
+		shortcut: "CmdOrCtrl+Shift+8",
 	},
 	{
 		kind: "orderedList",
@@ -103,6 +108,7 @@ const FORMAT_COMMANDS: FormatCommand[] = [
 		aliases: ["number", "numbered", "ol", "1."],
 		icon: MingcuteListOrderedLine,
 		group: "Block",
+		shortcut: "CmdOrCtrl+Shift+7",
 	},
 	{
 		kind: "taskList",
@@ -111,6 +117,7 @@ const FORMAT_COMMANDS: FormatCommand[] = [
 		aliases: ["todo", "task", "check", "checkbox"],
 		icon: MingcuteListCheck2Line,
 		group: "Block",
+		shortcut: "CmdOrCtrl+Shift+9",
 	},
 	{
 		kind: "blockquote",
@@ -135,6 +142,7 @@ const FORMAT_COMMANDS: FormatCommand[] = [
 		aliases: ["strong", "b"],
 		icon: MingcuteBoldLine,
 		group: "Inline",
+		shortcut: "CmdOrCtrl+B",
 	},
 	{
 		kind: "italic",
@@ -143,6 +151,7 @@ const FORMAT_COMMANDS: FormatCommand[] = [
 		aliases: ["emphasis", "i"],
 		icon: MingcuteItalicLine,
 		group: "Inline",
+		shortcut: "CmdOrCtrl+I",
 	},
 	{
 		kind: "strike",
@@ -151,6 +160,7 @@ const FORMAT_COMMANDS: FormatCommand[] = [
 		aliases: ["strike", "s", "delete"],
 		icon: MingcuteStrikethroughLine,
 		group: "Inline",
+		shortcut: "CmdOrCtrl+Shift+X",
 	},
 	{
 		kind: "link",
@@ -159,6 +169,7 @@ const FORMAT_COMMANDS: FormatCommand[] = [
 		aliases: ["url", "href", "wiki"],
 		icon: MingcuteLinkLine,
 		group: "Inline",
+		shortcut: "CmdOrCtrl+K",
 	},
 ];
 
@@ -313,9 +324,16 @@ function renderGroup(
 						<span className="block min-w-0 flex-1 truncate text-foreground">
 							{command.title}
 						</span>
-						{isApplied && (
+						{isApplied ? (
 							<MingcuteCheckLine className="size-3.5 shrink-0 text-muted-foreground" />
-						)}
+						) : command.shortcut ? (
+							<span
+								className="shrink-0 text-[10px] leading-none text-muted-foreground/60"
+								aria-hidden="true"
+							>
+								{formatShortcut(command.shortcut)}
+							</span>
+						) : null}
 					</Command.Item>
 				);
 			})}

--- a/packages/ui/src/editor/SlashCommandMenu.tsx
+++ b/packages/ui/src/editor/SlashCommandMenu.tsx
@@ -17,6 +17,7 @@ import MingcuteListOrderedLine from "~icons/mingcute/list-ordered-line";
 import MingcuteQuoteLeftLine from "~icons/mingcute/quote-left-line";
 import MingcuteStrikethroughLine from "~icons/mingcute/strikethrough-line";
 import MingcuteTextLine from "~icons/mingcute/text-line";
+import { formatShortcut } from "../lib/shortcut";
 import { cn } from "../lib/utils";
 import { useCommandMenuPosition } from "./commandMenuPosition";
 import {
@@ -32,6 +33,9 @@ type SlashCommand = {
 	description: string;
 	aliases: string[];
 	icon: ComponentType<{ className?: string }>;
+	// Platform-agnostic accelerator spec (e.g. "CmdOrCtrl+Shift+8"), rendered
+	// per-platform via formatShortcut. Omit when the command has no shortcut.
+	shortcut?: string;
 };
 
 type MenuPosition = {
@@ -74,6 +78,7 @@ const SLASH_COMMANDS: SlashCommand[] = [
 		description: "Create a simple list",
 		aliases: ["bullet", "bullets", "ul", "list"],
 		icon: MingcuteListCheckLine,
+		shortcut: "CmdOrCtrl+Shift+8",
 	},
 	{
 		kind: "orderedList",
@@ -81,6 +86,7 @@ const SLASH_COMMANDS: SlashCommand[] = [
 		description: "Create an ordered list",
 		aliases: ["number", "numbered", "ol", "1."],
 		icon: MingcuteListOrderedLine,
+		shortcut: "CmdOrCtrl+Shift+7",
 	},
 	{
 		kind: "taskList",
@@ -88,6 +94,7 @@ const SLASH_COMMANDS: SlashCommand[] = [
 		description: "Create a task list",
 		aliases: ["todo", "task", "check", "checkbox"],
 		icon: MingcuteListCheck2Line,
+		shortcut: "CmdOrCtrl+Shift+9",
 	},
 	{
 		kind: "blockquote",
@@ -109,6 +116,7 @@ const SLASH_COMMANDS: SlashCommand[] = [
 		description: "Toggle strikethrough",
 		aliases: ["strike", "s", "delete"],
 		icon: MingcuteStrikethroughLine,
+		shortcut: "CmdOrCtrl+Shift+X",
 	},
 ];
 
@@ -293,6 +301,14 @@ export function SlashCommandMenu({
 								<span className="block min-w-0 flex-1 truncate text-foreground">
 									{command.title}
 								</span>
+								{command.shortcut && (
+									<span
+										className="shrink-0 text-[10px] leading-none text-muted-foreground/60"
+										aria-hidden="true"
+									>
+										{formatShortcut(command.shortcut)}
+									</span>
+								)}
 							</Command.Item>
 						);
 					})}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -21,6 +21,7 @@ export { LinkCreationGhostExtension } from "./editor/LinkCreationGhostExtension"
 export { SmartLinkExtension } from "./editor/SmartLinkExtension";
 export { VirtualCursor } from "./editor/VirtualCursor";
 export type { VirtualCursorMode } from "./editor/virtualCursorMode";
+export { formatShortcut } from "./lib/shortcut";
 export { Button, buttonVariants } from "./primitives/button";
 export { Input } from "./primitives/input";
 export { Modal } from "./primitives/modal";

--- a/packages/ui/src/lib/shortcut.test.ts
+++ b/packages/ui/src/lib/shortcut.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const isMac = vi.fn();
+vi.mock("keymatch", () => ({ isMac: () => isMac() }));
+
+const { formatShortcut } = await import("./shortcut");
+
+afterEach(() => {
+	isMac.mockReset();
+});
+
+describe("formatShortcut", () => {
+	it("renders adjacent glyphs on macOS", () => {
+		isMac.mockReturnValue(true);
+		expect(formatShortcut("CmdOrCtrl+N")).toBe("⌘N");
+		expect(formatShortcut("CmdOrCtrl+Alt+R")).toBe("⌘⌥R");
+		expect(formatShortcut("CmdOrCtrl+Shift+C")).toBe("⌘⇧C");
+	});
+
+	it("renders +-joined words on Windows/Linux", () => {
+		isMac.mockReturnValue(false);
+		expect(formatShortcut("CmdOrCtrl+N")).toBe("Ctrl+N");
+		expect(formatShortcut("CmdOrCtrl+Alt+R")).toBe("Ctrl+Alt+R");
+		expect(formatShortcut("CmdOrCtrl+Shift+C")).toBe("Ctrl+Shift+C");
+	});
+
+	it("uppercases bare letter keys and leaves other keys intact", () => {
+		isMac.mockReturnValue(false);
+		expect(formatShortcut("CmdOrCtrl+,")).toBe("Ctrl+,");
+		expect(formatShortcut("Alt+Enter")).toBe("Alt+Enter");
+	});
+});

--- a/packages/ui/src/lib/shortcut.ts
+++ b/packages/ui/src/lib/shortcut.ts
@@ -1,0 +1,55 @@
+import { isMac } from "keymatch";
+
+// macOS renders modifiers as adjacent glyphs (⌘⌥R); Windows/Linux use
+// "+"-joined words (Ctrl+Alt+R). Keys are matched against the same
+// "CmdOrCtrl+..." accelerator syntax used by keymatch and Electron menus, so a
+// shortcut's display string and its matcher stay in sync.
+const MAC_SYMBOLS: Record<string, string> = {
+	mod: "⌘",
+	cmd: "⌘",
+	command: "⌘",
+	cmdorctrl: "⌘",
+	commandorcontrol: "⌘",
+	ctrl: "⌃",
+	control: "⌃",
+	alt: "⌥",
+	option: "⌥",
+	opt: "⌥",
+	shift: "⇧",
+	enter: "⏎",
+	return: "⏎",
+};
+
+const OTHER_WORDS: Record<string, string> = {
+	mod: "Ctrl",
+	cmd: "Ctrl",
+	command: "Ctrl",
+	cmdorctrl: "Ctrl",
+	commandorcontrol: "Ctrl",
+	ctrl: "Ctrl",
+	control: "Ctrl",
+	alt: "Alt",
+	option: "Alt",
+	opt: "Alt",
+	shift: "Shift",
+	enter: "Enter",
+	return: "Enter",
+};
+
+/**
+ * Formats a platform-agnostic shortcut spec into a display string.
+ *
+ * @example formatShortcut("CmdOrCtrl+Alt+R") // "⌘⌥R" on macOS, "Ctrl+Alt+R" elsewhere
+ */
+export function formatShortcut(spec: string): string {
+	const mac = isMac();
+	const map = mac ? MAC_SYMBOLS : OTHER_WORDS;
+	const rendered = spec.split("+").map((raw) => {
+		const part = raw.trim();
+		const mapped = map[part.toLowerCase()];
+		if (mapped) return mapped;
+		// A bare key (letter, digit, punctuation): uppercase single letters.
+		return part.length === 1 ? part.toUpperCase() : part;
+	});
+	return mac ? rendered.join("") : rendered.join("+");
+}


### PR DESCRIPTION
## Description

Keyboard shortcut hints were hardcoded to macOS glyphs (`⌘`, `⌥`, `⇧`) and only shown for some actions. This makes them platform-aware and consistent.

- New `formatShortcut()` helper renders a `CmdOrCtrl+...` accelerator spec as macOS glyphs (`⌘⌥R`) or Windows/Linux words (`Ctrl+Alt+R`). It reuses the same syntax `keymatch` and the Electron menus already match on, so a displayed hint can't drift from the combo that fires.
- Routed the existing hardcoded hints (Reveal, Copy path, New file) through the helper.
- Surfaced the shortcut on every persistent button/menu item that mirrors a bound shortcut but previously showed nothing: sidebar toggle (`⌘⇧E`), New file button + folder-menu item (`⌘N`), workspace switcher trigger (`⌘⇧O`) and Add folder (`⌘⇧N`).
- Added a shortcut column to the format and slash command menus (lists `⌘⇧7/8/9`, strikethrough `⌘⇧X`, plus link/bold/italic in the format menu).

Only combos verified in source are advertised — actions with no bound shortcut (headings, quote, divider, etc.) stay blank rather than showing a guess.

Closes #136

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update

## Testing

- [x] Existing tests pass
- [x] Added new tests for changes
- [x] Tested manually (describe below)

**Manual Testing Details:**

Added a unit test (`packages/ui/src/lib/shortcut.test.ts`) covering both platform branches and key normalization. Verified `pnpm build:desktop` (build + typecheck for the desktop dependency chain) and `biome check` pass. macOS output is byte-identical to the previous hardcoded glyphs, so there is no visual change on Mac; Windows/Linux now render `Ctrl`/`Alt` words.

## Checklist

- [x] I discussed this change in a GitHub issue before submitting this PR
- [x] I have run the linter, formatter, and tests to ensure my code is ready for review
