### PR TITLE
feat(desktop): chat about this note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 
 ### Added
 - Terminal panel in the desktop app: toggle with Cmd+J to run shell commands in your workspace, with tabs, drag resize, and double click to rename
+- Chat about the open note with your agent CLI: pick it from the note's ⋯ menu or press Cmd+Shift+J, and customize the command in Settings
 - Add table support. Markdown tables now render as expected, and you can create new tables using `/table`. There are still editing features left to add, like adding and removing rows. Track progress on GitHub: [#99](https://github.com/bholmesdev/hubble.md/issues/99)
 - Create HTML Apps from the new file dropdown, folder menus, and the File menu
 - Empty HTML App files show a setup screen with the skill install command and a ready-to-copy agent prompt, with a check once the skills are detected

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -110,7 +110,8 @@ const desktopApi = {
 		subscribe("desktop:fullscreen-change", (isFullScreen: boolean) =>
 			callback(isFullScreen),
 		),
-	terminalStart: (cwd) => ipcRenderer.invoke("desktop:terminal-start", { cwd }),
+	terminalStart: (cwd, options) =>
+		ipcRenderer.invoke("desktop:terminal-start", { cwd, ...options }),
 	terminalWrite: (sessionId, data) =>
 		ipcRenderer.invoke("desktop:terminal-write", { sessionId, data }),
 	terminalResize: (sessionId, cols, rows) =>

--- a/apps/desktop/electron/terminal.ts
+++ b/apps/desktop/electron/terminal.ts
@@ -11,6 +11,12 @@ export type TerminalSession = {
 	kill: () => void;
 };
 
+type TerminalStartPayload = {
+	cwd: string;
+	notePath?: string;
+	initialCommand?: string;
+};
+
 const sessions: Record<string, TerminalSession> = {};
 let nextSessionId = 0;
 const TERMINAL_HISTORY_LIMIT = 64_000;
@@ -24,6 +30,13 @@ function getDefaultShell() {
 		return process.env.COMSPEC || "powershell.exe";
 	}
 	return process.env.SHELL || "/bin/sh";
+}
+
+function getTerminalEnv(notePath?: string) {
+	return {
+		...process.env,
+		...(notePath ? { HUBBLE_NOTE_PATH: notePath } : {}),
+	};
 }
 
 function ensureSpawnHelperExecutable() {
@@ -48,6 +61,7 @@ function ensureSpawnHelperExecutable() {
 
 function createPtySession(
 	cwd: string,
+	notePath: string | undefined,
 	onData: (data: string) => void,
 	onExit: () => void,
 ): TerminalSession | null {
@@ -65,7 +79,7 @@ function createPtySession(
 			cols: 80,
 			rows: 24,
 			cwd: cwd,
-			env: process.env,
+			env: getTerminalEnv(notePath),
 		});
 
 		ptyProcess.onData((data: string) => {
@@ -104,27 +118,48 @@ export function setupTerminalIpc(
 ) {
 	ipcMain.handle(
 		"desktop:terminal-start",
-		(_event, { cwd }: { cwd: string }) => {
+		(_event, { cwd, notePath, initialCommand }: TerminalStartPayload) => {
 			const sessionId = `term-${++nextSessionId}`;
 			let session: TerminalSession | null = null;
+			let initialCommandTimer: NodeJS.Timeout | null = null;
+			let didWriteInitialCommand = false;
+
+			const writeInitialCommand = () => {
+				if (!initialCommand || didWriteInitialCommand || !session) return;
+				didWriteInitialCommand = true;
+				if (initialCommandTimer) {
+					clearTimeout(initialCommandTimer);
+					initialCommandTimer = null;
+				}
+				session.write(`${initialCommand}\n`);
+			};
 
 			const onData = (data: string) => {
 				if (session) appendHistory(session, data);
 				sendToRenderer(`desktop:terminal-data-${sessionId}`, data);
+				writeInitialCommand();
 			};
 
 			const onExit = () => {
+				if (initialCommandTimer) {
+					clearTimeout(initialCommandTimer);
+					initialCommandTimer = null;
+				}
 				delete sessions[sessionId];
 				sendToRenderer(`desktop:terminal-exit-${sessionId}`);
 			};
 
-			session = createPtySession(cwd, onData, onExit);
+			session = createPtySession(cwd, notePath, onData, onExit);
 			if (!session) {
 				throw new Error("The bundled shell module (node-pty) failed to load.");
 			}
 
 			session.id = sessionId;
 			sessions[sessionId] = session;
+
+			if (initialCommand) {
+				initialCommandTimer = setTimeout(writeInitialCommand, 1200);
+			}
 
 			return sessionId;
 		},

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,11 +1,12 @@
 import { wikiDisplayNameForTarget } from "@hubble.md/editor";
-import { Button, EditorView, type WikiTarget } from "@hubble.md/ui";
+import { Button, EditorView, Input, type WikiTarget } from "@hubble.md/ui";
 import { useStoreValue } from "@simplestack/store/react";
 import { keymatch } from "keymatch";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
+import MingcutePencilLine from "~icons/mingcute/pencil-line";
 import { HtmlAppEmptyState } from "./components/HtmlAppEmptyState";
-import { SettingsDialog } from "./components/SettingsDialog";
+import { SettingsDialog, SettingsSection } from "./components/SettingsDialog";
 import { Sidebar } from "./components/Sidebar";
 import { TerminalPanel } from "./components/TerminalPanel";
 import { Toolbar } from "./components/Toolbar";
@@ -36,13 +37,16 @@ import {
 	refreshFiles,
 	refreshFilesDebounced,
 	reloadFromDiskConflict,
+	requestChatAboutNote,
 	savePathContent,
+	setChatCommand,
 	setSidebarOpen,
 	setWorkspaceSwitcherOpen,
 	toggleTerminal,
 	updateEditorContent,
 } from "./store/actions";
 import {
+	chatCommandStore,
 	sidebarOpenStore,
 	uiStore,
 	viewerStore,
@@ -209,6 +213,14 @@ function App() {
 				if (!path) return;
 				event.preventDefault();
 				await revealPath(path);
+			} else if (keymatch(event, "CmdOrCtrl+Shift+J")) {
+				if (
+					!viewerStore.get().currentPath ||
+					!workspaceStore.get().workspacePath
+				)
+					return;
+				event.preventDefault();
+				requestChatAboutNote();
 			} else if (keymatch(event, "CmdOrCtrl+Shift+E")) {
 				event.preventDefault();
 				const opening = !uiStore.get().sidebarOpen;
@@ -375,6 +387,7 @@ function App() {
 				</section>
 			</div>
 			<SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen}>
+				<ChatAboutNoteSettingsSection />
 				{updateState ? (
 					<UpdatesSection
 						state={updateState}
@@ -383,6 +396,30 @@ function App() {
 				) : null}
 			</SettingsDialog>
 		</main>
+	);
+}
+
+function ChatAboutNoteSettingsSection() {
+	const [draft, setDraft] = useState(() => chatCommandStore.get());
+
+	return (
+		<SettingsSection
+			title="Chat about this note"
+			description={`This command runs in a new terminal when you pick "Chat about this note" from a note's ⋯ menu. The shell replaces $HUBBLE_NOTE_PATH with the current note's file path.`}
+		>
+			<div className="relative">
+				<Input
+					className="font-mono pe-8"
+					spellCheck={false}
+					value={draft}
+					onChange={(event) => {
+						setDraft(event.currentTarget.value);
+						setChatCommand(event.currentTarget.value);
+					}}
+				/>
+				<MingcutePencilLine className="pointer-events-none absolute end-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground/60" />
+			</div>
+		</SettingsSection>
 	);
 }
 

--- a/apps/desktop/src/components/SettingsDialog.tsx
+++ b/apps/desktop/src/components/SettingsDialog.tsx
@@ -15,9 +15,9 @@ export function SettingsDialog({
 			open={open}
 			onOpenChange={onOpenChange}
 			title="Settings"
-			className="max-w-2xl"
+			className="max-w-xl"
 		>
-			<div className="flex flex-col gap-4">{children}</div>
+			<div className="flex flex-col divide-y divide-border">{children}</div>
 		</Modal>
 	);
 }
@@ -32,9 +32,9 @@ export function SettingsSection({
 	children: ReactNode;
 }) {
 	return (
-		<section className="flex flex-col gap-3">
-			<div className="flex flex-col gap-1">
-				<h3 className="text-sm font-semibold">{title}</h3>
+		<section className="flex flex-col gap-2.5 py-4 first:pt-0 last:pb-0">
+			<div className="flex flex-col gap-0.5">
+				<h3 className="text-[13px] font-medium">{title}</h3>
 				{description ? (
 					<p className="text-xs text-muted-foreground">{description}</p>
 				) : null}

--- a/apps/desktop/src/components/TerminalPanel.test.tsx
+++ b/apps/desktop/src/components/TerminalPanel.test.tsx
@@ -138,8 +138,9 @@ async function loadTerminalPanel(api: MockDesktopApi) {
 	});
 
 	const state = await import("../store/state");
+	const actions = await import("../store/actions");
 	const { TerminalPanel } = await import("./TerminalPanel");
-	return { ...state, TerminalPanel };
+	return { ...actions, ...state, TerminalPanel };
 }
 
 describe("TerminalPanel", () => {
@@ -183,7 +184,79 @@ describe("TerminalPanel", () => {
 			await flush();
 		});
 
-		expect(api.terminalStart).toHaveBeenCalledWith("/workspace-a");
+		expect(api.terminalStart).toHaveBeenCalledWith("/workspace-a", {});
+	});
+
+	it("starts one chat session with the pending command when opened", async () => {
+		const { api } = createDesktopApi();
+		const { appStore, requestChatAboutNote, setChatCommand, TerminalPanel } =
+			await loadTerminalPanel(api);
+
+		appStore.set((state) => ({
+			...state,
+			workspace: {
+				...state.workspace,
+				workspacePath: "/workspace-a",
+			},
+			document: {
+				...state.document,
+				currentPath: "/workspace-a/note.md",
+			},
+		}));
+		setChatCommand("claude --continue");
+		requestChatAboutNote();
+
+		await act(async () => {
+			root.render(<TerminalPanel />);
+			await flush();
+		});
+
+		expect(api.terminalStart).toHaveBeenCalledTimes(1);
+		expect(api.terminalStart).toHaveBeenCalledWith("/workspace-a", {
+			notePath: "/workspace-a/note.md",
+			initialCommand: "claude --continue",
+		});
+		expect(api.terminalWrite).not.toHaveBeenCalled();
+		expect(getSessionButtons(container)[0]?.textContent).toBe("claude");
+		expect(appStore.get().ui.pendingTerminalCommand).toBeNull();
+	});
+
+	it("starts one chat session when requested after the panel has mounted closed", async () => {
+		const { api } = createDesktopApi();
+		const { appStore, requestChatAboutNote, setChatCommand, TerminalPanel } =
+			await loadTerminalPanel(api);
+
+		appStore.set((state) => ({
+			...state,
+			workspace: {
+				...state.workspace,
+				workspacePath: "/workspace-a",
+			},
+			document: {
+				...state.document,
+				currentPath: "/workspace-a/note.md",
+			},
+		}));
+		setChatCommand("claude --continue");
+
+		await act(async () => {
+			root.render(<TerminalPanel />);
+			await flush();
+		});
+		expect(api.terminalStart).not.toHaveBeenCalled();
+
+		await act(async () => {
+			requestChatAboutNote();
+			await flush();
+		});
+
+		expect(api.terminalStart).toHaveBeenCalledTimes(1);
+		expect(api.terminalStart).toHaveBeenCalledWith("/workspace-a", {
+			notePath: "/workspace-a/note.md",
+			initialCommand: "claude --continue",
+		});
+		expect(getSessionButtons(container)[0]?.textContent).toBe("claude");
+		expect(appStore.get().ui.pendingTerminalCommand).toBeNull();
 	});
 
 	it("shows an error state when the shell backend fails to load", async () => {
@@ -244,7 +317,7 @@ describe("TerminalPanel", () => {
 			root.render(<TerminalPanel />);
 			await flush();
 		});
-		expect(api.terminalStart).toHaveBeenNthCalledWith(1, "/workspace-a");
+		expect(api.terminalStart).toHaveBeenNthCalledWith(1, "/workspace-a", {});
 
 		// Switch workspaces while the first shell is still starting.
 		await act(async () => {
@@ -264,7 +337,7 @@ describe("TerminalPanel", () => {
 		});
 
 		expect(api.terminalStop).toHaveBeenCalledWith("term-stale");
-		expect(api.terminalStart).toHaveBeenNthCalledWith(2, "/workspace-b");
+		expect(api.terminalStart).toHaveBeenNthCalledWith(2, "/workspace-b", {});
 		const sessionTitles = getSessionButtons(container).map(
 			(button) => button.textContent,
 		);
@@ -293,7 +366,7 @@ describe("TerminalPanel", () => {
 			await flush();
 		});
 
-		expect(api.terminalStart).toHaveBeenNthCalledWith(1, "/workspace-a");
+		expect(api.terminalStart).toHaveBeenNthCalledWith(1, "/workspace-a", {});
 
 		await act(async () => {
 			appStore.set((state) => ({
@@ -307,7 +380,7 @@ describe("TerminalPanel", () => {
 		});
 
 		expect(api.terminalStop).toHaveBeenCalledWith("term-1");
-		expect(api.terminalStart).toHaveBeenNthCalledWith(2, "/workspace-b");
+		expect(api.terminalStart).toHaveBeenNthCalledWith(2, "/workspace-b", {});
 
 		// Late exit events from the old workspace should be harmless after reset.
 		await act(async () => {
@@ -375,8 +448,8 @@ describe("TerminalPanel", () => {
 			await flush();
 		});
 
-		expect(api.terminalStart).toHaveBeenNthCalledWith(1, "/workspace-a");
-		expect(api.terminalStart).toHaveBeenNthCalledWith(2, "/workspace-a");
+		expect(api.terminalStart).toHaveBeenNthCalledWith(1, "/workspace-a", {});
+		expect(api.terminalStart).toHaveBeenNthCalledWith(2, "/workspace-a", {});
 		expect(getSessionButtons(container)).toHaveLength(2);
 		expect(getSessionButtons(container)[1]?.getAttribute("aria-pressed")).toBe(
 			"true",

--- a/apps/desktop/src/components/TerminalPanel.tsx
+++ b/apps/desktop/src/components/TerminalPanel.tsx
@@ -5,8 +5,17 @@ import { Terminal } from "@xterm/xterm";
 import { useEffect, useReducer, useRef, useState } from "react";
 import { desktopApi } from "../desktopApi";
 import { cn } from "../lib/utils";
-import { setTerminalOpen, toggleTerminal } from "../store/actions";
-import { terminalOpenStore, workspacePathStore } from "../store/state";
+import {
+	clearPendingTerminalCommand,
+	setTerminalOpen,
+	toggleTerminal,
+} from "../store/actions";
+import {
+	pendingTerminalCommandStore,
+	terminalOpenStore,
+	viewerStore,
+	workspacePathStore,
+} from "../store/state";
 import "@xterm/xterm/css/xterm.css";
 import MingcuteAddLine from "~icons/mingcute/add-line";
 import MingcuteCloseLine from "~icons/mingcute/close-line";
@@ -154,6 +163,7 @@ const DARK_THEME = {
 export function TerminalPanel() {
 	const isOpen = useStoreValue(terminalOpenStore);
 	const workspacePath = useStoreValue(workspacePathStore);
+	const pendingTerminalCommand = useStoreValue(pendingTerminalCommandStore);
 	const [{ sessions, activeSessionId }, dispatch] = useReducer(
 		terminalStateReducer,
 		EMPTY_TERMINAL_STATE,
@@ -219,33 +229,53 @@ export function TerminalPanel() {
 		);
 	}, [sessions, workspacePath]);
 
-	// Create a new session when the panel is opened and there are no sessions
-	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional
+	// Start sessions while the panel is open: a pending chat command gets its
+	// own tab; otherwise an empty panel boots a plain shell. sessions.length
+	// retries a chat launch that arrived while another session was starting.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: startSession is render-local
 	useEffect(() => {
-		if (
-			isOpen &&
-			sessions.length === 0 &&
-			workspacePath &&
-			!isInitializingRef.current
-		) {
-			isInitializingRef.current = true;
-			void handleNewSession();
-		}
-	}, [isOpen, sessions.length, workspacePath]);
+		if (!isOpen || !workspacePath || isInitializingRef.current) return;
+		if (!pendingTerminalCommand && sessions.length > 0) return;
 
-	const handleNewSession = async () => {
+		isInitializingRef.current = true;
+		void (async () => {
+			try {
+				if (pendingTerminalCommand) {
+					await startSession(
+						pendingTerminalCommand.split(/\s+/, 1)[0] || "chat",
+						{ initialCommand: pendingTerminalCommand },
+					);
+					clearPendingTerminalCommand();
+				} else {
+					await startSession("bash");
+				}
+			} finally {
+				isInitializingRef.current = false;
+			}
+		})();
+	}, [isOpen, pendingTerminalCommand, workspacePath, sessions.length]);
+
+	const startSession = async (
+		title: string,
+		options: { initialCommand?: string } = {},
+	) => {
 		setStartError(null);
 		try {
 			while (true) {
 				const requestedWorkspacePath = workspacePathStore.get();
 				if (!requestedWorkspacePath) return;
+				const notePath = viewerStore.get().currentPath ?? undefined;
 				const sessionId = await desktopApi.terminalStart(
 					requestedWorkspacePath,
+					{
+						...(notePath ? { notePath } : {}),
+						...options,
+					},
 				);
 				if (workspacePathStore.get() === requestedWorkspacePath) {
 					dispatch({
 						type: "add",
-						session: { id: sessionId, title: "bash" },
+						session: { id: sessionId, title },
 					});
 					return;
 				}
@@ -259,8 +289,6 @@ export function TerminalPanel() {
 			setStartError(
 				"Terminal unavailable. The bundled shell module failed to load.",
 			);
-		} finally {
-			isInitializingRef.current = false;
 		}
 	};
 
@@ -374,7 +402,7 @@ export function TerminalPanel() {
 					<button
 						type="button"
 						className="p-1 ml-1 rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
-						onClick={handleNewSession}
+						onClick={() => void startSession("bash")}
 						title="New Terminal"
 					>
 						<MingcuteAddLine className="w-4 h-4" />

--- a/apps/desktop/src/components/Toolbar.tsx
+++ b/apps/desktop/src/components/Toolbar.tsx
@@ -113,7 +113,7 @@ function NoteActionsMenu({ path }: { path: string }) {
 			</Menu.Trigger>
 			<Menu.Portal>
 				<Menu.Positioner align="end" side="bottom" sideOffset={4}>
-					<Menu.Popup className="z-50 w-44 origin-(--transform-origin) rounded-sm border border-border bg-popover p-1 text-[11px] text-popover-foreground outline-hidden transition-[transform,opacity] data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95">
+					<Menu.Popup className="z-50 w-52 origin-(--transform-origin) rounded-sm border border-border bg-popover p-1 text-[11px] text-popover-foreground outline-hidden transition-[transform,opacity] data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95">
 						<Menu.Item
 							className="flex w-full cursor-pointer items-center gap-2 rounded-sm [padding-block:0.375rem] [padding-inline:0.5rem] text-start text-[11px] outline-hidden select-none data-highlighted:bg-accent"
 							onClick={requestChatAboutNote}

--- a/apps/desktop/src/components/Toolbar.tsx
+++ b/apps/desktop/src/components/Toolbar.tsx
@@ -16,6 +16,7 @@ import { copyText } from "../lib/clipboard";
 import { revealFileLabel } from "../lib/revealFile";
 import {
 	renameCurrentMarkdownFile,
+	requestChatAboutNote,
 	toggleSidebar,
 	toggleTerminal,
 } from "../store/actions";
@@ -113,6 +114,14 @@ function NoteActionsMenu({ path }: { path: string }) {
 			<Menu.Portal>
 				<Menu.Positioner align="end" side="bottom" sideOffset={4}>
 					<Menu.Popup className="z-50 w-44 origin-(--transform-origin) rounded-sm border border-border bg-popover p-1 text-[11px] text-popover-foreground outline-hidden transition-[transform,opacity] data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95">
+						<Menu.Item
+							className="flex w-full cursor-pointer items-center gap-2 rounded-sm [padding-block:0.375rem] [padding-inline:0.5rem] text-start text-[11px] outline-hidden select-none data-highlighted:bg-accent"
+							onClick={requestChatAboutNote}
+						>
+							<MingcuteTerminalLine className="size-3 shrink-0" />
+							<span className="min-w-0 flex-1">Chat about this note</span>
+							<ShortcutHint>⌘⇧J</ShortcutHint>
+						</Menu.Item>
 						<Menu.Item
 							className="flex w-full cursor-pointer items-center gap-2 rounded-sm [padding-block:0.375rem] [padding-inline:0.5rem] text-start text-[11px] outline-hidden select-none data-highlighted:bg-accent"
 							onClick={() => void revealFile()}

--- a/apps/desktop/src/components/UpdatesSection.tsx
+++ b/apps/desktop/src/components/UpdatesSection.tsx
@@ -48,10 +48,10 @@ export function UpdatesSection({
 
 	return (
 		<SettingsSection title="Updates">
-			<div className="flex flex-col gap-3">
+			<div className="flex flex-col gap-2">
 				<div className="flex flex-wrap items-center justify-between gap-3">
-					<div className="flex min-w-0 flex-col gap-1">
-						<p className="text-sm text-foreground">
+					<div className="flex min-w-0 flex-col gap-0.5">
+						<p className="text-[13px] text-foreground">
 							Current version {state.currentVersion}
 						</p>
 						{state.lastCheckedAt ? (

--- a/apps/desktop/src/desktopApi/types.ts
+++ b/apps/desktop/src/desktopApi/types.ts
@@ -58,6 +58,11 @@ export type DesktopUpdateState = {
 
 export type DesktopPlatform = NodeJS.Platform;
 
+export type TerminalStartOptions = {
+	notePath?: string;
+	initialCommand?: string;
+};
+
 export type WorkspaceConfig = {
 	version: 1;
 	pinnedNotes: string[];
@@ -127,7 +132,7 @@ export type DesktopApi = {
 	onFullScreenChange(callback: (isFullScreen: boolean) => void): Unsubscribe;
 
 	// Terminal
-	terminalStart(cwd: string): Promise<string>;
+	terminalStart(cwd: string, options?: TerminalStartOptions): Promise<string>;
 	terminalWrite(sessionId: string, data: string): Promise<void>;
 	terminalResize(sessionId: string, cols: number, rows: number): Promise<void>;
 	terminalStop(sessionId: string): Promise<void>;

--- a/apps/desktop/src/store/actions.test.ts
+++ b/apps/desktop/src/store/actions.test.ts
@@ -52,6 +52,40 @@ describe("desktop savePathContent", () => {
 		vi.unstubAllGlobals();
 	});
 
+	it("hydrates the default chat command and persists edits", async () => {
+		const api = createDesktopApi();
+		const { chatCommandStore, setChatCommand } = await loadStoreActions(api);
+		const { STORAGE_KEY } = await import("./persistence");
+		const { DEFAULT_CHAT_COMMAND } = await import("./settings");
+
+		expect(chatCommandStore.get()).toBe(DEFAULT_CHAT_COMMAND);
+
+		setChatCommand("codex exec");
+
+		expect(chatCommandStore.get()).toBe("codex exec");
+		expect(localStorage.setItem).toHaveBeenLastCalledWith(
+			STORAGE_KEY,
+			expect.stringContaining('"chatCommand":"codex exec"'),
+		);
+	});
+
+	it("requests chat with the default command when the setting is blank", async () => {
+		const api = createDesktopApi();
+		const {
+			appStore,
+			requestChatAboutNote,
+			setChatCommand,
+			pendingTerminalCommandStore,
+		} = await loadStoreActions(api);
+		const { DEFAULT_CHAT_COMMAND } = await import("./settings");
+
+		setChatCommand("   ");
+		requestChatAboutNote();
+
+		expect(appStore.get().ui.isTerminalOpen).toBe(true);
+		expect(pendingTerminalCommandStore.get()).toBe(DEFAULT_CHAT_COMMAND);
+	});
+
 	it("preserves newer editor content when an older save finishes", async () => {
 		const api = createDesktopApi();
 		let finishWrite: () => void = () => {};

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -23,9 +23,11 @@ import {
 	pathAfterMove,
 	rewriteMovedLinks,
 } from "../lib/markdownLinkRewrite";
+import { DEFAULT_CHAT_COMMAND } from "./settings";
 import {
 	applyFileAction,
 	appStore,
+	chatCommandStore,
 	cleanFileState,
 	emptyDoc,
 	type FileEntry,
@@ -34,6 +36,7 @@ import {
 	isInWorkspace,
 	LOADING_DELAY_MS,
 	MAX_RECENT,
+	pendingTerminalCommandStore,
 	type SortMode,
 	sidebarOpenStore,
 	switcherOpenStore,
@@ -370,6 +373,22 @@ export function setTerminalOpen(isOpen: boolean) {
 
 export function toggleTerminal() {
 	uiStore.select("isTerminalOpen").set((open) => !open);
+}
+
+export function setChatCommand(command: string) {
+	chatCommandStore.set(command);
+}
+
+export function requestChatAboutNote() {
+	const command = chatCommandStore.get().trim() || DEFAULT_CHAT_COMMAND;
+	// Set the command before opening so the panel's open effect can see it
+	// and defer to the chat launch instead of starting a plain session.
+	pendingTerminalCommandStore.set(command);
+	uiStore.select("isTerminalOpen").set(true);
+}
+
+export function clearPendingTerminalCommand() {
+	uiStore.set((state) => ({ ...state, pendingTerminalCommand: null }));
 }
 
 export function clearViewer() {

--- a/apps/desktop/src/store/persistence.ts
+++ b/apps/desktop/src/store/persistence.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_CHAT_COMMAND } from "./settings";
 import { emptyDoc, type SortMode } from "./state";
 
 type WorkspaceState = {
@@ -16,12 +17,18 @@ type UiState = {
 	sidebarOpen: boolean;
 	isSwitcherOpen: boolean;
 	isTerminalOpen: boolean;
+	pendingTerminalCommand: string | null;
+};
+
+type SettingsState = {
+	chatCommand: string;
 };
 
 export type DesktopState = {
 	workspace: WorkspaceState;
 	document: DocumentState;
 	ui: UiState;
+	settings: SettingsState;
 };
 
 type Persisted = {
@@ -33,6 +40,7 @@ type Persisted = {
 	};
 	document?: { lastOpenedPath?: string | null };
 	ui?: { sidebarOpen?: boolean; isTerminalOpen?: boolean };
+	settings?: { chatCommand?: string };
 };
 
 export const STORAGE_KEY = "hubble-desktop-app";
@@ -77,6 +85,13 @@ export function getInitialState(): DesktopState {
 			sidebarOpen: p?.ui?.sidebarOpen ?? false,
 			isSwitcherOpen: false,
 			isTerminalOpen: p?.ui?.isTerminalOpen ?? false,
+			pendingTerminalCommand: null,
+		},
+		settings: {
+			chatCommand:
+				typeof p?.settings?.chatCommand === "string"
+					? p.settings.chatCommand
+					: DEFAULT_CHAT_COMMAND,
 		},
 	};
 }
@@ -95,6 +110,9 @@ export function serialize(state: DesktopState): Persisted {
 		ui: {
 			sidebarOpen: state.ui.sidebarOpen,
 			isTerminalOpen: state.ui.isTerminalOpen,
+		},
+		settings: {
+			chatCommand: state.settings.chatCommand,
 		},
 	};
 }

--- a/apps/desktop/src/store/settings.ts
+++ b/apps/desktop/src/store/settings.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_CHAT_COMMAND =
+	'claude "Read $HUBBLE_NOTE_PATH and help me with it"';

--- a/apps/desktop/src/store/state.ts
+++ b/apps/desktop/src/store/state.ts
@@ -149,3 +149,9 @@ export const currentPathStore = viewerStore.select("currentPath");
 export const sidebarOpenStore = uiStore.select("sidebarOpen");
 export const switcherOpenStore = uiStore.select("isSwitcherOpen");
 export const terminalOpenStore = uiStore.select("isTerminalOpen");
+export const pendingTerminalCommandStore = uiStore.select(
+	"pendingTerminalCommand",
+);
+export const chatCommandStore = appStore
+	.select("settings")
+	.select("chatCommand");


### PR DESCRIPTION
Closes #138. Stacked on #131.

Demo: https://screen.studio/share/N7pejQ4x

## What
- `HUBBLE_NOTE_PATH` set to the open note's absolute path in every terminal session Hubble starts (PTY + fallback)
- Settings: configurable chat command (persisted), default `claude "Read $HUBBLE_NOTE_PATH and help me with it"`; blank falls back to default
- "Chat about this note" in the note's overflow menu and Cmd+Shift+J: opens the terminal panel, starts a fresh session, runs the command once the shell emits output (1.2s fallback timer), tab titled after the command's first word
- Settings dialog spacing polish (hairline section dividers, tighter type scale, narrower modal)

## Notes
- Env var stays absolute: `~` inside a quoted $VAR never tilde-expands, so home-relative values would break commands like `vim $HUBBLE_NOTE_PATH`
- The initial command is written by the main process after first shell output to avoid the raw pre-prompt echo
- Session-start effect defers to a pending chat command so open+launch races can't drop the command (covered by tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)