### PR TITLE
feat(desktop): add rpm packaging for linux

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -108,6 +108,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install rpmbuild
+        run: sudo apt-get update && sudo apt-get install -y rpm
+
       - name: Verify tag matches desktop version
         run: |
           VERSION="$(node -p "require('./apps/desktop/package.json').version")"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 
 ### Added
 
+- Linux desktop builds now ship an RPM package alongside the existing AppImage and deb, for install on Fedora/RHEL/openSUSE and other RPM-based distros. [#151](https://github.com/bholmesdev/hubble.md/pull/151)
+
 ### Changed
 
 ### Fixed

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -121,13 +121,18 @@
 			"category": "Office",
 			"target": [
 				"AppImage",
-				"deb"
+				"deb",
+				"rpm"
 			]
 		},
 		"appImage": {
 			"artifactName": "hubble_${version}_${arch}.${ext}"
 		},
 		"deb": {
+			"packageName": "hubble.md",
+			"artifactName": "hubble_${version}_${arch}.${ext}"
+		},
+		"rpm": {
 			"packageName": "hubble.md",
 			"artifactName": "hubble_${version}_${arch}.${ext}"
 		},


### PR DESCRIPTION
## Summary

Adds RPM as a Linux distribution format for the desktop app, alongside the existing AppImage and deb targets. This lets users on Fedora/RHEL/openSUSE and other RPM-based distros install Hubble through their native package manager.

## Changes

- **`apps/desktop/package.json`** — add `"rpm"` to `build.linux.target`, plus an `rpm` config block mirroring the existing `deb` one so the artifact is named consistently (`hubble_${version}_${arch}.rpm`).
- **`.github/workflows/desktop-release.yml`** — install `rpmbuild` (`apt-get install -y rpm`) in the Linux release job so electron-builder can produce the RPM. electron-builder bundles its own `fpm`, so `rpmbuild` is the only extra dependency needed.

## Testing

Built locally on Fedora with `pnpm bundle:desktop:linux` — AppImage, deb, and rpm all produced under `apps/desktop/release/`. Verified the RPM metadata with `rpm -qip`.

## Notes

The change is additive and reuses the same unpacked app payload as the deb/AppImage targets, so there's no extra native-module risk. Happy to open an issue first to align on the approach if preferred — flagging since CONTRIBUTING asks for discussion before feature work.