### PR TITLE
Add source mode editor

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -25,6 +25,7 @@ import { z } from "zod/v4";
 import type {
 	DesktopUpdateState,
 	DirectoryListing,
+	MenuState,
 	WorkspaceConfig,
 } from "../src/desktopApi/types";
 import {
@@ -49,10 +50,6 @@ type HtmlAppFileEntry = {
 	path: string;
 	modified_at: number;
 	size: number;
-};
-
-type MenuState = {
-	hasWorkspace: boolean;
 };
 
 type IgnoreRule = {
@@ -112,7 +109,10 @@ const launchWorkspacePath =
 	isDev && process.env.HUBBLE_DESKTOP_DEV_WORKSPACE
 		? resolvePath(process.env.HUBBLE_DESKTOP_DEV_WORKSPACE)
 		: null;
-let menuState: MenuState = { hasWorkspace: false };
+let menuState: MenuState = {
+	hasWorkspace: false,
+	isSourceMode: false,
+};
 let updateState: DesktopUpdateState = {
 	isSupported: supportsAutoUpdates,
 	status: "idle",
@@ -680,8 +680,17 @@ function buildTextContextMenu(
 	webContents: Electron.WebContents,
 	params: Electron.ContextMenuParams,
 ) {
-	const template: Electron.MenuItemConstructorOptions[] =
-		textContextMenuItems.map((item) =>
+	// In source mode the text is already markdown, so plain copy covers it.
+	const template: Electron.MenuItemConstructorOptions[] = textContextMenuItems
+		.filter(
+			(item) =>
+				!(
+					menuState.isSourceMode &&
+					"id" in item &&
+					item.id === "copy-as-markdown"
+				),
+		)
+		.map((item) =>
 			"role" in item
 				? {
 						role: item.role,
@@ -765,6 +774,7 @@ function buildMenu() {
 					id: "copy-as-markdown",
 					label: "Copy as Markdown",
 					accelerator: "Alt+CmdOrCtrl+C",
+					enabled: !menuState.isSourceMode,
 					click: () => sendToRenderer("desktop:menu-copy-as-markdown"),
 				},
 				{ role: "paste" },
@@ -1534,7 +1544,10 @@ function registerIpc() {
 	});
 
 	ipcMain.handle("desktop:set-menu-state", (_event, state: MenuState) => {
-		menuState = { hasWorkspace: state.hasWorkspace === true };
+		menuState = {
+			hasWorkspace: state.hasWorkspace === true,
+			isSourceMode: state.isSourceMode === true,
+		};
 		buildMenu();
 	});
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -111,6 +111,7 @@ const launchWorkspacePath =
 		: null;
 let menuState: MenuState = {
 	hasWorkspace: false,
+	hasMarkdownNoteOpen: false,
 	isSourceMode: false,
 };
 let updateState: DesktopUpdateState = {
@@ -809,6 +810,13 @@ function buildMenu() {
 					accelerator: "CmdOrCtrl+J",
 					enabled: menuState.hasWorkspace,
 					click: () => sendToRenderer("desktop:menu-toggle-terminal"),
+				},
+				{
+					id: "toggle-source-mode",
+					label: "Toggle Source Mode",
+					accelerator: "Alt+CmdOrCtrl+U",
+					enabled: menuState.hasMarkdownNoteOpen,
+					click: () => sendToRenderer("desktop:menu-toggle-source-mode"),
 				},
 				...(isDev
 					? ([
@@ -1546,6 +1554,7 @@ function registerIpc() {
 	ipcMain.handle("desktop:set-menu-state", (_event, state: MenuState) => {
 		menuState = {
 			hasWorkspace: state.hasWorkspace === true,
+			hasMarkdownNoteOpen: state.hasMarkdownNoteOpen === true,
 			isSourceMode: state.isSourceMode === true,
 		};
 		buildMenu();

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -109,6 +109,8 @@ const desktopApi = {
 		subscribe("desktop:menu-sync-workspace", callback),
 	onMenuToggleTerminal: (callback) =>
 		subscribe("desktop:menu-toggle-terminal", callback),
+	onMenuToggleSourceMode: (callback) =>
+		subscribe("desktop:menu-toggle-source-mode", callback),
 	onWindowFocus: (callback) => subscribe("desktop:window-focus", callback),
 	onFullScreenChange: (callback) =>
 		subscribe("desktop:fullscreen-change", (isFullScreen: boolean) =>

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -192,8 +192,11 @@ function App() {
 	}, []);
 
 	useEffect(() => {
-		void desktopApi.setMenuState({ hasWorkspace });
-	}, [hasWorkspace]);
+		void desktopApi.setMenuState({
+			hasWorkspace,
+			isSourceMode: state.viewMode === "source",
+		});
+	}, [hasWorkspace, state.viewMode]);
 
 	useEffect(() => {
 		if (!sidebarOpen) setFocusedSidebarPath(null);

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -4,6 +4,7 @@ import {
 	classifyHref,
 	EditorView,
 	Input,
+	MarkdownSourceEditor,
 	type WikiTarget,
 } from "@hubble.md/ui";
 import { useStoreValue } from "@simplestack/store/react";
@@ -60,6 +61,7 @@ import {
 	chatCommandStore,
 	sidebarOpenStore,
 	uiStore,
+	type ViewMode,
 	viewerStore,
 	workspacePathStore,
 	workspaceStore,
@@ -394,6 +396,7 @@ function App() {
 									path={state.currentPath}
 									content={state.content}
 									copyAsMarkdownRequest={copyAsMarkdownRequest}
+									viewMode={state.viewMode}
 									onScrollContainerChange={setScrollContainerEl}
 								/>
 							</div>
@@ -443,11 +446,13 @@ function DocumentViewer({
 	path,
 	content,
 	copyAsMarkdownRequest,
+	viewMode,
 	onScrollContainerChange,
 }: {
 	path: string;
 	content: string;
 	copyAsMarkdownRequest: number;
+	viewMode: ViewMode;
 	onScrollContainerChange?: (el: HTMLDivElement | null) => void;
 }) {
 	if (hasHtmlExtension(path)) {
@@ -464,13 +469,26 @@ function DocumentViewer({
 	}
 
 	return (
-		<MarkdownEditor
-			key={`${path}:${HMR_REV}`}
-			path={path}
-			initialMarkdown={content}
-			copyAsMarkdownRequest={copyAsMarkdownRequest}
-			onScrollContainerChange={onScrollContainerChange}
-		/>
+		<>
+			{viewMode === "source" ? (
+				<MarkdownSourceEditor
+					key={`${path}:source:${HMR_REV}`}
+					path={path}
+					initialMarkdown={content}
+					onLocalChange={updateEditorContent}
+					onSave={savePathContent}
+					onScrollContainerChange={onScrollContainerChange}
+				/>
+			) : (
+				<MarkdownEditor
+					key={`${path}:rich:${HMR_REV}`}
+					path={path}
+					initialMarkdown={content}
+					copyAsMarkdownRequest={copyAsMarkdownRequest}
+					onScrollContainerChange={onScrollContainerChange}
+				/>
+			)}
+		</>
 	);
 }
 

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -53,6 +53,7 @@ import {
 	savePathContent,
 	setChatCommand,
 	setSidebarOpen,
+	setViewerMode,
 	setWorkspaceSwitcherOpen,
 	toggleTerminal,
 	updateEditorContent,
@@ -192,11 +193,14 @@ function App() {
 	}, []);
 
 	useEffect(() => {
+		const currentPath = state.currentPath;
 		void desktopApi.setMenuState({
 			hasWorkspace,
+			hasMarkdownNoteOpen:
+				typeof currentPath === "string" && hasMarkdownExtension(currentPath),
 			isSourceMode: state.viewMode === "source",
 		});
-	}, [hasWorkspace, state.viewMode]);
+	}, [hasWorkspace, state.currentPath, state.viewMode]);
 
 	useEffect(() => {
 		if (!sidebarOpen) setFocusedSidebarPath(null);
@@ -289,6 +293,16 @@ function App() {
 			),
 			desktopApi.onMenuSyncWorkspace(() => void refreshFiles()),
 			desktopApi.onMenuToggleTerminal(() => toggleTerminal()),
+			desktopApi.onMenuToggleSourceMode(() => {
+				const current = viewerStore.get();
+				if (
+					!current.currentPath ||
+					!hasMarkdownExtension(current.currentPath)
+				) {
+					return;
+				}
+				setViewerMode(current.viewMode === "source" ? "rich" : "source");
+			}),
 		];
 		return () => {
 			for (const dispose of disposers) dispose();

--- a/apps/desktop/src/components/Toolbar.tsx
+++ b/apps/desktop/src/components/Toolbar.tsx
@@ -27,6 +27,7 @@ import {
 	currentPathStore,
 	sidebarOpenStore,
 	viewerStore,
+	workspacePathStore,
 } from "../store/state";
 
 const dragRegionStyle = {
@@ -50,6 +51,7 @@ export function Toolbar({
 	scrollContainer: HTMLDivElement | null;
 	showSidebarBadge?: boolean;
 }) {
+	const workspacePath = useStoreValue(workspacePathStore);
 	const sidebarOpen = useStoreValue(sidebarOpenStore);
 	const currentPath = useStoreValue(currentPathStore);
 	const isFullScreen = useIsFullScreen();
@@ -77,14 +79,25 @@ export function Toolbar({
 					>
 						<MingcuteTerminalLine className="size-3.5" />
 					</Button>
-					{currentPath && <NoteActionsMenu path={currentPath} />}
+					{currentPath && (
+						<NoteActionsMenu
+							path={currentPath}
+							canChatAboutNote={workspacePath !== null}
+						/>
+					)}
 				</div>
 			}
 		/>
 	);
 }
 
-function NoteActionsMenu({ path }: { path: string }) {
+function NoteActionsMenu({
+	path,
+	canChatAboutNote,
+}: {
+	path: string;
+	canChatAboutNote: boolean;
+}) {
 	const viewMode = useStoreValue(viewerStore).viewMode;
 	const isSourceMode = viewMode === "source";
 
@@ -117,14 +130,16 @@ function NoteActionsMenu({ path }: { path: string }) {
 			<Menu.Portal>
 				<Menu.Positioner align="end" side="bottom" sideOffset={4}>
 					<Menu.Popup className="z-50 w-52 origin-(--transform-origin) rounded-sm border border-border bg-popover p-1 text-[11px] text-popover-foreground outline-hidden transition-[transform,opacity] data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95">
-						<Menu.Item
-							className="flex w-full cursor-pointer items-center gap-2 rounded-sm [padding-block:0.375rem] [padding-inline:0.5rem] text-start text-[11px] outline-hidden select-none data-highlighted:bg-accent"
-							onClick={requestChatAboutNote}
-						>
-							<MingcuteTerminalLine className="size-3 shrink-0" />
-							<span className="min-w-0 flex-1">Chat about this note</span>
-							<ShortcutHint>⌘⇧J</ShortcutHint>
-						</Menu.Item>
+						{canChatAboutNote && (
+							<Menu.Item
+								className="flex w-full cursor-pointer items-center gap-2 rounded-sm [padding-block:0.375rem] [padding-inline:0.5rem] text-start text-[11px] outline-hidden select-none data-highlighted:bg-accent"
+								onClick={requestChatAboutNote}
+							>
+								<MingcuteTerminalLine className="size-3 shrink-0" />
+								<span className="min-w-0 flex-1">Chat about this note</span>
+								<ShortcutHint>⌘⇧J</ShortcutHint>
+							</Menu.Item>
+						)}
 						{hasMarkdownExtension(path) && (
 							<Menu.Item
 								className="flex w-full cursor-pointer items-center gap-2 rounded-sm [padding-block:0.375rem] [padding-inline:0.5rem] text-start text-[11px] outline-hidden select-none data-highlighted:bg-accent"

--- a/apps/desktop/src/components/Toolbar.tsx
+++ b/apps/desktop/src/components/Toolbar.tsx
@@ -98,7 +98,7 @@ function NoteActionsMenu({
 	path: string;
 	canChatAboutNote: boolean;
 }) {
-	const viewMode = useStoreValue(viewerStore).viewMode;
+	const { viewMode } = useStoreValue(viewerStore);
 	const isSourceMode = viewMode === "source";
 
 	async function revealFile() {
@@ -137,7 +137,7 @@ function NoteActionsMenu({
 							>
 								<MingcuteTerminalLine className="size-3 shrink-0" />
 								<span className="min-w-0 flex-1">Chat about this note</span>
-								<ShortcutHint>⌘⇧J</ShortcutHint>
+								<ShortcutHint spec="CmdOrCtrl+Shift+J" />
 							</Menu.Item>
 						)}
 						{hasMarkdownExtension(path) && (
@@ -149,6 +149,7 @@ function NoteActionsMenu({
 								<span className="min-w-0 flex-1">
 									{isSourceMode ? "Edit rich text" : "Edit source"}
 								</span>
+								<ShortcutHint spec="Alt+CmdOrCtrl+U" />
 							</Menu.Item>
 						)}
 						<Menu.Item
@@ -159,7 +160,7 @@ function NoteActionsMenu({
 							<span className="min-w-0 flex-1">
 								{revealFileLabel(desktopApi.platform)}
 							</span>
-							<ShortcutHint>{formatShortcut("CmdOrCtrl+Alt+R")}</ShortcutHint>
+							<ShortcutHint spec="CmdOrCtrl+Alt+R" />
 						</Menu.Item>
 						<Menu.Item
 							className="flex w-full cursor-pointer items-center gap-2 rounded-sm [padding-block:0.375rem] [padding-inline:0.5rem] text-start text-[11px] outline-hidden select-none data-highlighted:bg-accent"
@@ -167,7 +168,7 @@ function NoteActionsMenu({
 						>
 							<MingcuteCopy2Line className="size-3 shrink-0" />
 							<span className="min-w-0 flex-1">Copy file path</span>
-							<ShortcutHint>{formatShortcut("CmdOrCtrl+Shift+C")}</ShortcutHint>
+							<ShortcutHint spec="CmdOrCtrl+Shift+C" />
 						</Menu.Item>
 					</Menu.Popup>
 				</Menu.Positioner>
@@ -176,13 +177,15 @@ function NoteActionsMenu({
 	);
 }
 
-function ShortcutHint({ children }: { children: string }) {
+// Takes the "CmdOrCtrl+..." accelerator spec, not a display string, so call
+// sites can't hardcode platform-specific glyphs.
+function ShortcutHint({ spec }: { spec: string }) {
 	return (
 		<span
 			className="ms-auto shrink-0 text-[11px] leading-none text-muted-foreground/60"
 			aria-hidden="true"
 		>
-			{children}
+			{formatShortcut(spec)}
 		</span>
 	);
 }

--- a/apps/desktop/src/components/Toolbar.tsx
+++ b/apps/desktop/src/components/Toolbar.tsx
@@ -7,23 +7,26 @@ import {
 import { useStoreValue } from "@simplestack/store/react";
 import { type CSSProperties, useEffect, useState } from "react";
 import { toast } from "sonner";
+import MingcuteCodeLine from "~icons/mingcute/code-line";
 import MingcuteCopy2Line from "~icons/mingcute/copy-2-line";
 import MingcuteFolderOpenLine from "~icons/mingcute/folder-open-line";
 import MingcuteMore2Line from "~icons/mingcute/more-2-line";
 import MingcuteTerminalLine from "~icons/mingcute/terminal-line";
 import { desktopApi } from "../desktopApi";
 import { copyText } from "../lib/clipboard";
+import { hasMarkdownExtension } from "../lib/filePath";
 import { revealFileLabel } from "../lib/revealFile";
 import {
 	renameCurrentMarkdownFile,
 	requestChatAboutNote,
+	setViewerMode,
 	toggleSidebar,
 	toggleTerminal,
 } from "../store/actions";
 import {
 	currentPathStore,
 	sidebarOpenStore,
-	workspacePathStore,
+	viewerStore,
 } from "../store/state";
 
 const dragRegionStyle = {
@@ -47,7 +50,6 @@ export function Toolbar({
 	scrollContainer: HTMLDivElement | null;
 	showSidebarBadge?: boolean;
 }) {
-	const workspacePath = useStoreValue(workspacePathStore);
 	const sidebarOpen = useStoreValue(sidebarOpenStore);
 	const currentPath = useStoreValue(currentPathStore);
 	const isFullScreen = useIsFullScreen();
@@ -75,9 +77,7 @@ export function Toolbar({
 					>
 						<MingcuteTerminalLine className="size-3.5" />
 					</Button>
-					{workspacePath && currentPath && (
-						<NoteActionsMenu path={currentPath} />
-					)}
+					{currentPath && <NoteActionsMenu path={currentPath} />}
 				</div>
 			}
 		/>
@@ -85,6 +85,9 @@ export function Toolbar({
 }
 
 function NoteActionsMenu({ path }: { path: string }) {
+	const viewMode = useStoreValue(viewerStore).viewMode;
+	const isSourceMode = viewMode === "source";
+
 	async function revealFile() {
 		try {
 			await desktopApi.revealFile(path);
@@ -122,6 +125,17 @@ function NoteActionsMenu({ path }: { path: string }) {
 							<span className="min-w-0 flex-1">Chat about this note</span>
 							<ShortcutHint>⌘⇧J</ShortcutHint>
 						</Menu.Item>
+						{hasMarkdownExtension(path) && (
+							<Menu.Item
+								className="flex w-full cursor-pointer items-center gap-2 rounded-sm [padding-block:0.375rem] [padding-inline:0.5rem] text-start text-[11px] outline-hidden select-none data-highlighted:bg-accent"
+								onClick={() => setViewerMode(isSourceMode ? "rich" : "source")}
+							>
+								<MingcuteCodeLine className="size-3 shrink-0" />
+								<span className="min-w-0 flex-1">
+									{isSourceMode ? "Edit rich text" : "Edit source"}
+								</span>
+							</Menu.Item>
+						)}
 						<Menu.Item
 							className="flex w-full cursor-pointer items-center gap-2 rounded-sm [padding-block:0.375rem] [padding-inline:0.5rem] text-start text-[11px] outline-hidden select-none data-highlighted:bg-accent"
 							onClick={() => void revealFile()}

--- a/apps/desktop/src/desktopApi/types.ts
+++ b/apps/desktop/src/desktopApi/types.ts
@@ -40,6 +40,7 @@ export type Unsubscribe = () => void;
 
 export type MenuState = {
 	hasWorkspace: boolean;
+	isSourceMode: boolean;
 };
 
 export type DesktopUpdateStatus =

--- a/apps/desktop/src/desktopApi/types.ts
+++ b/apps/desktop/src/desktopApi/types.ts
@@ -40,6 +40,7 @@ export type Unsubscribe = () => void;
 
 export type MenuState = {
 	hasWorkspace: boolean;
+	hasMarkdownNoteOpen: boolean;
 	isSourceMode: boolean;
 };
 
@@ -135,6 +136,7 @@ export type DesktopApi = {
 	onMenuShowWorkspaceSwitcher(callback: () => void): Unsubscribe;
 	onMenuSyncWorkspace(callback: () => void): Unsubscribe;
 	onMenuToggleTerminal(callback: () => void): Unsubscribe;
+	onMenuToggleSourceMode(callback: () => void): Unsubscribe;
 	onWindowFocus(callback: () => void): Unsubscribe;
 	onFullScreenChange(callback: (isFullScreen: boolean) => void): Unsubscribe;
 

--- a/apps/desktop/src/store/actions.test.ts
+++ b/apps/desktop/src/store/actions.test.ts
@@ -210,6 +210,60 @@ describe("desktop savePathContent", () => {
 		expect(viewerStore.get().diskContent).toBe("draft 2");
 		expect(viewerStore.get().externalChange).toEqual({ kind: "none" });
 	});
+
+	it("switches view mode without changing editor content", async () => {
+		const api = createDesktopApi();
+		const { appStore, setViewerMode, viewerStore } =
+			await loadStoreActions(api);
+		const path = "/workspace/note.md";
+
+		appStore.set((current) => ({
+			...current,
+			document: {
+				...current.document,
+				currentPath: path,
+				lastOpenedPath: path,
+				content: "draft",
+				diskContent: "before",
+				externalChange: { kind: "none" },
+				status: "ready",
+				error: null,
+			},
+		}));
+
+		setViewerMode("source");
+
+		expect(viewerStore.get().viewMode).toBe("source");
+		expect(viewerStore.get().content).toBe("draft");
+	});
+
+	it("resets source mode when opening another file", async () => {
+		const api = createDesktopApi();
+		api.readFileText.mockResolvedValue("next file");
+		const { appStore, loadPath, setViewerMode, viewerStore } =
+			await loadStoreActions(api);
+
+		appStore.set((current) => ({
+			...current,
+			document: {
+				...current.document,
+				currentPath: "/workspace/old.md",
+				lastOpenedPath: "/workspace/old.md",
+				content: "old file",
+				diskContent: "old file",
+				externalChange: { kind: "none" },
+				status: "ready",
+				error: null,
+			},
+		}));
+		setViewerMode("source");
+
+		await loadPath("/workspace/next.md");
+
+		expect(viewerStore.get().currentPath).toBe("/workspace/next.md");
+		expect(viewerStore.get().content).toBe("next file");
+		expect(viewerStore.get().viewMode).toBe("rich");
+	});
 });
 
 describe("desktop renameMarkdownFile", () => {

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -41,6 +41,7 @@ import {
 	sidebarOpenStore,
 	switcherOpenStore,
 	uiStore,
+	type ViewMode,
 	viewerStore,
 	withOpenedDoc,
 	workspaceStore,
@@ -465,6 +466,13 @@ export function updateEditorContent(path: string, content: string) {
 			status: "ready",
 			error: null,
 		};
+	});
+}
+
+export function setViewerMode(viewMode: ViewMode) {
+	viewerStore.set((state) => {
+		if (state.viewMode === viewMode) return state;
+		return { ...state, viewMode };
 	});
 }
 

--- a/apps/desktop/src/store/state.ts
+++ b/apps/desktop/src/store/state.ts
@@ -18,6 +18,7 @@ export type FileEntry = {
 export type FolderEntry = FileEntry;
 
 type ViewerStatus = "idle" | "loading" | "ready" | "error";
+export type ViewMode = "rich" | "source";
 type ExternalChange =
 	| { kind: "none" }
 	| { kind: "conflict"; diskContent: string };
@@ -30,6 +31,7 @@ type DocumentState = {
 	externalChange: ExternalChange;
 	status: ViewerStatus;
 	error: string | null;
+	viewMode: ViewMode;
 };
 
 const NO_CONFLICT: ExternalChange = { kind: "none" };
@@ -47,6 +49,7 @@ export const emptyDoc = (
 	externalChange: NO_CONFLICT,
 	status: "idle",
 	error: null,
+	viewMode: "rich",
 });
 
 export function cleanFileState(content: string) {
@@ -129,6 +132,7 @@ export function withOpenedDoc(
 			currentPath: path,
 			lastOpenedPath: path,
 			...cleanFileState(content),
+			viewMode: "rich",
 		},
 	};
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -41,6 +41,7 @@
 		"@hubble.md/editor": "workspace:*",
 		"@tiptap/core": "^3.4.3",
 		"@tiptap/extension-code-block-lowlight": "3.20.0",
+		"@tiptap/extension-document": "3.20.0",
 		"@tiptap/extension-list": "^3.4.2",
 		"@tiptap/extension-table": "^3.27.1",
 		"@tiptap/extension-table-cell": "^3.27.1",

--- a/packages/ui/src/editor/EditorView.css
+++ b/packages/ui/src/editor/EditorView.css
@@ -303,19 +303,41 @@
 }
 
 [data-hubble-source-editor] .editorViewport {
-	padding-block: var(--editor-padding-block, 1.25rem);
+	display: flex;
+	flex-direction: column;
+	padding-block: 0;
+}
+
+/* Tiptap's EditorContent wrapper sits between the viewport and .ProseMirror. */
+[data-hubble-source-editor] .editorViewport > div {
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	min-block-size: 0;
 }
 
 [data-hubble-source-editor] .ProseMirror {
-	min-block-size: 100%;
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	padding-block: var(--editor-padding-block, 1.25rem);
+	/* The rich editor hides the native caret in favor of the virtual cursor;
+	 * source mode has no virtual cursor, so restore a native caret in the
+	 * same accent color. */
+	caret-color: var(--brand-accent);
 }
 
 [data-hubble-source-editor] .ProseMirror > .react-renderer.node-codeBlock {
+	display: flex;
+	flex: 1;
+	flex-direction: column;
 	margin-block: 0;
 }
 
 [data-hubble-source-editor] .pm-code-block {
-	min-block-size: 100%;
+	display: flex;
+	flex: 1;
+	flex-direction: column;
 }
 
 [data-hubble-source-editor] .pm-code-block-controls {
@@ -323,7 +345,10 @@
 }
 
 [data-hubble-source-editor] .ProseMirror pre {
-	min-block-size: inherit;
+	flex: 1;
+	background: transparent;
+	border-radius: 0;
+	padding: 0;
 }
 
 [data-hubble-editor]

--- a/packages/ui/src/editor/EditorView.css
+++ b/packages/ui/src/editor/EditorView.css
@@ -302,6 +302,30 @@
 	transition: opacity 160ms var(--ease-snappy);
 }
 
+[data-hubble-source-editor] .editorViewport {
+	padding-block: var(--editor-padding-block, 1.25rem);
+}
+
+[data-hubble-source-editor] .ProseMirror {
+	min-block-size: 100%;
+}
+
+[data-hubble-source-editor] .ProseMirror > .react-renderer.node-codeBlock {
+	margin-block: 0;
+}
+
+[data-hubble-source-editor] .pm-code-block {
+	min-block-size: 100%;
+}
+
+[data-hubble-source-editor] .pm-code-block-controls {
+	display: none;
+}
+
+[data-hubble-source-editor] .ProseMirror pre {
+	min-block-size: inherit;
+}
+
 [data-hubble-editor]
 	.react-renderer.node-codeBlock:hover
 	.pm-code-block-controls {

--- a/packages/ui/src/editor/MarkdownSourceEditor.test.ts
+++ b/packages/ui/src/editor/MarkdownSourceEditor.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment happy-dom
+
+import { Editor } from "@tiptap/core";
+import Document from "@tiptap/extension-document";
+import StarterKit from "@tiptap/starter-kit";
+import { afterEach, describe, expect, it } from "vitest";
+import { HubbleCodeBlock } from "./CodeBlockExtension";
+import {
+	markdownFromSourceDoc,
+	sourceDocFromMarkdown,
+} from "./MarkdownSourceEditor";
+
+const editors: Editor[] = [];
+const SourceDocument = Document.extend({ content: "codeBlock" });
+
+afterEach(() => {
+	for (const editor of editors) editor.destroy();
+	editors.length = 0;
+});
+
+describe("MarkdownSourceEditor document helpers", () => {
+	it("stores the whole markdown file in one markdown code block", () => {
+		const markdown = "---\ntitle: Test\n---\n\n# Hello\n\nBody";
+
+		expect(sourceDocFromMarkdown(markdown)).toEqual({
+			type: "doc",
+			content: [
+				{
+					type: "codeBlock",
+					attrs: { language: "md" },
+					content: [{ type: "text", text: markdown }],
+				},
+			],
+		});
+	});
+
+	it("reads the whole markdown file back from the code block", () => {
+		const markdown = "---\ntitle: Test\n---\n\n# Hello\n\nBody";
+		const editor = new Editor({
+			element: document.createElement("div"),
+			extensions: [
+				SourceDocument,
+				StarterKit.configure({ codeBlock: false, document: false }),
+				HubbleCodeBlock.configure({ defaultLanguage: "md" }),
+			],
+			content: sourceDocFromMarkdown(markdown),
+		});
+		editors.push(editor);
+
+		expect(markdownFromSourceDoc(editor)).toBe(markdown);
+	});
+
+	it("keeps replacement typing inside the code block", () => {
+		const editor = new Editor({
+			element: document.createElement("div"),
+			extensions: [
+				SourceDocument,
+				StarterKit.configure({ codeBlock: false, document: false }),
+				HubbleCodeBlock.configure({ defaultLanguage: "md" }),
+			],
+			content: sourceDocFromMarkdown("before"),
+		});
+		editors.push(editor);
+
+		editor.commands.selectAll();
+		editor.commands.insertContent("after");
+
+		expect(editor.getJSON().content?.[0]).toMatchObject({
+			type: "codeBlock",
+			attrs: { language: "md" },
+			content: [{ type: "text", text: "after" }],
+		});
+	});
+});

--- a/packages/ui/src/editor/MarkdownSourceEditor.tsx
+++ b/packages/ui/src/editor/MarkdownSourceEditor.tsx
@@ -1,0 +1,132 @@
+import type { Editor } from "@tiptap/core";
+import Document from "@tiptap/extension-document";
+import { EditorContent, type JSONContent, useEditor } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import { useCallback, useEffect, useRef } from "react";
+import { HubbleCodeBlock } from "./CodeBlockExtension";
+import "./EditorView.css";
+
+const DEFAULT_SAVE_DEBOUNCE_MS = 120;
+const SourceDocument = Document.extend({ content: "codeBlock" });
+
+export type MarkdownSourceEditorProps = {
+	path: string;
+	initialMarkdown: string;
+	saveDebounceMs?: number;
+	onLocalChange: (path: string, markdown: string) => void;
+	onSave: (path: string, markdown: string) => void | Promise<void>;
+	onScrollContainerChange?: (el: HTMLDivElement | null) => void;
+};
+
+export function MarkdownSourceEditor({
+	path,
+	initialMarkdown,
+	saveDebounceMs = DEFAULT_SAVE_DEBOUNCE_MS,
+	onLocalChange,
+	onSave,
+	onScrollContainerChange,
+}: MarkdownSourceEditorProps) {
+	const pathRef = useRef(path);
+	const latestMarkdownRef = useRef(initialMarkdown);
+	const saveTimerRef = useRef<number | null>(null);
+	pathRef.current = path;
+
+	const setEditorViewport = useCallback(
+		(node: HTMLDivElement | null) => {
+			onScrollContainerChange?.(node);
+		},
+		[onScrollContainerChange],
+	);
+
+	const scheduleSave = useCallback(() => {
+		const savePath = pathRef.current;
+		if (saveTimerRef.current !== null) {
+			window.clearTimeout(saveTimerRef.current);
+		}
+		saveTimerRef.current = window.setTimeout(() => {
+			void onSave(savePath, latestMarkdownRef.current);
+		}, saveDebounceMs);
+	}, [onSave, saveDebounceMs]);
+
+	const editor = useEditor({
+		extensions: [
+			SourceDocument,
+			StarterKit.configure({ codeBlock: false, document: false }),
+			HubbleCodeBlock.configure({ defaultLanguage: "md" }),
+		],
+		content: sourceDocFromMarkdown(initialMarkdown),
+		onUpdate: ({ editor: current }) => {
+			const markdown = markdownFromSourceDoc(current);
+			latestMarkdownRef.current = markdown;
+			onLocalChange(pathRef.current, markdown);
+			scheduleSave();
+		},
+		editorProps: {
+			attributes: {
+				"data-editor-input": "",
+				"aria-label": "Markdown source",
+			},
+		},
+	});
+
+	useEffect(() => {
+		if (!editor) return;
+		editor.commands.focus("end");
+	}, [editor]);
+
+	useEffect(() => {
+		if (!editor) return;
+		if (initialMarkdown === latestMarkdownRef.current) return;
+		latestMarkdownRef.current = initialMarkdown;
+		editor.commands.setContent(sourceDocFromMarkdown(initialMarkdown), {
+			emitUpdate: false,
+		});
+	}, [editor, initialMarkdown]);
+
+	useEffect(() => {
+		return () => {
+			if (saveTimerRef.current !== null) {
+				window.clearTimeout(saveTimerRef.current);
+				saveTimerRef.current = null;
+				void onSave(path, latestMarkdownRef.current);
+			}
+		};
+	}, [path, onSave]);
+
+	return (
+		<div
+			className="relative flex h-full min-h-0 flex-col"
+			data-hubble-editor
+			data-hubble-source-editor
+		>
+			<div
+				className="editorViewport relative min-h-0 flex-1 overflow-auto overscroll-contain"
+				ref={setEditorViewport}
+			>
+				<EditorContent editor={editor} />
+			</div>
+		</div>
+	);
+}
+
+export function sourceDocFromMarkdown(markdown: string): JSONContent {
+	return {
+		type: "doc",
+		content: [
+			{
+				type: "codeBlock",
+				attrs: { language: "md" },
+				content: markdown.length > 0 ? [{ type: "text", text: markdown }] : [],
+			},
+		],
+	};
+}
+
+export function markdownFromSourceDoc(editor: Editor) {
+	return editor.state.doc.textBetween(
+		0,
+		editor.state.doc.content.size,
+		"\n",
+		"\n",
+	);
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -19,6 +19,10 @@ export {
 export { FormattingStatusBar } from "./editor/FormattingStatusBar";
 export { classifyHref } from "./editor/href";
 export { LinkCreationGhostExtension } from "./editor/LinkCreationGhostExtension";
+export {
+	MarkdownSourceEditor,
+	type MarkdownSourceEditorProps,
+} from "./editor/MarkdownSourceEditor";
 export { SmartLinkExtension } from "./editor/SmartLinkExtension";
 export { VirtualCursor } from "./editor/VirtualCursor";
 export type { VirtualCursorMode } from "./editor/virtualCursorMode";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -406,6 +406,9 @@ importers:
       '@tiptap/extension-code-block-lowlight':
         specifier: 3.20.0
         version: 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/extension-code-block@3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)(highlight.js@11.11.1)(lowlight@3.3.0)
+      '@tiptap/extension-document':
+        specifier: 3.20.0
+        version: 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))
       '@tiptap/extension-list':
         specifier: ^3.4.2
         version: 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)

--- a/specs/gh-142/PRODUCT.md
+++ b/specs/gh-142/PRODUCT.md
@@ -1,0 +1,57 @@
+# Source Mode
+
+## Summary
+
+Source mode lets desktop users edit the exact raw Markdown for the open Markdown File, including front matter, without leaving Hubble. The user can switch between the normal rich editor and a full-page highlighted Markdown source editor from the note actions menu.
+
+## Problem
+
+The rich editor intentionally presents File Properties separately from the document body. Users still need an escape hatch for raw Markdown tasks: fixing malformed front matter, editing unsupported YAML, adjusting syntax the rich editor does not expose, or copying a whole file exactly as stored on disk.
+
+## Goals
+
+1. Make raw source editing available for the current desktop Markdown File.
+2. Preserve the whole-file Markdown source as the source of truth.
+3. Keep switching between rich and source views predictable and reversible.
+
+## Non-goals
+
+1. No source mode for HTML App files.
+2. No split view, diff view, or preview mode.
+3. No keyboard shortcut in this slice.
+4. No new Markdown syntax support beyond editing the source text.
+
+## Design Context
+
+The entry point is the existing note actions overflow menu in the desktop toolbar. Source mode should feel like a mode switch on the current document, not a separate file opener. Rich mode remains the default when opening Markdown Files.
+
+## Behavior
+
+1. When a Markdown File is open on desktop, the note actions overflow menu includes an `Edit source` item.
+2. Selecting `Edit source` switches the main content panel from the rich editor to a full-page source editor for the same file.
+3. While source mode is active, the same menu item reads `Edit rich text`.
+4. Selecting `Edit rich text` switches the main content panel back to the rich editor for the same file.
+5. Source mode displays the whole Markdown File exactly as Hubble currently knows it, including YAML front matter, blank lines, comments, unsupported front matter fields, and the Markdown body.
+6. The source editor fills the document area that the rich editor normally occupies. Existing app chrome, sidebar, terminal panel, update banners, and external-change conflict banner remain visible and behave normally.
+7. Source mode uses a highlighted Markdown editing surface. It must not look or behave like an unstyled plain textarea.
+8. Source mode is editable with normal text editing affordances: typing, deletion, selection, paste, undo/redo, scrolling, and tab indentation.
+9. Edits made in source mode update the current file through the same save behavior users already get in rich mode. Users should not need a separate save command.
+10. If the user switches back to rich mode after editing source, the rich editor reflects the latest source text.
+11. If source edits include valid front matter, File Properties reflect those front matter changes after returning to rich mode.
+12. If source edits include invalid or unsupported front matter, Hubble preserves that source text and shows the existing File Properties unavailable/unsupported behavior after returning to rich mode.
+13. Switching modes must not discard unsaved in-memory edits. The visible next mode uses the latest editor content, not only the last content flushed to disk.
+14. Opening another file resets the view to rich mode for Markdown Files.
+15. Opening an HTML App file does not show source-mode controls and does not preserve a prior Markdown source-mode state.
+16. When an external disk change conflict is shown, the conflict banner stays above either rich or source mode. `Reload from disk` replaces the source editor content with disk content; `Keep my edits` keeps the current source or rich edits.
+17. Source mode keeps focus in the editing surface after switching into it.
+18. The source editor is keyboard accessible as a document editing region and does not trap focus away from toolbar, sidebar, or terminal controls.
+19. The current mode is local app view state only. Restarting the app or reopening a file starts in rich mode.
+20. The feature is desktop-only until a separate web source-mode issue specifies web save and sync behavior.
+
+## UX Validation
+
+1. Open the desktop app with a Workspace Folder or Plain Folder containing a Markdown File with front matter.
+2. Open the Markdown File, use the note actions menu, and choose `Edit source`.
+3. Confirm the editor becomes a full-page highlighted Markdown source view, includes front matter, and receives focus.
+4. Edit both front matter and body text, wait for save, switch back with `Edit rich text`, and confirm File Properties plus body content reflect the source edits.
+5. Reopen or switch to another Markdown File and confirm the initial view is rich mode.

--- a/specs/gh-142/TECH.md
+++ b/specs/gh-142/TECH.md
@@ -1,0 +1,160 @@
+# Source Mode Technical Plan
+
+## Context
+
+Issue: https://github.com/bholmesdev/hubble.md/issues/142
+
+Product spec: `specs/gh-142/PRODUCT.md`
+
+Current commit researched: `19f98b4817256bc3cbc89f371761b6ab3d8c26a1`
+
+Hubble desktop currently opens Markdown Files into `EditorView`, which parses front matter out of `initialMarkdown`, edits the body as a TipTap document, and recombines front matter plus body before `onLocalChange` and `onSave`. ADR-0003 establishes that File Properties live in YAML front matter and the full Markdown File remains the source of truth across desktop, web, Workspace Folders, Plain Folders, and Loose Files.
+
+Relevant code:
+
+- `apps/desktop/src/App.tsx`: `DocumentViewer`, `MarkdownEditor`, desktop save wiring, conflict banner, menu event handlers.
+- `apps/desktop/src/components/Toolbar.tsx`: `NoteActionsMenu`, the right-side note overflow menu.
+- `apps/desktop/src/store/state.ts`: `viewerStore`, `DocumentState`, `cleanFileState`, conflict baseline helpers.
+- `apps/desktop/src/store/actions.ts`: `updateEditorContent`, `savePathContent`, file load/save/conflict actions.
+- `apps/desktop/src/store/persistence.ts`: desktop state hydration/serialization. Persisted document state currently stores only `lastOpenedPath`.
+- `packages/ui/src/editor/EditorView.tsx`: rich editor, frontmatter/body split, `HubbleCodeBlock` extension use.
+- `packages/ui/src/editor/CodeBlockExtension.tsx`: `HubbleCodeBlock`, lowlight Markdown alias, code block controls, tab behavior.
+
+## Affected Apps and Packages
+
+`apps/desktop`
+
+- Owns source/rich view state, toolbar menu entry, file switching reset, and save plumbing for desktop Markdown Files.
+
+`packages/ui`
+
+- Owns the reusable TipTap editor pieces. Add a source editor component here if it reuses `HubbleCodeBlock` and should be testable outside the desktop shell.
+
+`packages/editor`
+
+- No new Markdown parser behavior is planned. Existing `markdownToTiptapDoc` remains the rich-mode reconciliation path when returning from source mode.
+
+## Module Architecture
+
+Add `viewMode: "rich" | "source"` to desktop `DocumentState`.
+
+- Default `emptyDoc()` mode: `"rich"`.
+- `withOpenedDoc()` and successful reload/load paths reset to `"rich"` to satisfy PRODUCT behavior 14 and 19.
+- `cleanFileState()` should not force mode by itself unless the caller is opening/reloading a file. This avoids `updateEditorContent()` accidentally switching modes while typing.
+- Add `viewModeStore` only if a component needs direct selection; otherwise read from `viewerStore`.
+
+Add desktop actions:
+
+- `setViewerMode(mode: "rich" | "source")`
+- `toggleSourceMode()` or `setViewMode()` for toolbar use.
+
+`Toolbar` / `NoteActionsMenu`:
+
+- Read current path and current `viewMode`.
+- Show `Edit source` only for open Markdown Files.
+- Toggle label to `Edit rich text` while source mode is active.
+- Keep the item in the existing menu rather than adding another toolbar button.
+
+`DocumentViewer`:
+
+- Continue routing HTML App files to `HtmlDocumentViewer`.
+- For Markdown Files, branch on `state.viewMode`.
+- Rich branch keeps `MarkdownEditor`.
+- Source branch renders a new `MarkdownSourceEditor`.
+
+`MarkdownSourceEditor`:
+
+- Receives `path`, `initialMarkdown`, `onLocalChange`, `onSave`, and `onScrollContainerChange`.
+- Creates a minimal TipTap editor whose document is exactly one `codeBlock` node with `language: "md"` and text content equal to the whole Markdown File.
+- Uses `HubbleCodeBlock` for highlighting and editing behavior.
+- On update, reads the single code block text and calls `onLocalChange(path, markdown)` plus debounced `onSave(path, markdown)`, mirroring `EditorView`.
+- On prop content changes from reload/conflict resolution, updates the code block without emitting local changes.
+- On unmount, flushes pending save like `EditorView`.
+- Sets the scroll container for toolbar scroll behavior and focuses the editor after mount.
+
+`HubbleCodeBlock` reuse:
+
+- Prefer a configurable node view option over duplicating the component. Add an option such as `sourceMode?: boolean` or `controls?: "default" | "source"` only if necessary.
+- In source mode, hide or disable the language selector because PRODUCT behavior requires Markdown source, not user-selectable languages.
+- The copy button can be hidden in source mode; whole-file copy is not part of this issue and normal selection copy still works.
+- Preserve existing in-document code block controls for rich mode.
+
+## Detailed Plan
+
+1. Extend desktop document state.
+   - Add `type ViewMode = "rich" | "source"` in `apps/desktop/src/store/state.ts`.
+   - Add `viewMode` to `DocumentState` and `emptyDoc`.
+   - Ensure file-open and reload actions set mode to `"rich"` where they replace the current document.
+   - Leave `serialize()` unchanged so mode is not persisted.
+
+2. Add mode actions.
+   - Implement a small setter in `apps/desktop/src/store/actions.ts`.
+   - When switching modes, only mutate `viewMode`; do not read from disk.
+   - Rely on `viewerStore.content` as the in-memory source for the next view.
+
+3. Add toolbar menu item.
+   - In `NoteActionsMenu`, read current mode from `viewerStore`.
+   - Add item after `Chat about this note` or near other document actions.
+   - Use the same Base UI menu item styling.
+   - Consider a code/text icon from the current icon set, but keep visual density consistent.
+
+4. Implement `MarkdownSourceEditor`.
+   - Place in `packages/ui/src/editor/MarkdownSourceEditor.tsx` if it can stay app-agnostic.
+   - Export it from the UI package editor barrel if needed.
+   - Use `StarterKit.configure({ codeBlock: false })` plus `HubbleCodeBlock.configure(...)`.
+   - Define helpers to build/read a single code-block TipTap document.
+   - Reuse `DEFAULT_SAVE_DEBOUNCE_MS` semantics from `EditorView`; consider extracting the constant only if duplication becomes noisy.
+
+5. Wire source mode in desktop.
+   - Import and render `MarkdownSourceEditor` from `apps/desktop/src/App.tsx`.
+   - Pass `updateEditorContent`, `savePathContent`, and `setScrollContainerEl`.
+   - Key by `path`, `viewMode`, and `HMR_REV` so switching modes creates the correct TipTap instance.
+
+6. Reconcile source to rich.
+   - No explicit conversion action is needed if source mode writes whole Markdown to `viewerStore.content`.
+   - Switching to rich mode remounts `EditorView` with latest `initialMarkdown`, and `EditorView` already parses front matter and calls `markdownToTiptapDoc` on the body.
+
+7. Conflict behavior.
+   - Existing conflict banner stays outside `DocumentViewer`, so it applies to both modes.
+   - Verify `reloadFromDiskConflict()` updates `content`; source editor must react to prop changes.
+   - Verify `forceKeepLocalEdits()` saves `viewerStore.content`; source editor updates that through `onLocalChange`.
+
+8. Tests.
+   - Add store tests for default mode, toggling mode, non-persistence, and reset on file open.
+   - Add UI/component tests for `MarkdownSourceEditor`: initializes with full source, calls local change/save with edited text, and updates from new props without emitting changes.
+   - Add desktop component or integration coverage for menu label and `DocumentViewer` branch if existing test setup supports it.
+
+## Testing and Validation
+
+Map to product behavior:
+
+- PRODUCT 1-4, 14-15: desktop component tests for note menu label/visibility and mode reset.
+- PRODUCT 5, 9-13: `MarkdownSourceEditor` tests plus desktop store action tests.
+- PRODUCT 16: existing external change action tests extended to assert mode/content behavior.
+- PRODUCT 17-18: manual desktop validation.
+
+Commands:
+
+- Quick iteration: `pnpm check`
+- Targeted tests: `pnpm --filter @hubble.md/desktop test` and UI/editor tests once added.
+- Final confidence: `pnpm build:desktop`
+
+Manual desktop validation:
+
+1. Run `HUBBLE_DESKTOP_ENABLE_CDP=1 pnpm dev:desktop`.
+2. Open a Workspace Folder or Plain Folder with a Markdown File containing front matter.
+3. Switch to `Edit source`, confirm highlighted whole-file Markdown and initial focus.
+4. Edit front matter and body, wait for save, switch to `Edit rich text`, confirm File Properties and body reflect edits.
+5. Trigger or simulate an external disk conflict and verify banner actions update the visible source/rich content correctly.
+6. Open an HTML App file and confirm source mode is not offered.
+
+## Parallelization
+
+Implementation is small enough for one agent. Parallel work would add coordination overhead because the state shape, toolbar, and editor component need to agree on the same mode semantics.
+
+## Risks and Mitigations
+
+- Data loss from stale saves: source editor should mirror `EditorView`'s debounce and unmount flush pattern.
+- Frontmatter drift: source mode edits whole-file Markdown only; rich mode remains responsible for parsing front matter from `initialMarkdown`.
+- Code block control leakage: make source-mode controls explicit so the in-document language selector does not let users switch away from Markdown highlighting.
+- Invalid front matter: preserve raw source and rely on existing File Properties unavailable behavior rather than normalizing YAML.


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/814accac-b588-4b74-be26-2b2638deb3b1


- add desktop `viewMode` state and toolbar overflow toggle for `Edit source` / `Edit rich text`
- add a Markdown-locked TipTap source editor that reuses `HubbleCodeBlock` highlighting and saves whole-file markdown through the existing save path
- keep specs in `specs/gh-142`, and add tests for mode switching/reset plus source editor document behavior

Closes #142

## Testing

- `pnpm check`
- `pnpm --filter @hubble.md/desktop test -- actions.test.ts`
- `pnpm --filter @hubble.md/ui test -- MarkdownSourceEditor.test.ts`
- `pnpm build:desktop`

## E2E

- Ran `HUBBLE_DESKTOP_ENABLE_CDP=1 pnpm dev:desktop`.
- Opened a playground Markdown file with front matter.
- Switched to `Edit source`, verified full raw Markdown including front matter appeared in highlighted source mode.
- Edited front matter/body in source mode, verified disk content saved as raw Markdown.
- Switched back to rich mode and verified File Properties/body reflected the source edits.
- Stopped the dev app and confirmed no `Hubble Dev` process remained.

## Notes

- The web package still warns it wants Node 22.x under current Node v24.14.0; checks/build passed.
