### PR TITLE
Spec desktop document back/forward navigation (#111)

### DIFF
--- a/specs/gh-111/PRODUCT.md
+++ b/specs/gh-111/PRODUCT.md
@@ -1,0 +1,78 @@
+# Document back/forward navigation
+
+## Summary
+
+Desktop users can step back and forward through documents they opened in the current app session, using toolbar buttons, keyboard shortcuts, and View menu items. History is per open folder session, not a browser-style app location stack.
+
+## Problem
+
+Users can follow wiki links and relative Markdown links into other files, but cannot return through that trail without re-finding each file. Restart can also show a failure banner when the remembered last-opened path no longer exists on disk.
+
+## Flows
+
+### Browse a linked trail and return
+
+1. With a Workspace Folder or Plain Folder open, the user opens Markdown File A, then opens B via sidebar, wiki link, relative link, file picker, or creating a new file.
+2. Back becomes available. Forward stays unavailable until the user has moved back.
+3. The user chooses Back (toolbar, `CmdOrCtrl+[`, or View → Go Back). The editor shows the previous path in the trail.
+4. The user chooses Forward (toolbar, `CmdOrCtrl+]`, or View → Go Forward). The editor returns to the later path.
+5. After moving back, opening a different file truncates the forward trail (browser-like). Re-opening the path already showing does not add another history step. Re-opening a path that appears earlier but is not the current tip adds a new tip entry.
+
+- History records successful document opens only.
+- Entries are file paths only (no scroll position, no rich/source mode).
+- Cap is 50 entries per stack; oldest entries drop first.
+- Desktop only. Web keeps ordinary browser URL history and is unchanged.
+
+### Leave a dirty note via history
+
+1. The user edits the open file without resolving an external conflict, then chooses Back or Forward.
+2. Hubble saves the current file with normal save behavior, then navigates.
+3. If the open file already has an external disk conflict, or save discovers one, navigation does not run; the user stays on the current file and sees existing conflict UI where applicable.
+4. While a history navigation is in progress, Back and Forward are unavailable (toolbar and menu). There is no optimistic transition.
+
+### Follow a path outside the open folder
+
+1. From a file in the open folder, the user follows a relative link (or opens a Loose File) that resolves outside that folder.
+2. The outside path becomes the current document and is part of the same history trail for that open-folder session.
+3. Back returns to the prior path in that trail, including the in-folder note the user came from.
+
+### Switch open folders mid-session
+
+1. The user builds a history trail in open folder A, then opens folder B.
+2. Folder B has its own trail (empty until an open, or seeded by restore of its last-opened path).
+3. Switching back to A in the same app session restores A’s trail and cursor as left.
+
+- No open folder: one ephemeral session trail so Loose File browsing can still use Back/Forward.
+- Opening a folder does not merge the no-folder trail into that folder’s trail.
+- Restart discards all trails. Restore still uses the existing last-opened path bookkeeping only.
+
+### Missing files
+
+1. On app or folder restore, if the remembered last-opened path is missing on disk, Hubble clears the open document quietly: no error toast, no failure banner, and the bad last-opened entry is dropped.
+2. If Back or Forward would land on a missing path, that entry is removed and navigation continues in the same direction until a file loads or no further step exists. A toast appears only if the whole move fails.
+3. An intentional open of a missing path (broken link, picker race) still shows the existing open-failure toast and does not add a history entry.
+
+### Rename, move, and delete
+
+1. Renaming or moving a file or folder rewrites matching history paths the same way the open path and last-opened bookkeeping already update.
+2. Deleting a file or folder removes matching history entries.
+3. Deleting the currently open document clears the editor (existing behavior) and clears the active history trail. The next successful open starts a new tip. Hubble does not auto-open a neighbor from history.
+
+### Toolbar, shortcuts, and menu
+
+1. Back and Forward sit in the top toolbar’s start-side chrome.
+2. With the sidebar open, that start-side region matches the sidebar width and the nav buttons sit at its end edge (aligned to the sidebar/content seam).
+3. With the sidebar collapsed, the buttons sit immediately after the sidebar toggle with normal control spacing.
+4. Buttons use the existing ghost icon control style, show disabled when the action cannot run, and expose shortcut hints in accessible names/titles.
+5. Shortcuts: `CmdOrCtrl+[` (Back), `CmdOrCtrl+]` (Forward). The app handles them only when the corresponding action can run.
+6. View menu includes Go Back and Go Forward at the top (with those accelerators), then a separator, then existing View items. Menu enablement matches the toolbar.
+
+## Out of scope
+
+- React Router or URL routing on desktop.
+- Web app document history parity.
+- Persisting history across app restarts.
+- Restoring scroll position or rich/source mode from history.
+- Auto-opening another history entry after deleting the current file.
+- Optimistic UI while history navigation is in flight.
+- A separate long-lived history for Loose Files independent of the open-folder trail.

--- a/specs/gh-111/TECH.md
+++ b/specs/gh-111/TECH.md
@@ -1,0 +1,90 @@
+# Document back/forward navigation — technical plan
+
+## Context
+
+Issue: https://github.com/bholmesdev/hubble.md/issues/111
+
+Product spec: `specs/gh-111/PRODUCT.md`
+
+Current commit researched: `4c62c623f50d968a3b6703e9b11918a1a064d8aa`
+
+Desktop navigation is already centralized on `loadPath` in `apps/desktop/src/store/actions.ts`. The viewer only tracks `currentPath` / `lastOpenedPath` (`apps/desktop/src/store/state.ts`); persistence keeps `lastOpenedPaths` per workspace path and a single `document.lastOpenedPath` (`apps/desktop/src/store/persistence.ts`). Path rewrite on rename/move/delete already updates those fields in the same `appStore.set` blocks. The shared toolbar left cluster is a fixed-basis actions region with `leftSlot` (`packages/ui/src/components/Toolbar.tsx`); sidebar width is a CSS variable `--sidebar-width` from `SidebarFrame` (`packages/ui/src/components/Sidebar.tsx`). Electron app menu + `MenuState` live in `apps/desktop/electron/main.ts` with renderer sync via `setMenuState` / `onMenu*` in `apps/desktop/src/desktopApi`.
+
+Tradeoff: a custom session stack on `loadPath` instead of React Router. Desktop is not URL-routed; per-open-folder history and path rewrite fit store state better than browser history.
+
+## Approach
+
+### Session history state
+
+- Add an in-memory `historyByWorkspace: Record<string, { entries: string[]; index: number }>` next to desktop app state (workspace key = `workspacePath`, sentinel key when `workspacePath` is null).
+- Do **not** add it to `Persisted` / `serialize()` in `apps/desktop/src/store/persistence.ts`.
+- Pure helpers (unit-tested): `canGoBack` / `canGoForward`, `pushPath` (no consecutive duplicate; truncate forward; max 50 drop-oldest), `move`, path rewrite / prefix rewrite, prune path / prune under folder + index clamp, `clear`.
+- Active stack is always the map entry for the current open-folder key. External absolute paths may appear on that stack.
+
+### `loadPath` as the chokepoint
+
+- Extend `loadPath` roughly: `loadPath(path, { history?: "push" | "replace" | "none"; missing?: "toast" | "silent" })`.
+- Defaults: `history: "push"`, `missing: "toast"`.
+- Apply history mutation only after a successful read, beside `withOpenedDoc` (`actions.ts` / `state.ts`).
+- Back/Forward and rename reloads use `history: "none"`. Prefer rewriting the stack entry in the existing rename/move `appStore.set` rather than inventing a second visit.
+- Restore paths (`App.tsx` init, `openWorkspace` last file): `missing: "silent"` — clear viewer, drop bad `lastOpenedPath` / `lastOpenedPaths[ws]`, no toast.
+- Intentional opens keep the failure toast; failed opens never push.
+
+### `goBack` / `goForward`
+
+- Single `navigateHistory(delta)` used by both.
+- In-flight flag: while set, `canGo*` is false for toolbar + menu; concurrent calls no-op (product: block, no optimistic UI).
+- Before leave: if `externalChange.kind === "conflict"`, abort; if dirty, `await savePathContent` (non-force); if still conflicted, abort.
+- Walk `delta`, pruning missing targets (existence check and/or silent load failure) until success or stop; load with `{ history: "none", missing: "silent" }`.
+
+### Rewrite / prune with existing file ops
+
+- Extend the `appStore.set` updates in `renameMarkdownFile`, `renameFolder`, `moveSidebarItem`, `deleteMarkdownFile`, `deleteFolder` to rewrite or prune history the same way they already handle `lastOpenedPaths` / `currentPath`.
+- When delete clears the current document (`emptyDoc` path): clear the **active** stack entirely.
+
+### UI + menu
+
+- `packages/ui` `Toolbar`: when `sidebarOpen`, size the start actions region to `var(--sidebar-width)` (same source as `SidebarFrame`); place nav controls at the end of that region (`ms-auto` / end alignment). When collapsed, keep compact cluster: sidebar toggle + nav with existing `gap-1`. Logical spacing only (`padding-inline-*`, not left/right).
+- Desktop `Toolbar` / `leftSlot`: Back/Forward ghost `icon-sm` buttons; disabled from store selectors + in-flight; titles via `formatShortcut`.
+- `App.tsx` keydown: `CmdOrCtrl+[` / `]` only when the action can run.
+- Electron `buildMenu` View submenu: Go Back / Go Forward first, accelerators `CmdOrCtrl+[` / `]`, separator, then existing items. Extend `MenuState` with `canGoBack` / `canGoForward`; IPC `onMenuGoBack` / `onMenuGoForward` (names flexible); renderer `setMenuState` whenever stack, cursor, in-flight, or workspace changes.
+
+### What does not change
+
+- No React Router on desktop; `apps/www` routing untouched.
+- No persistence of stacks; no scroll/viewMode in entries.
+- `withOpenedDoc` may keep forcing `viewMode: "rich"` on open — history does not restore mode.
+
+## E2E test plan
+
+Desktop (running app; use `.agents/skills/test-desktop-app` when automating):
+
+1. Open a folder with linked Markdown Files. Open A → wiki/relative open B → C. Back to B then A; Forward to B; from B open D and confirm Forward to C is gone.
+2. Edit B without saving wait if needed, press Back: file on disk reflects edits, previous note opens. With conflict banner showing, Back does nothing.
+3. From an in-folder note follow a relative link outside the folder; Back returns to the in-folder note.
+4. Build a trail in folder A, switch to folder B, switch back to A: A’s trail/cursor restored in-session.
+5. Delete the open file: empty editor, Back/Forward disabled; open another file starts a fresh tip.
+6. Set last-opened to a deleted path (or delete the file on disk), restart: no failure banner; editor empty or normal empty state.
+7. Confirm toolbar placement with sidebar open (nav at sidebar end edge) and collapsed (nav after toggle); View menu items and shortcuts match enablement.
+
+Unit / integration:
+
+- Pure history helpers: push, duplicate, truncate-forward, max 50, rewrite, prune, clear.
+- `actions` tests: `loadPath` history modes; `navigateHistory` save-before-leave and conflict block; per-workspace isolation; null-workspace stack; silent missing restore; delete-current clears stack; rename rewrites stack entries.
+
+Commands:
+
+- Iteration: `pnpm check`
+- Targeted: desktop store/action tests under `apps/desktop`
+- Final: `pnpm build:desktop`
+
+## Risks
+
+- **Lost edits on rapid Back:** mitigate by awaiting save and blocking concurrent history ops with the in-flight flag.
+- **Stale stack after external deletes:** prune-and-walk on history nav; silent restore for last-opened.
+- **Toolbar width drift vs resizable sidebar:** bind start region to `--sidebar-width` from the same sidebar mechanism, not a hard-coded pixel guess.
+
+## Follow-ups
+
+- Web document-history parity (separate product call; browser URL history is not the same model).
+- Optional later: view mode or scroll in history entries.


### PR DESCRIPTION
## Description
Adds product and tech specs for desktop document history (back/forward navigation), locking the design from the #111 grilling session.

- Custom per-open-folder session stacks (not React Router)
- `loadPath` history modes, dirty leave + conflict block
- External paths allowed on the active stack; silent missing last-opened restore
- Toolbar placement, View menu items, `CmdOrCtrl+[` / `]`

Specs: `specs/gh-111/PRODUCT.md`, `specs/gh-111/TECH.md`

Related to #111 (specs only — does not implement the feature)

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Testing
- [x] Existing tests pass
- [ ] Added new tests for changes
- [ ] Tested manually (describe below)

**Manual Testing Details:**
N/A — specs only; no runtime code changes.

## Checklist

- [x] I discussed this change in a GitHub issue before submitting this PR
- [x] I have run the linter, formatter, and tests to ensure my code is ready for review