### PR TITLE
Add dark mode support (system-follow)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 ### Added
 
 - Edit a note's raw Markdown with source mode: toggle from the note's ⋯ menu or press Cmd+Option+U. [#144](https://github.com/bholmesdev/hubble.md/pull/144)
+- Dark mode: the desktop app, editor (including code-block syntax highlighting), and embedded HTML apps now follow your system appearance. [#110](https://github.com/bholmesdev/hubble.md/issues/110)
 
 ### Changed
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -92,6 +92,17 @@ const updateCheckIntervalMs = 4 * 60 * 60 * 1000;
 // class-based Tailwind dark variant and `.dark { … }` token block activate.
 nativeTheme.themeSource = "system";
 
+// Windows/Linux draw the min/max/close buttons as a native overlay whose colors
+// are static unless we update them. Mirror the app palette so the button strip
+// follows the OS appearance instead of staying light in dark mode. Hex values
+// are the resolved sRGB of the `--background`/`--muted-foreground` tokens in
+// `index.css` (light) and its `.dark` block (dark).
+function titleBarOverlayColors() {
+	return nativeTheme.shouldUseDarkColors
+		? { color: "#181715", symbolColor: "#a6a5a0" }
+		: { color: "#ffffff", symbolColor: "#454545" };
+}
+
 app.setName(appName);
 if (devAppName) {
 	app.setPath("userData", path.join(app.getPath("appData"), devAppName));
@@ -104,6 +115,16 @@ if (isDev && process.env.HUBBLE_DESKTOP_ENABLE_CDP === "1") {
 
 let mainWindow: BrowserWindow | null = null;
 let saveWindowStateTimer: ReturnType<typeof setTimeout> | null = null;
+
+// Repaint the native window-control overlay when the OS appearance changes so it
+// tracks the live theme switch (macOS manages its traffic lights itself).
+if (process.platform !== "darwin") {
+	nativeTheme.on("updated", () => {
+		if (mainWindow && !mainWindow.isDestroyed()) {
+			mainWindow.setTitleBarOverlay(titleBarOverlayColors());
+		}
+	});
+}
 let pendingOpenPath: string | null = firstExistingFileArg(
 	process.argv.slice(1),
 );
@@ -1105,7 +1126,7 @@ async function createWindow() {
 		show: false,
 		titleBarStyle: "hidden",
 		...(process.platform !== "darwin"
-			? { titleBarOverlay: { color: "#ffffff", symbolColor: "#454545" } }
+			? { titleBarOverlay: titleBarOverlayColors() }
 			: {}),
 		trafficLightPosition: trafficLightPositionForZoom(zoomFactor),
 		webPreferences: {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -94,9 +94,7 @@ nativeTheme.themeSource = "system";
 
 // Windows/Linux draw the min/max/close buttons as a native overlay whose colors
 // are static unless we update them. Mirror the app palette so the button strip
-// follows the OS appearance instead of staying light in dark mode. Hex values
-// are the resolved sRGB of the `--background`/`--muted-foreground` tokens in
-// `index.css` (light) and its `.dark` block (dark).
+// follows the OS appearance instead of staying light in dark mode.
 function titleBarOverlayColors() {
 	return nativeTheme.shouldUseDarkColors
 		? { color: "#181715", symbolColor: "#a6a5a0" }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -88,7 +88,9 @@ const supportsAutoUpdates = !isDev && process.platform === "darwin";
 // Check every 4 hours after the initial packaged-app update check.
 const updateCheckIntervalMs = 4 * 60 * 60 * 1000;
 
-nativeTheme.themeSource = "light";
+// Follow the OS appearance. The renderer mirrors this to a `.dark` class so the
+// class-based Tailwind dark variant and `.dark { … }` token block activate.
+nativeTheme.themeSource = "system";
 
 app.setName(appName);
 if (devAppName) {

--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -5,6 +5,15 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hubble</title>
+    <script>
+      // Apply the theme class before first paint so a cold launch into dark mode
+      // doesn't flash light. The live listener is attached in src/theme.ts.
+      try {
+        if (matchMedia("(prefers-color-scheme: dark)").matches) {
+          document.documentElement.classList.add("dark");
+        }
+      } catch {}
+    </script>
   </head>
 
   <body>

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -46,36 +46,34 @@
 }
 
 .dark {
-	/* Warm neutrals at hue ~95 (matching the light palette's warmth), guided by
-	   Notion's dark gray rather than a cool/neutral charcoal. */
-	--background: oklch(0.205 0.004 95);
-	--foreground: oklch(0.945 0.003 95);
-	--card: oklch(0.245 0.005 95);
+	--background: oklch(0.2 0.004 60);
+	--foreground: oklch(0.945 0.002 60);
+	--card: oklch(0.24 0.005 60);
 	--card-foreground: var(--foreground);
-	--popover: oklch(0.245 0.005 95);
+	--popover: oklch(0.24 0.005 60);
 	--popover-foreground: var(--foreground);
-	--primary: color-mix(in oklab, var(--brand) 88%, white);
-	--primary-foreground: oklch(0.18 0.004 95);
-	--secondary: oklch(0.285 0.005 95);
+	--primary: oklch(0.47 0.08 159.6);
+	--primary-foreground: oklch(0.985 0 0);
+	--secondary: oklch(0.285 0.005 60);
 	--secondary-foreground: var(--foreground);
-	--muted: oklch(0.275 0.005 95);
-	--muted-foreground: oklch(0.72 0.006 95);
-	--accent: oklch(0.29 0.006 95);
+	--muted: oklch(0.275 0.005 60);
+	--muted-foreground: oklch(0.72 0.006 60);
+	--accent: oklch(0.32 0.04 88);
 	--accent-foreground: var(--foreground);
-	/* Warm amber selection, echoing the light palette's yellow. */
-	--selected: oklch(0.4 0.045 92);
-	--selected-foreground: var(--foreground);
+	--selected: oklch(0.73 0.125 88);
+	--selected-foreground: oklch(0.24 0.03 85);
 	--destructive: oklch(0.704 0.191 22.216);
 	--destructive-foreground: oklch(0.985 0 0);
 	--border: oklch(1 0 0 / 10%);
 	--input: oklch(1 0 0 / 14%);
-	--ring: color-mix(in oklab, var(--brand) 68%, white);
+	--ring: oklch(0.75 0.13 85);
 	--sidebar: var(--card);
 	--sidebar-foreground: var(--foreground);
 	--sidebar-primary: var(--primary);
 	--sidebar-primary-foreground: var(--primary-foreground);
-	--sidebar-accent: var(--accent);
-	--sidebar-accent-foreground: var(--accent-foreground);
+	/* gray until sidebar focused; :focus-within (theme.css) swaps to --selected */
+	--sidebar-accent: oklch(0.32 0.006 60);
+	--sidebar-accent-foreground: var(--foreground);
 	--sidebar-border: var(--border);
 	--sidebar-ring: var(--ring);
 }

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -46,22 +46,24 @@
 }
 
 .dark {
-	--background: oklch(0.236 0.006 106);
-	--foreground: oklch(0.962 0.003 106);
-	--card: oklch(0.274 0.006 106);
+	/* Warm neutrals at hue ~95 (matching the light palette's warmth), guided by
+	   Notion's dark gray rather than a cool/neutral charcoal. */
+	--background: oklch(0.205 0.004 95);
+	--foreground: oklch(0.945 0.003 95);
+	--card: oklch(0.245 0.005 95);
 	--card-foreground: var(--foreground);
-	--popover: oklch(0.274 0.006 106);
+	--popover: oklch(0.245 0.005 95);
 	--popover-foreground: var(--foreground);
 	--primary: color-mix(in oklab, var(--brand) 88%, white);
-	--primary-foreground: oklch(0.18 0.005 106);
-	--secondary: oklch(0.315 0.006 106);
+	--primary-foreground: oklch(0.18 0.004 95);
+	--secondary: oklch(0.285 0.005 95);
 	--secondary-foreground: var(--foreground);
-	--muted: oklch(0.302 0.006 106);
-	--muted-foreground: oklch(0.754 0.005 106);
-	--accent: oklch(0.312 0.006 106);
+	--muted: oklch(0.275 0.005 95);
+	--muted-foreground: oklch(0.72 0.006 95);
+	--accent: oklch(0.29 0.006 95);
 	--accent-foreground: var(--foreground);
-	/* Dark keeps neutral state colors for now (light mode is the brand focus) */
-	--selected: oklch(0.36 0.008 106);
+	/* Warm amber selection, echoing the light palette's yellow. */
+	--selected: oklch(0.4 0.045 92);
 	--selected-foreground: var(--foreground);
 	--destructive: oklch(0.704 0.191 22.216);
 	--destructive-foreground: oklch(0.985 0 0);

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -2,8 +2,11 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import { Toaster } from "./components/Toaster";
+import { initSystemTheme } from "./theme";
 import "./components/toast.css";
 import "./index.css";
+
+initSystemTheme();
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
 	<React.StrictMode>

--- a/apps/desktop/src/theme.test.ts
+++ b/apps/desktop/src/theme.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { initSystemTheme } from "./theme";
+
+type ChangeListener = (event: { matches: boolean }) => void;
+
+/**
+ * Stubs `matchMedia` with a controllable MediaQueryList so a test can flip the
+ * OS appearance via `emit()` and assert how `initSystemTheme` reacts.
+ */
+function mockMatchMedia(initialMatches: boolean) {
+	let matches = initialMatches;
+	const listeners = new Set<ChangeListener>();
+	const mql = {
+		get matches() {
+			return matches;
+		},
+		media: "(prefers-color-scheme: dark)",
+		addEventListener: (_type: "change", listener: ChangeListener) => {
+			listeners.add(listener);
+		},
+		removeEventListener: (_type: "change", listener: ChangeListener) => {
+			listeners.delete(listener);
+		},
+	};
+	vi.stubGlobal(
+		"matchMedia",
+		vi.fn(() => mql),
+	);
+	return {
+		emit(next: boolean) {
+			matches = next;
+			for (const listener of listeners) listener({ matches: next });
+		},
+	};
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	document.documentElement.classList.remove("dark");
+});
+
+describe("initSystemTheme", () => {
+	it("adds the dark class when the OS prefers dark", () => {
+		mockMatchMedia(true);
+		initSystemTheme();
+		expect(document.documentElement.classList.contains("dark")).toBe(true);
+	});
+
+	it("leaves the dark class off when the OS prefers light", () => {
+		mockMatchMedia(false);
+		initSystemTheme();
+		expect(document.documentElement.classList.contains("dark")).toBe(false);
+	});
+
+	it("reacts to the OS switching appearance at runtime", () => {
+		const { emit } = mockMatchMedia(false);
+		initSystemTheme();
+		expect(document.documentElement.classList.contains("dark")).toBe(false);
+
+		emit(true);
+		expect(document.documentElement.classList.contains("dark")).toBe(true);
+
+		emit(false);
+		expect(document.documentElement.classList.contains("dark")).toBe(false);
+	});
+});

--- a/apps/desktop/src/theme.ts
+++ b/apps/desktop/src/theme.ts
@@ -1,12 +1,5 @@
 /**
  * Keeps the `dark` class on `<html>` in sync with the OS color scheme.
- *
- * The desktop theme uses a class-based Tailwind dark variant
- * (`@custom-variant dark (&:is(.dark *))` in `index.css`), so the dormant
- * `.dark { … }` token block only takes effect when `.dark` is present on an
- * ancestor. Electron sets `nativeTheme.themeSource = "system"`, which mirrors
- * the OS appearance onto the renderer's `prefers-color-scheme`, so the media
- * query is the source of truth for "is the OS in dark mode?".
  */
 export function initSystemTheme(): void {
 	const query = window.matchMedia("(prefers-color-scheme: dark)");

--- a/apps/desktop/src/theme.ts
+++ b/apps/desktop/src/theme.ts
@@ -1,0 +1,18 @@
+/**
+ * Keeps the `dark` class on `<html>` in sync with the OS color scheme.
+ *
+ * The desktop theme uses a class-based Tailwind dark variant
+ * (`@custom-variant dark (&:is(.dark *))` in `index.css`), so the dormant
+ * `.dark { … }` token block only takes effect when `.dark` is present on an
+ * ancestor. Electron sets `nativeTheme.themeSource = "system"`, which mirrors
+ * the OS appearance onto the renderer's `prefers-color-scheme`, so the media
+ * query is the source of truth for "is the OS in dark mode?".
+ */
+export function initSystemTheme(): void {
+	const query = window.matchMedia("(prefers-color-scheme: dark)");
+	const apply = (isDark: boolean) => {
+		document.documentElement.classList.toggle("dark", isDark);
+	};
+	apply(query.matches);
+	query.addEventListener("change", (event) => apply(event.matches));
+}

--- a/packages/runtime/html-app-theme.css
+++ b/packages/runtime/html-app-theme.css
@@ -24,8 +24,6 @@
 	--radius: 0.625rem;
 }
 
-/* Dark mode. The sandboxed iframe inherits the host's resolved color scheme, so
-   prefers-color-scheme works without host-to-iframe messaging. Mirrors `.dark`. */
 @media (prefers-color-scheme: dark) {
 	:root {
 		--background: oklch(0.2 0.004 60);

--- a/packages/runtime/html-app-theme.css
+++ b/packages/runtime/html-app-theme.css
@@ -1,5 +1,5 @@
 :root {
-	color-scheme: light;
+	color-scheme: light dark;
 	--brand: oklch(0.426 0.08 159.6);
 	--brand-accent: oklch(0.847 0.168 84.7);
 	--brand-accent-foreground: oklch(0.327 0.051 164.9);
@@ -22,6 +22,31 @@
 	--input: oklch(0.91 0.004 95);
 	--ring: var(--brand-accent);
 	--radius: 0.625rem;
+}
+
+/*
+ * Dark mode. HTML apps render in a sandboxed iframe that still inherits the
+ * host renderer's resolved color scheme, so a media query is the right signal
+ * for system-follow — no host-to-iframe messaging needed. Palette mirrors the
+ * desktop `.dark` block (warm neutrals at hue ~95, Notion-guided).
+ */
+@media (prefers-color-scheme: dark) {
+	:root {
+		--background: oklch(0.205 0.004 95);
+		--foreground: oklch(0.945 0.003 95);
+		--card: oklch(0.245 0.005 95);
+		--primary: color-mix(in oklab, var(--brand) 88%, white);
+		--primary-foreground: oklch(0.18 0.004 95);
+		--secondary: oklch(0.285 0.005 95);
+		--muted: oklch(0.275 0.005 95);
+		--muted-foreground: oklch(0.72 0.006 95);
+		--accent: oklch(0.29 0.006 95);
+		--selected: oklch(0.4 0.045 92);
+		--destructive: oklch(0.704 0.191 22.216);
+		--border: oklch(1 0 0 / 10%);
+		--input: oklch(1 0 0 / 14%);
+		--ring: color-mix(in oklab, var(--brand) 68%, white);
+	}
 }
 
 @theme inline {

--- a/packages/runtime/html-app-theme.css
+++ b/packages/runtime/html-app-theme.css
@@ -24,28 +24,29 @@
 	--radius: 0.625rem;
 }
 
-/*
- * Dark mode. HTML apps render in a sandboxed iframe that still inherits the
- * host renderer's resolved color scheme, so a media query is the right signal
- * for system-follow — no host-to-iframe messaging needed. Palette mirrors the
- * desktop `.dark` block (warm neutrals at hue ~95, Notion-guided).
- */
+/* Dark mode. The sandboxed iframe inherits the host's resolved color scheme, so
+   prefers-color-scheme works without host-to-iframe messaging. Mirrors `.dark`. */
 @media (prefers-color-scheme: dark) {
 	:root {
-		--background: oklch(0.205 0.004 95);
-		--foreground: oklch(0.945 0.003 95);
-		--card: oklch(0.245 0.005 95);
-		--primary: color-mix(in oklab, var(--brand) 88%, white);
-		--primary-foreground: oklch(0.18 0.004 95);
-		--secondary: oklch(0.285 0.005 95);
-		--muted: oklch(0.275 0.005 95);
-		--muted-foreground: oklch(0.72 0.006 95);
-		--accent: oklch(0.29 0.006 95);
-		--selected: oklch(0.4 0.045 92);
+		--background: oklch(0.2 0.004 60);
+		--foreground: oklch(0.945 0.002 60);
+		--card: oklch(0.24 0.005 60);
+		--primary: oklch(0.47 0.08 159.6);
+		--primary-foreground: oklch(0.985 0 0);
+		--secondary: oklch(0.285 0.005 60);
+		--muted: oklch(0.275 0.005 60);
+		--muted-foreground: oklch(0.72 0.006 60);
+		--accent: oklch(0.32 0.04 88);
+		--selected: oklch(0.73 0.125 88);
+		--selected-foreground: oklch(0.24 0.03 85);
 		--destructive: oklch(0.704 0.191 22.216);
 		--border: oklch(1 0 0 / 10%);
 		--input: oklch(1 0 0 / 14%);
-		--ring: color-mix(in oklab, var(--brand) 68%, white);
+		--ring: oklch(0.75 0.13 85);
+	}
+
+	::selection {
+		background: color-mix(in oklab, #8a764b 88%, transparent);
 	}
 }
 

--- a/packages/ui/src/editor/EditorView.css
+++ b/packages/ui/src/editor/EditorView.css
@@ -469,6 +469,84 @@
 	font-style: italic;
 }
 
+/*
+ * Dark-mode syntax palette (Atom One Dark), paired with the Xcode-style light
+ * theme above. The light rules' hardcoded hex would be unreadable on a dark
+ * surface, so each selector group is re-colored when a `.dark` ancestor is
+ * present (the class-based dark variant). The weight/style rules above are
+ * color-agnostic and need no override.
+ */
+.dark [data-hubble-editor] .ProseMirror pre code {
+	color: #abb2bf;
+}
+
+.dark [data-hubble-editor] .ProseMirror .xml .hljs-meta {
+	color: #5c6370;
+}
+
+.dark [data-hubble-editor] .ProseMirror .hljs-comment,
+.dark [data-hubble-editor] .ProseMirror .hljs-quote {
+	color: #7f848e;
+}
+
+.dark [data-hubble-editor] .ProseMirror .hljs-tag,
+.dark [data-hubble-editor] .ProseMirror .hljs-attribute,
+.dark [data-hubble-editor] .ProseMirror .hljs-keyword,
+.dark [data-hubble-editor] .ProseMirror .hljs-selector-tag,
+.dark [data-hubble-editor] .ProseMirror .hljs-literal,
+.dark [data-hubble-editor] .ProseMirror .hljs-name {
+	color: #c678dd;
+}
+
+.dark [data-hubble-editor] .ProseMirror .hljs-variable,
+.dark [data-hubble-editor] .ProseMirror .hljs-template-variable {
+	color: #e06c75;
+}
+
+.dark [data-hubble-editor] .ProseMirror .hljs-code,
+.dark [data-hubble-editor] .ProseMirror .hljs-string,
+.dark [data-hubble-editor] .ProseMirror .hljs-meta .hljs-string {
+	color: #98c379;
+}
+
+.dark [data-hubble-editor] .ProseMirror .hljs-regexp,
+.dark [data-hubble-editor] .ProseMirror .hljs-link {
+	color: #56b6c2;
+}
+
+.dark [data-hubble-editor] .ProseMirror .hljs-title,
+.dark [data-hubble-editor] .ProseMirror .hljs-symbol,
+.dark [data-hubble-editor] .ProseMirror .hljs-bullet,
+.dark [data-hubble-editor] .ProseMirror .hljs-number {
+	color: #d19a66;
+}
+
+.dark [data-hubble-editor] .ProseMirror .hljs-section,
+.dark [data-hubble-editor] .ProseMirror .hljs-meta {
+	color: #61afef;
+}
+
+.dark [data-hubble-editor] .ProseMirror .hljs-title.class_,
+.dark [data-hubble-editor] .ProseMirror .hljs-class .hljs-title,
+.dark [data-hubble-editor] .ProseMirror .hljs-type,
+.dark [data-hubble-editor] .ProseMirror .hljs-built_in,
+.dark [data-hubble-editor] .ProseMirror .hljs-params {
+	color: #e5c07b;
+}
+
+.dark [data-hubble-editor] .ProseMirror .hljs-attr {
+	color: #d19a66;
+}
+
+.dark [data-hubble-editor] .ProseMirror .hljs-subst {
+	color: #abb2bf;
+}
+
+.dark [data-hubble-editor] .ProseMirror .hljs-selector-id,
+.dark [data-hubble-editor] .ProseMirror .hljs-selector-class {
+	color: #e06c75;
+}
+
 [data-hubble-editor] .ProseMirror span[data-link="true"] {
 	color: color-mix(in oklab, var(--brand) 48%, var(--foreground));
 	text-decoration: underline;

--- a/packages/ui/src/editor/EditorView.css
+++ b/packages/ui/src/editor/EditorView.css
@@ -471,10 +471,7 @@
 
 /*
  * Dark-mode syntax palette (Atom One Dark), paired with the Xcode-style light
- * theme above. The light rules' hardcoded hex would be unreadable on a dark
- * surface, so each selector group is re-colored when a `.dark` ancestor is
- * present (the class-based dark variant). The weight/style rules above are
- * color-agnostic and need no override.
+ * theme above.
  */
 .dark [data-hubble-editor] .ProseMirror pre code {
 	color: #abb2bf;

--- a/packages/ui/src/theme.css
+++ b/packages/ui/src/theme.css
@@ -99,8 +99,14 @@
 /* Selected row goes yellow only while the sidebar pane is focused (else gray). */
 [data-sidebar-root]:focus-within {
 	--sidebar-accent: var(--selected);
+	--sidebar-accent-foreground: var(--selected-foreground);
 }
 
 ::selection {
 	background: color-mix(in oklab, var(--selected) 70%, transparent);
+}
+
+/* muted highlight; the brand gold is too loud on dark */
+.dark ::selection {
+	background: color-mix(in oklab, #8a764b 88%, transparent);
 }

--- a/specs/gh-110/PRODUCT.md
+++ b/specs/gh-110/PRODUCT.md
@@ -1,0 +1,69 @@
+# Dark mode
+
+## Summary
+
+Hubble Desktop follows the operating system's appearance. When macOS (or the
+host OS) is in dark mode, the app, the editor, and embedded HTML apps switch to
+a dark color scheme; when it returns to light, they switch back. There is no
+in-app theme control in this slice — the OS is the single source of truth.
+
+## Problem
+
+The desktop app is hard-locked to light (`nativeTheme.themeSource = "light"` in
+`apps/desktop/electron/main.ts`). A `.dark` token palette and a class-based dark
+variant already exist in `apps/desktop/src/index.css`, but nothing ever applies
+the `.dark` class, so the dark palette is dead code. Users who run their OS in
+dark mode get a bright window regardless. (GitHub #110.)
+
+## Goals
+
+- The desktop app respects the OS appearance on launch and reacts when the OS
+  appearance changes while the app is open.
+- The editor surface — prose, sidebar, chrome, and code-block syntax
+  highlighting — is legible and on-brand in dark mode.
+- Embedded HTML apps render against a dark palette when the app is dark.
+- Light mode is visually unchanged from today.
+- The dark palette is warm and brand-consistent, guided by Notion's dark
+  palette, not a generic neutral gray.
+
+## Non-goals
+
+- No in-app theme switcher (System / Light / Dark menu or setting). A manual
+  override can be a follow-up; this slice is system-follow only.
+- No persisted theme preference (nothing to persist without an override).
+- No change to the `www` marketing/web app. It is WIP and consumes the shared
+  theme separately; bringing it to dark is tracked with the shared-token
+  unification (#56) and is out of scope here.
+- No redesign of the light palette.
+
+## Behavior
+
+1. On launch, the desktop app detects the OS appearance and renders dark when
+   the OS is dark, light otherwise.
+2. When the OS appearance changes while the app is open, the app switches to
+   match without a relaunch.
+3. The window chrome, traffic-light region, and native menus follow the OS
+   appearance (handled by Electron once the light lock is removed).
+4. In dark mode, editor prose, headings, links, inline code, task lists,
+   blockquotes, and the sidebar use the dark token palette.
+5. Code-block syntax highlighting uses a dark theme that stays legible on the
+   dark code surface (the current highlight colors are tuned for light only).
+6. Embedded HTML apps render against the dark palette when the app is dark, and
+   declare `color-scheme: light dark` so their native form controls and scrollbars
+   match.
+7. Light mode renders identically to the current release.
+
+## UX validation
+
+Run the desktop app (`pnpm dev:desktop`) with the OS in dark mode:
+
+1. Confirm the window, sidebar, and editor open dark, with legible text and
+   on-brand accents.
+2. Open a note containing a fenced code block; confirm syntax colors are
+   readable on the dark surface.
+3. Open a note with an embedded HTML app; confirm it renders dark, not a bright
+   panel inside a dark window.
+4. Switch the OS to light while the app is open; confirm the app follows within
+   a moment, with no relaunch and no stuck half-dark state.
+5. Switch back to dark; confirm the same.
+6. With the OS in light mode, confirm the app is visually identical to today.

--- a/specs/gh-110/TECH.md
+++ b/specs/gh-110/TECH.md
@@ -1,0 +1,139 @@
+# Dark mode — technical notes
+
+## Theme detection (the mechanism)
+
+Remove the light lock in `apps/desktop/electron/main.ts`:
+
+```diff
+- nativeTheme.themeSource = "light";
++ nativeTheme.themeSource = "system";
+```
+
+`"system"` makes Electron mirror the OS appearance onto the renderer's
+`prefers-color-scheme`, and it lets the native chrome/menus follow the OS for
+free.
+
+The renderer's dark variant is **class-based**
+(`@custom-variant dark (&:is(.dark *))` in `apps/desktop/src/index.css`), so a
+CSS `@media (prefers-color-scheme: dark)` block would not activate it. A small
+renderer module watches the media query and toggles `.dark` on
+`<html>`:
+
+```ts
+// apps/desktop/src/theme.ts
+export function initSystemTheme(): void {
+	const query = window.matchMedia("(prefers-color-scheme: dark)");
+	const apply = (isDark: boolean) =>
+		document.documentElement.classList.toggle("dark", isDark);
+	apply(query.matches);
+	query.addEventListener("change", (e) => apply(e.matches));
+}
+```
+
+Called once from `src/main.tsx` before `createRoot`. This is the full mechanism
+for the main app surface, and it is the part proven by the reference branch
+(see below).
+
+**Light-lock decision:** the lock is removed, not kept behind a flag. Keeping a
+light override would defeat the feature; `"system"` is the desired default and
+is reversible if a manual override is added later.
+
+**Flash-on-launch:** `main.tsx` runs after first paint, so cold-launching into
+dark would show a one-frame light flash. A tiny inline `<head>` script in
+`index.html` sets the class from `matchMedia` before paint (the standard FOUC
+fix); `src/theme.ts` then attaches the live listener. The app ships no Content
+Security Policy, so the inline script is unblocked; if a CSP is added later it
+needs a hash/nonce for this script.
+
+## Surfaces in scope
+
+Dark mode touches three theme sources. They are independent and can land
+incrementally.
+
+1. **Desktop React app** — `apps/desktop/src/index.css` already defines the
+   `.dark` token block and the dark variant. Only the detection wiring above is
+   needed. **(Proven in the reference branch.)**
+
+2. **Code-block syntax highlighting** — `packages/ui/src/editor/EditorView.css`
+   hardcodes Xcode-light hex for `.hljs-*` tokens (lines ~331–401). Add a
+   `.dark`-scoped override block with a dark palette (the reference branch uses
+   Atom One Dark). Lower-churn than tokenizing every rule; can be promoted to
+   `--syntax-*` custom properties later if desired.
+
+3. **Embedded HTML apps** — `packages/runtime/html-app-theme.css` is a
+   self-contained copy of the light palette with `color-scheme: light`, injected
+   `?raw` into each HTML-app `<head>` via `htmlAppHeadStyles` in
+   `apps/desktop/electron/main.ts`. HTML apps render in a sandboxed
+   `<iframe sandbox="allow-scripts allow-forms">` (`src/editor/IframeView.tsx`).
+   A sandboxed iframe still inherits the host renderer's resolved
+   `prefers-color-scheme`, so a `@media (prefers-color-scheme: dark)` block in
+   the injected theme is enough — **no host-to-iframe theme messaging needed**.
+   The fix: set `color-scheme: light dark` on `:root` (so UA controls and
+   scrollbars adapt) and add a `@media (prefers-color-scheme: dark)` block that
+   swaps the palette tokens. Verified working in a sandboxed HTML app, light and
+   dark. (Note: this surface is media-query driven; the main app is class
+   driven. They agree under system-follow. A future manual override would need
+   to also signal the iframe — e.g. emulate/propagate the scheme — to stay in
+   sync.)
+
+### Token duplication note
+
+The light palette now lives in three places: `packages/ui/src/theme.css`
+(shared), `apps/desktop/src/index.css` (desktop superset, holds the `.dark`
+block), and `packages/runtime/html-app-theme.css` (HTML-app runtime). #56 closed
+the desktop↔shared duplication conceptually; dark mode re-raises it because the
+`.dark` block currently lives only in the desktop file. Decide whether the dark
+tokens should move into the shared `theme.css` so the runtime and any future
+`www` work inherit them, or stay per-surface for this slice. The minimal slice
+keeps them per-surface to limit blast radius.
+
+## Dark palette (the open design decision)
+
+The existing `.dark` tokens are explicitly placeholder ("Dark keeps neutral
+state colors for now (light mode is the brand focus)") and sit at hue 106
+(yellow-green). The light palette is warm at hue ~95. To match #110's
+"warmer, Notion-guided" ask, align the dark neutrals to the warm family and let
+the brand green carry the accent:
+
+| Token | Current placeholder | Proposed (warm, Notion-guided) |
+|-------|--------------------|--------------------------------|
+| `--background` | `oklch(0.236 0.006 106)` | `oklch(0.205 0.004 95)` — near-Notion `#191919`, warm |
+| `--card` / `--popover` | `oklch(0.274 0.006 106)` | `oklch(0.245 0.005 95)` |
+| `--sidebar` | `= card` | `var(--card)` |
+| `--foreground` | `oklch(0.962 0.003 106)` | `oklch(0.945 0.003 95)` (warm off-white) |
+| `--muted-foreground` | `oklch(0.754 0.005 106)` | `oklch(0.72 0.006 95)` |
+| `--primary` | `brand 88% + white` | keep (lifted forest reads well on dark) |
+| `--selected` | neutral gray | warm amber tint to echo the light "selected" yellow |
+
+These values are applied in the reference branch (desktop `.dark` block and the
+HTML-app runtime dark block) and verified in screenshots. They are still open to
+a designer's eye on final tuning — listed so the palette decision is explicit
+rather than implicit.
+
+## Testing
+
+- **Unit (proven):** `apps/desktop/src/theme.test.ts` — `initSystemTheme` adds
+  `.dark` when the OS prefers dark, leaves it off for light, and reacts to a
+  runtime appearance change. Runs under the per-file `// @vitest-environment
+  happy-dom` directive (happy-dom is already available; no new dep/config).
+- **Manual:** the UX-validation steps in PRODUCT.md, plus before/after
+  screenshots in light and dark.
+- **Regression:** existing desktop (`pnpm --filter @hubble.md/desktop test`) and
+  editor (`pnpm --filter @hubble.md/editor test`) suites stay green;
+  `pnpm build:desktop` (tsc + electron-vite) and Biome stay clean.
+
+## Reference branch
+
+A working branch implements all three surfaces plus the warm palette and the
+anti-flash guard:
+
+- detection wiring (`themeSource = "system"`, `src/theme.ts`, inline guard),
+- dark code-block syntax theme,
+- warm Notion-guided palette in the desktop `.dark` block,
+- HTML-app runtime dark block,
+- a `happy-dom` unit test for the toggle, and a `CHANGELOG` entry.
+
+Verified: desktop suite (42) and editor suite (32) pass; `pnpm build:desktop`
+(tsc + electron-vite) and Biome are clean; screenshots cover the editor and an
+embedded HTML app in both light and dark, with light unchanged. The open item
+left for review is final palette tuning, not mechanism.


### PR DESCRIPTION
## Description

Adds dark mode that follows the system appearance, as discussed in #110 (spec + implementation, per your comment there).

**How it works:**
- `nativeTheme.themeSource` flips from `"light"` to `"system"`, so the native chrome and menus follow the OS.
- The dark variant is class-based (`@custom-variant dark (&:is(.dark *))`), so a small renderer module (`apps/desktop/src/theme.ts`) watches `matchMedia("(prefers-color-scheme: dark)")` and toggles `.dark` on `<html>`, reacting to live OS changes. An inline `<head>` guard sets the class before first paint so a cold launch into dark doesn't flash light.

**Surfaces covered:**
1. **Desktop app** — the existing `.dark` token block in `index.css` activates; placeholder values replaced with a warmer palette (neutrals at hue ~95 matching the light palette's warm family, background near Notion's `#191919`, warm amber selection, brand green accent).
2. **Code blocks** — `EditorView.css` had hardcoded Xcode-light hex for `.hljs-*`; added a `.dark`-scoped Atom One Dark palette.
3. **Embedded HTML apps** — `html-app-theme.css` moves to `color-scheme: light dark` with a `@media (prefers-color-scheme: dark)` token block mirroring the desktop palette. The sandboxed iframe inherits the host's resolved scheme, so no host→iframe messaging is needed.
4. **Terminal panel** — no changes needed: it already watches for `.dark` on `<html>` with a MutationObserver and ships its own dark ANSI palette, so it lights up as soon as the toggle exists.

Product + tech specs are in `specs/gh-110/` (PRODUCT.md, TECH.md).

Scope note: system-follow only — no in-app theme override in this slice. The `.dark` class toggle keeps that easy to add later.

Closes #110

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update

## Testing

- [x] Existing tests pass
- [x] Added new tests for changes
- [x] Tested manually (describe below)

New `happy-dom` unit test for the theme toggle (`apps/desktop/src/theme.test.ts`) covering initial dark, initial light, and live OS switching. Full workspace suites pass; `pnpm build:desktop` (electron-vite + tsc) and Biome are clean. (Pre-existing, unrelated on main: `TerminalPanel.test.tsx` fails with `useResizeSeparator is not a function` — fails identically on a clean `main` checkout.)

**Manual Testing Details:**

Verified on macOS: cold launch into dark (no flash), live switching while the app is open (editor, code blocks, embedded HTML app, and terminal panel all follow), and light mode unchanged. Windows smoke test + screenshots coming shortly (draft until then). The mechanism is all standard Electron/`matchMedia`.

### Screenshots

<img width="1840" height="1440" alt="editor-dark" src="https://github.com/user-attachments/assets/6e78c963-cf51-4767-8e4a-7aed118dddbc" />

<img width="1840" height="1440" alt="editor-light" src="https://github.com/user-attachments/assets/47fbaf5d-a008-4857-b6a7-ddb40eb373cd" />

<img width="1840" height="1440" alt="htmlapp-dark" src="https://github.com/user-attachments/assets/6fef98ef-5bc5-4ea2-b8cb-931822b962da" />

<img width="1840" height="1440" alt="htmlapp-light" src="https://github.com/user-attachments/assets/008c5bda-ce14-4eff-8edd-ff6452c5ce9a" />

<img width="1840" height="1440" alt="terminal-dark" src="https://github.com/user-attachments/assets/e3158dfc-adee-4740-a1d3-37b0795d61fd" />

<img width="1840" height="1440" alt="terminal-light" src="https://github.com/user-attachments/assets/f5c62868-02d8-4b9a-9c63-7d8a80194a77" />

https://github.com/user-attachments/assets/f6b9341f-ee48-4534-a874-a4468ae0f518



## Checklist

- [x] I discussed this change in a GitHub issue before submitting this PR
- [x] I have run the linter, formatter, and tests to ensure my code is ready for review
