### PR TITLE
Preserve links when copying rich text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 
 ### Fixed
 
-- Copying linked rich text now preserves hyperlinks when pasted into other rich text editors. [#149](https://github.com/bholmesdev/hubble.md/issues/149)
+- Copying linked rich text now preserves hyperlinks when pasted into other rich text editors. Thanks [@snvtac](https://github.com/snvtac)! [#149](https://github.com/bholmesdev/hubble.md/issues/149)
 
 ## [0.1.18] - 2026-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 
 ### Fixed
 
+- Copying linked rich text now preserves hyperlinks when pasted into other rich text editors. [#149](https://github.com/bholmesdev/hubble.md/issues/149)
+
 ## [0.1.18] - 2026-07-07
 
 ### Added

--- a/packages/editor/src/Link.ts
+++ b/packages/editor/src/Link.ts
@@ -38,8 +38,15 @@ export const LinkExtension = Mark.create({
 			{
 				tag: "a[href]",
 				getAttrs: (element) => {
-					const href = (element as HTMLAnchorElement).getAttribute("href");
-					return { href: href ?? "", kind: "url", target: null };
+					const anchor = element as HTMLAnchorElement;
+					const href = anchor.getAttribute("href");
+					const kind = anchor.getAttribute("data-link-kind");
+					const target = anchor.getAttribute("data-target");
+					return {
+						href: href ?? "",
+						kind: kind === "wiki" ? "wiki" : "url",
+						target,
+					};
 				},
 			},
 		];

--- a/packages/editor/src/RichTextClipboardExtension.ts
+++ b/packages/editor/src/RichTextClipboardExtension.ts
@@ -1,0 +1,56 @@
+import { Extension } from "@tiptap/core";
+import {
+	type DOMOutputSpec,
+	DOMSerializer,
+	type Mark,
+	type Schema,
+} from "@tiptap/pm/model";
+import { Plugin } from "@tiptap/pm/state";
+import { getLinkAttrs } from "./Link";
+
+export const RichTextClipboardExtension = Extension.create({
+	name: "richTextClipboard",
+
+	addProseMirrorPlugins() {
+		const clipboardSerializer = createRichTextClipboardSerializer(
+			this.editor.schema,
+		);
+		return [
+			new Plugin({
+				props: {
+					clipboardSerializer,
+				},
+			}),
+		];
+	},
+});
+
+export function createRichTextClipboardSerializer(
+	schema: Schema,
+): DOMSerializer {
+	const baseSerializer = DOMSerializer.fromSchema(schema);
+	return new DOMSerializer(baseSerializer.nodes, {
+		...baseSerializer.marks,
+		link: serializeLinkForClipboard,
+	});
+}
+
+function serializeLinkForClipboard(mark: Mark): DOMOutputSpec {
+	const attrs = getLinkAttrs(mark.attrs);
+	if (!attrs?.href) {
+		return ["span", { "data-link": "true" }, 0];
+	}
+
+	const htmlAttrs: Record<string, string> = {
+		href: attrs.href,
+		"data-href": attrs.href,
+		"data-link-kind": attrs.kind,
+		"data-link": "true",
+	};
+
+	if (attrs.target) {
+		htmlAttrs["data-target"] = attrs.target;
+	}
+
+	return ["a", htmlAttrs, 0];
+}

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -50,6 +50,10 @@ export {
 	selectionToMarkdown,
 	tiptapDocToMarkdown,
 } from "./prosemirrorToMarkdown";
+export {
+	createRichTextClipboardSerializer,
+	RichTextClipboardExtension,
+} from "./RichTextClipboardExtension";
 export { StoredMarksDecorationExtension } from "./StoredMarksDecorationExtension";
 export { StrikethroughShortcutExtension } from "./StrikethroughShortcutExtension";
 export {

--- a/packages/ui/src/editor/EditorView.tsx
+++ b/packages/ui/src/editor/EditorView.tsx
@@ -8,6 +8,7 @@ import {
 	MarkdownRolloverExtension,
 	markdownToTiptapDoc,
 	parseMarkdownFrontMatter,
+	RichTextClipboardExtension,
 	StrikethroughShortcutExtension,
 	tiptapDocToMarkdown,
 } from "@hubble.md/editor";
@@ -150,6 +151,7 @@ export function EditorView({
 			StarterKit.configure({ codeBlock: false, listItem: false }),
 			HubbleCodeBlock,
 			LinkExtension,
+			RichTextClipboardExtension,
 			SmartLinkExtension,
 			LinkClickExtension.configure({ onOpenExternalLink, onOpenWikiLink }),
 			LinkCreationGhostExtension,

--- a/packages/ui/src/editor/richTextClipboard.test.ts
+++ b/packages/ui/src/editor/richTextClipboard.test.ts
@@ -1,0 +1,159 @@
+// @vitest-environment happy-dom
+
+import { LinkExtension, RichTextClipboardExtension } from "@hubble.md/editor";
+import { Editor, type JSONContent } from "@tiptap/core";
+import { DOMParser } from "@tiptap/pm/model";
+import { TextSelection } from "@tiptap/pm/state";
+import StarterKit from "@tiptap/starter-kit";
+import { afterEach, describe, expect, it } from "vitest";
+
+const editors: Editor[] = [];
+
+afterEach(() => {
+	for (const editor of editors) editor.destroy();
+	editors.length = 0;
+});
+
+describe("rich text clipboard serialization", () => {
+	it("serializes linked selections as HTML anchors", () => {
+		const editor = createEditor(
+			docWithLinkedText("OpenAI", "https://openai.com"),
+		);
+		selectText(editor, 1, 7);
+
+		const html = serializeSelectionHTML(editor);
+
+		expect(html).toContain("<a");
+		expect(html).toContain('href="https://openai.com"');
+		expect(html).toContain(">OpenAI</a>");
+	});
+
+	it("keeps Hubble link metadata on copied wiki links", () => {
+		const editor = createEditor(
+			docWithLinkedText("Project note", "Notes/Project.md", {
+				kind: "wiki",
+				target: "Notes/Project.md",
+			}),
+		);
+		selectText(editor, 1, 13);
+
+		const html = serializeSelectionHTML(editor);
+
+		expect(html).toContain("<a");
+		expect(html).toContain('href="Notes/Project.md"');
+		expect(html).toContain('data-link-kind="wiki"');
+		expect(html).toContain('data-target="Notes/Project.md"');
+	});
+
+	it("parses copied wiki anchors back into wiki link marks", () => {
+		const editor = createEditor(docWithParagraph("placeholder"));
+		const container = document.createElement("div");
+		container.innerHTML =
+			'<p><a href="Notes/Project.md" data-link-kind="wiki" data-target="Notes/Project.md">Project note</a></p>';
+
+		const parsed = DOMParser.fromSchema(editor.schema).parse(container);
+
+		expect(parsed.toJSON()).toMatchObject({
+			type: "doc",
+			content: [
+				{
+					type: "paragraph",
+					content: [
+						{
+							type: "text",
+							text: "Project note",
+							marks: [
+								{
+									type: "link",
+									attrs: {
+										href: "Notes/Project.md",
+										kind: "wiki",
+										target: "Notes/Project.md",
+									},
+								},
+							],
+						},
+					],
+				},
+			],
+		});
+	});
+});
+
+function createEditor(content: JSONContent) {
+	const editor = new Editor({
+		element: document.createElement("div"),
+		extensions: [
+			StarterKit.configure({ link: false }),
+			LinkExtension,
+			RichTextClipboardExtension,
+		],
+		content,
+	});
+	editors.push(editor);
+	return editor;
+}
+
+function selectText(editor: Editor, from: number, to: number) {
+	editor.view.dispatch(
+		editor.state.tr.setSelection(
+			TextSelection.create(editor.state.doc, from, to),
+		),
+	);
+}
+
+function serializeSelectionHTML(editor: Editor) {
+	const serializer = editor.view.someProp("clipboardSerializer");
+	if (!serializer) throw new Error("Expected clipboard serializer");
+
+	const wrapper = document.createElement("div");
+	wrapper.appendChild(
+		serializer.serializeFragment(editor.state.selection.content().content, {
+			document,
+		}),
+	);
+	return wrapper.innerHTML;
+}
+
+function docWithParagraph(text: string): JSONContent {
+	return {
+		type: "doc",
+		content: [
+			{
+				type: "paragraph",
+				content: [{ type: "text", text }],
+			},
+		],
+	};
+}
+
+function docWithLinkedText(
+	text: string,
+	href: string,
+	attrs?: { kind?: "url" | "wiki"; target?: string },
+): JSONContent {
+	return {
+		type: "doc",
+		content: [
+			{
+				type: "paragraph",
+				content: [
+					{
+						type: "text",
+						text,
+						marks: [
+							{
+								type: "link",
+								attrs: {
+									href,
+									kind: attrs?.kind ?? "url",
+									target: attrs?.target ?? null,
+								},
+							},
+						],
+					},
+				],
+			},
+		],
+	};
+}


### PR DESCRIPTION
## Description

Copying linked content from the rich text editor now includes an HTML clipboard representation with real `<a href>` anchors, so links survive when pasted into rich text targets.

- Adds a rich text clipboard serializer that emits anchors for Hubble link marks while preserving `data-link-kind` and `data-target` metadata for internal wiki links.
- Updates anchor parsing so copied wiki anchors round-trip back into Hubble wiki link marks.
- Registers the serializer in the shared editor view and covers URL/wiki serialization with regression tests.
- Adds an Unreleased changelog entry.

Closes #149

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update

## Testing

- [x] Existing tests pass
- [x] Added new tests for changes
- [ ] Tested manually (describe below)

**Manual Testing Details:**

Not manually tested in an external rich text target. Verified with automated clipboard serializer coverage and repo validation:

- `git diff --check`
- `pnpm check`
- `pnpm --filter @hubble.md/ui exec vitest run src/editor/richTextClipboard.test.ts`
- `pnpm --filter @hubble.md/editor test`
- `pnpm --filter @hubble.md/ui test`
- `pnpm test`
- `pnpm build`
- `pnpm build:desktop`

## Checklist

- [x] I discussed this change in a GitHub issue before submitting this PR
- [x] I have run the linter, formatter, and tests to ensure my code is ready for review
