### PR TITLE
Add in-app changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 ### Added
 
 - Global search: press Cmd+P (or File → Go to File…) to find notes by name, by path, or by a phrase inside them. Results show a matching excerpt, and selecting one opens the note. Thanks [@zcuric](https://github.com/zcuric)! [#159](https://github.com/bholmesdev/hubble.md/pull/159)
+- Added a button to view the changelog after an update. Revisit the changelog anytime from Help or Settings. [#163](https://github.com/bholmesdev/hubble.md/pull/163)
 
 ### Changed
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -888,6 +888,16 @@ function buildMenu() {
 					: []),
 			],
 		},
+		{
+			label: "Help",
+			submenu: [
+				{
+					id: "whats-new",
+					label: "See what's new",
+					click: () => sendToRenderer("desktop:menu-open-changelog"),
+				},
+			],
+		},
 	];
 
 	if (process.platform === "darwin") {

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -103,6 +103,8 @@ const desktopApi = {
 		subscribe("desktop:menu-open-folder", callback),
 	onMenuOpenSettings: (callback) =>
 		subscribe("desktop:menu-open-settings", callback),
+	onMenuOpenChangelog: (callback) =>
+		subscribe("desktop:menu-open-changelog", callback),
 	onMenuCopyAsMarkdown: (callback) =>
 		subscribe("desktop:menu-copy-as-markdown", callback),
 	onMenuShowWorkspaceSwitcher: (callback) =>

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -19,10 +19,7 @@ import { SettingsDialog, SettingsSection } from "./components/SettingsDialog";
 import { Sidebar } from "./components/Sidebar";
 import { TerminalPanel } from "./components/TerminalPanel";
 import { Toolbar } from "./components/Toolbar";
-import {
-	SidebarUpdateCallout,
-	UpdatesSection,
-} from "./components/UpdatesSection";
+import { SidebarCallout, UpdatesSection } from "./components/UpdatesSection";
 import { WelcomeScreen } from "./components/WelcomeScreen";
 import { desktopApi } from "./desktopApi";
 import type { DesktopUpdateState } from "./desktopApi/types";
@@ -31,6 +28,7 @@ import { handleImageDrop, handleImagePaste } from "./editor/handleImagePaste";
 import { IframeView, toAssetUrl } from "./editor/IframeView";
 import { createImageExtension } from "./editor/ImageExtension";
 import { createHtmlFile, createMarkdownFile } from "./fileActions";
+import { isChangelogPath } from "./lib/changelogNote";
 import { copyText } from "./lib/clipboard";
 import {
 	hasHtmlExtension,
@@ -48,6 +46,7 @@ import {
 	goForward,
 	handleExternalFileChange,
 	loadPath,
+	openChangelog,
 	openWorkspace,
 	openWorkspaceWithSidebar,
 	refreshFiles,
@@ -56,6 +55,7 @@ import {
 	requestChatAboutNote,
 	savePathContent,
 	setChatCommand,
+	setLastSeenVersion,
 	setSidebarOpen,
 	setViewerMode,
 	setWorkspaceSwitcherOpen,
@@ -66,6 +66,7 @@ import { canGoBack, canGoForward } from "./store/history";
 import { useHistoryNav } from "./store/hooks";
 import {
 	chatCommandStore,
+	lastSeenVersionStore,
 	sidebarOpenStore,
 	terminalPositionStore,
 	uiStore,
@@ -149,15 +150,41 @@ function App() {
 			})),
 		[workspaceFiles, workspacePath],
 	);
+	const lastSeenVersion = useStoreValue(lastSeenVersionStore);
 
 	const readyVersion =
 		updateState?.status === "ready"
 			? (updateState.availableVersion ?? "__unknown__")
 			: null;
-	const showUpdateCallout = readyVersion !== dismissedVersion;
+	const showReadyCallout =
+		readyVersion !== null && readyVersion !== dismissedVersion;
+
+	const currentVersion = updateState?.currentVersion ?? null;
+	// First launch after an update: the persisted version lags behind the
+	// running one until the callout is opened or dismissed.
+	const whatsNewVersion =
+		currentVersion !== null &&
+		lastSeenVersion !== null &&
+		lastSeenVersion !== currentVersion
+			? currentVersion
+			: null;
+	const markWhatsNewSeen = useCallback(() => {
+		if (currentVersion) setLastSeenVersion(currentVersion);
+	}, [currentVersion]);
+
+	useEffect(() => {
+		// First install has no update to announce; just record the version.
+		if (currentVersion && lastSeenVersion === null) {
+			setLastSeenVersion(currentVersion);
+		}
+	}, [currentVersion, lastSeenVersion]);
 
 	const openSettings = useCallback(() => {
 		setSettingsOpen(true);
+	}, []);
+	const openWhatsNew = useCallback(() => {
+		setSettingsOpen(false);
+		void openChangelog();
 	}, []);
 
 	const installUpdate = useCallback(async () => {
@@ -181,7 +208,8 @@ function App() {
 
 	useEffect(() => {
 		const currentPath = state.currentPath;
-		if (!currentPath) return;
+		// The changelog note is virtual; there is no file to watch.
+		if (!currentPath || isChangelogPath(currentPath)) return;
 
 		let disposed = false;
 		let unwatch: null | (() => void) = null;
@@ -220,8 +248,9 @@ function App() {
 	}, [state.currentPath]);
 
 	const openFilePicker = useCallback(async () => {
+		const currentPath = viewerStore.get().currentPath;
 		const defaultPath =
-			viewerStore.get().currentPath ??
+			(isChangelogPath(currentPath) ? null : currentPath) ??
 			workspaceStore.get().workspacePath ??
 			undefined;
 		const selected = await desktopApi.openFilePicker({ defaultPath });
@@ -285,12 +314,12 @@ function App() {
 				await openFilePicker();
 			} else if (keymatch(event, "CmdOrCtrl+Shift+C")) {
 				const path = focusedSidebarPath ?? viewerStore.get().currentPath;
-				if (!path) return;
+				if (!path || isChangelogPath(path)) return;
 				event.preventDefault();
 				await copyFilePath(path);
 			} else if (keymatch(event, "CmdOrCtrl+Alt+R")) {
 				const path = focusedSidebarPath ?? viewerStore.get().currentPath;
-				if (!path) return;
+				if (!path || isChangelogPath(path)) return;
 				event.preventDefault();
 				await revealPath(path);
 			} else if (keymatch(event, "CmdOrCtrl+Shift+J")) {
@@ -344,6 +373,7 @@ function App() {
 			desktopApi.onMenuOpenFile(() => void openFilePicker()),
 			desktopApi.onMenuOpenFolder(() => void openWorkspaceWithSidebar()),
 			desktopApi.onMenuOpenSettings(() => openSettings()),
+			desktopApi.onMenuOpenChangelog(openWhatsNew),
 			desktopApi.onMenuCopyAsMarkdown(() =>
 				setCopyAsMarkdownRequest((request) => request + 1),
 			),
@@ -369,7 +399,7 @@ function App() {
 		return () => {
 			for (const dispose of disposers) dispose();
 		};
-	}, [openFilePicker, openSettings]);
+	}, [openFilePicker, openSettings, openWhatsNew]);
 
 	useEffect(() => {
 		// Window focus can fire in bursts when switching apps, so debounce the
@@ -423,18 +453,46 @@ function App() {
 		<main className="flex h-dvh flex-col bg-background text-foreground">
 			<Toolbar
 				scrollContainer={scrollContainerEl}
-				showSidebarBadge={!sidebarOpen && showUpdateCallout}
+				showSidebarBadge={
+					!sidebarOpen && (showReadyCallout || whatsNewVersion !== null)
+				}
 			/>
 			<div className="flex min-h-0 flex-1 overflow-hidden">
 				<Sidebar
 					onFocusedPathChange={setFocusedSidebarPath}
 					footer={
-						updateState?.status === "ready" && showUpdateCallout ? (
-							<SidebarUpdateCallout
-								onInstall={installUpdate}
+						// A pending restart outranks the what's-new nudge.
+						showReadyCallout ? (
+							<SidebarCallout
+								message={
+									<>
+										<span className="font-semibold">A new version</span> is
+										ready to install.
+									</>
+								}
+								primaryLabel="Restart"
+								onPrimary={installUpdate}
 								onDismiss={() =>
 									setDismissedVersion(readyVersion ?? "__unknown__")
 								}
+							/>
+						) : whatsNewVersion !== null ? (
+							<SidebarCallout
+								message={
+									<>
+										<span className="font-semibold">Hubble updated</span> to{" "}
+										{whatsNewVersion}.
+									</>
+								}
+								primaryLabel="See what's new"
+								onPrimary={() => {
+									// Only consume the one-shot callout once the changelog is
+									// actually showing; openChangelog can bail on a conflict.
+									void openChangelog().then((opened) => {
+										if (opened) markWhatsNewSeen();
+									});
+								}}
+								onDismiss={markWhatsNewSeen}
 							/>
 						) : undefined
 					}
@@ -502,6 +560,7 @@ function App() {
 					<UpdatesSection
 						state={updateState}
 						onPrimaryAction={() => void triggerPrimaryUpdateAction()}
+						onViewChangelog={openWhatsNew}
 					/>
 				) : null}
 			</SettingsDialog>
@@ -710,6 +769,7 @@ function MarkdownEditor({
 		<EditorView
 			path={path}
 			initialMarkdown={initialMarkdown}
+			editable={!isChangelogPath(path)}
 			wikiTargets={wikiTargets}
 			extensions={[
 				createImageExtension(path),

--- a/apps/desktop/src/components/Toolbar.tsx
+++ b/apps/desktop/src/components/Toolbar.tsx
@@ -15,6 +15,7 @@ import MingcuteFolderOpenLine from "~icons/mingcute/folder-open-line";
 import MingcuteMore2Line from "~icons/mingcute/more-2-line";
 import MingcuteTerminalLine from "~icons/mingcute/terminal-line";
 import { desktopApi } from "../desktopApi";
+import { isChangelogPath } from "../lib/changelogNote";
 import { copyText } from "../lib/clipboard";
 import { hasMarkdownExtension } from "../lib/filePath";
 import { revealFileLabel } from "../lib/revealFile";
@@ -60,10 +61,13 @@ export function Toolbar({
 	const sidebarOpen = useStoreValue(sidebarOpenStore);
 	const currentPath = useStoreValue(currentPathStore);
 	const isFullScreen = useIsFullScreen();
+	// The changelog note is virtual: show a friendly title and disable the
+	// file actions (rename, reveal, copy path) that assume a file on disk.
+	const isChangelog = isChangelogPath(currentPath);
 
 	return (
 		<SharedToolbar
-			currentPath={currentPath ?? null}
+			currentPath={isChangelog ? "What's new" : (currentPath ?? null)}
 			sidebarOpen={sidebarOpen}
 			sidebarBadge={showSidebarBadge}
 			scrollContainer={scrollContainer}
@@ -71,8 +75,10 @@ export function Toolbar({
 			rootProps={{ style: dragRegionStyle }}
 			onToggleSidebar={toggleSidebar}
 			leftSlot={<NavigationControls />}
-			onRenameCurrentPath={(nextName) =>
-				void renameCurrentMarkdownFile(nextName)
+			onRenameCurrentPath={
+				isChangelog
+					? undefined
+					: (nextName) => void renameCurrentMarkdownFile(nextName)
 			}
 			rightSlot={
 				<div className="flex items-center gap-1">
@@ -85,7 +91,7 @@ export function Toolbar({
 					>
 						<MingcuteTerminalLine className="size-3.5" />
 					</Button>
-					{currentPath && (
+					{currentPath && !isChangelog && (
 						<NoteActionsMenu
 							path={currentPath}
 							canChatAboutNote={workspacePath !== null}

--- a/apps/desktop/src/components/UpdatesSection.tsx
+++ b/apps/desktop/src/components/UpdatesSection.tsx
@@ -2,25 +2,24 @@ import { Button } from "@hubble.md/ui";
 import type { DesktopUpdateState } from "../desktopApi/types";
 import { SettingsSection } from "./SettingsDialog";
 
-export function SidebarUpdateCallout({
-	onInstall,
+export function SidebarCallout({
+	message,
+	primaryLabel,
+	onPrimary,
 	onDismiss,
 }: {
-	onInstall: () => void;
+	message: React.ReactNode;
+	primaryLabel: string;
+	onPrimary: () => void;
 	onDismiss: () => void;
 }) {
 	return (
 		<div className="rounded-md border border-primary/20 bg-primary/8 p-3">
 			<div className="flex flex-col gap-3">
-				<div className="flex flex-col gap-1">
-					<p className="text-[11px] text-foreground">
-						<span className="font-semibold">A new version</span> is ready to
-						install.
-					</p>
-				</div>
+				<p className="text-[11px] text-foreground">{message}</p>
 				<div className="flex flex-wrap gap-2">
-					<Button size="sm" onClick={onInstall}>
-						Restart
+					<Button size="sm" onClick={onPrimary}>
+						{primaryLabel}
 					</Button>
 					<Button
 						size="sm"
@@ -39,9 +38,11 @@ export function SidebarUpdateCallout({
 export function UpdatesSection({
 	state,
 	onPrimaryAction,
+	onViewChangelog,
 }: {
 	state: DesktopUpdateState;
 	onPrimaryAction: () => void;
+	onViewChangelog: () => void;
 }) {
 	const button = getPrimaryButton(state);
 	const secondaryText = getSecondaryText(state);
@@ -60,14 +61,19 @@ export function UpdatesSection({
 							</p>
 						) : null}
 					</div>
-					<Button
-						size="sm"
-						variant={button.variant}
-						disabled={button.disabled}
-						onClick={onPrimaryAction}
-					>
-						{button.label}
-					</Button>
+					<div className="flex flex-wrap gap-2">
+						<Button size="sm" variant="ghost" onClick={onViewChangelog}>
+							See what's new
+						</Button>
+						<Button
+							size="sm"
+							variant={button.variant}
+							disabled={button.disabled}
+							onClick={onPrimaryAction}
+						>
+							{button.label}
+						</Button>
+					</div>
 				</div>
 				{state.status === "error" && state.message ? (
 					<p className="text-xs text-muted-foreground">{state.message}</p>

--- a/apps/desktop/src/desktopApi/types.ts
+++ b/apps/desktop/src/desktopApi/types.ts
@@ -166,6 +166,7 @@ export type DesktopApi = {
 	onMenuOpenFile(callback: () => void): Unsubscribe;
 	onMenuOpenFolder(callback: () => void): Unsubscribe;
 	onMenuOpenSettings(callback: () => void): Unsubscribe;
+	onMenuOpenChangelog(callback: () => void): Unsubscribe;
 	onMenuCopyAsMarkdown(callback: () => void): Unsubscribe;
 	onMenuShowWorkspaceSwitcher(callback: () => void): Unsubscribe;
 	onMenuGoToFile(callback: () => void): Unsubscribe;

--- a/apps/desktop/src/lib/changelogNote.test.ts
+++ b/apps/desktop/src/lib/changelogNote.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { prepareChangelogMarkdown } from "./changelogNote";
+
+describe("prepareChangelogMarkdown", () => {
+	it("drops the preamble, Unreleased, and empty subheads; keeps entries verbatim", () => {
+		const raw = `# Changelog
+
+All notable user-facing changes to Hubble.
+
+## [Unreleased]
+
+### Added
+
+### Fixed
+
+- Development-only fix.
+
+## [0.1.19] - 2026-07-11
+
+### Added
+
+- Linux builds. Thanks [@ricardoraposo](https://github.com/ricardoraposo)! [#151](https://github.com/bholmesdev/hubble.md/pull/151)
+
+### Changed
+
+### Fixed
+
+- Copying linked rich text. [#149](https://github.com/bholmesdev/hubble.md/issues/149)
+
+## [0.1.18] - 2026-07-07
+
+### Added
+
+- Source mode.
+`;
+
+		expect(prepareChangelogMarkdown(raw)).toBe(`# What's new in Hubble
+
+## Latest — [0.1.19] - 2026-07-11
+
+### Added
+
+- Linux builds. Thanks [@ricardoraposo](https://github.com/ricardoraposo)! [#151](https://github.com/bholmesdev/hubble.md/pull/151)
+
+### Fixed
+
+- Copying linked rich text. [#149](https://github.com/bholmesdev/hubble.md/issues/149)
+
+---
+
+## [0.1.18] - 2026-07-07
+
+### Added
+
+- Source mode.
+`);
+	});
+});

--- a/apps/desktop/src/lib/changelogNote.ts
+++ b/apps/desktop/src/lib/changelogNote.ts
@@ -1,0 +1,46 @@
+export const CHANGELOG_PATH = "hubble://changelog";
+
+export function isChangelogPath(
+	path: string | null | undefined,
+): path is typeof CHANGELOG_PATH {
+	return path === CHANGELOG_PATH;
+}
+
+export function prepareChangelogMarkdown(raw: string): string {
+	const lines = raw.match(/[^\n]*(?:\n|$)/g)?.filter(Boolean) ?? [];
+	const firstRelease = lines.findIndex((line) =>
+		/^## \[\d+\.\d+\.\d+\]/.test(line),
+	);
+	// Unreleased is intentionally dropped so development entries never show in-app.
+	const releasedLines = firstRelease === -1 ? lines : lines.slice(firstRelease);
+	const content: string[] = [];
+	let releaseIndex = 0;
+	for (let index = 0; index < releasedLines.length; index++) {
+		let line = releasedLines[index];
+		if (/^## \[\d+\.\d+\.\d+\]/.test(line)) {
+			if (releaseIndex === 0) {
+				line = line.replace(/^## /, "## Latest — ");
+			} else if (releaseIndex === 1) {
+				content.push("---\n\n");
+			}
+			releaseIndex += 1;
+		}
+		if (/^### (Added|Changed|Fixed)\r?(?:\n|$)/.test(line)) {
+			let next = index + 1;
+			while (next < releasedLines.length && /^\s*$/.test(releasedLines[next])) {
+				next += 1;
+			}
+			const isEmpty =
+				next === releasedLines.length ||
+				/^(## |### )/.test(releasedLines[next]);
+			if (isEmpty) {
+				// Drop the subhead with its blank lines; the next heading keeps its own.
+				index = next - 1;
+				continue;
+			}
+		}
+		content.push(line);
+	}
+
+	return `# What's new in Hubble\n\n${content.join("")}`;
+}

--- a/apps/desktop/src/lib/latest.ts
+++ b/apps/desktop/src/lib/latest.ts
@@ -3,7 +3,7 @@
  * result.  Earlier in-flight calls become "stale" and silently no-op.
  *
  * ```ts
- * const load = latest(async ({ isStale }, path: string) => {
+ * const { run: load } = latest(async ({ isStale }, path: string) => {
  *   const content = await readFile(path);
  *   if (isStale()) return;
  *   applyContent(content);
@@ -14,11 +14,17 @@
  */
 export function latest<Args extends unknown[]>(
 	fn: (signal: { isStale: () => boolean }, ...args: Args) => Promise<void>,
-): (...args: Args) => Promise<void> {
+) {
 	let token = 0;
 
-	return async (...args: Args) => {
+	const run = async (...args: Args) => {
 		const myToken = ++token;
 		await fn({ isStale: () => myToken !== token }, ...args);
+	};
+	return {
+		run,
+		invalidate: () => {
+			token += 1;
+		},
 	};
 }

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -1,6 +1,12 @@
 import { toast } from "sonner";
+import changelogRaw from "../../../../CHANGELOG.md?raw";
 import { desktopApi } from "../desktopApi";
 import { classifyFileChange } from "../externalFileChange";
+import {
+	CHANGELOG_PATH,
+	isChangelogPath,
+	prepareChangelogMarkdown,
+} from "../lib/changelogNote";
 import {
 	absoluteWorkspacePath,
 	basename,
@@ -48,6 +54,7 @@ import {
 	historyStore,
 	isInWorkspace,
 	LOADING_DELAY_MS,
+	lastSeenVersionStore,
 	MAX_RECENT,
 	pendingTerminalCommandStore,
 	type SortMode,
@@ -402,7 +409,12 @@ export function setChatCommand(command: string) {
 	chatCommandStore.set(command);
 }
 
+export function setLastSeenVersion(version: string) {
+	lastSeenVersionStore.set(version);
+}
+
 export function requestChatAboutNote() {
+	if (isChangelogPath(viewerStore.get().currentPath)) return;
 	const command = chatCommandStore.get().trim() || DEFAULT_CHAT_COMMAND;
 	// Set the command before opening so the panel's open effect can see it
 	// and defer to the chat launch instead of starting a plain session.
@@ -503,6 +515,8 @@ export async function savePathContent(
 	content: string,
 	options?: { force?: boolean },
 ) {
+	// The changelog note is virtual and read-only; nothing to write.
+	if (isChangelogPath(path)) return;
 	const current = viewerStore.get();
 	const force = options?.force === true;
 	if (current.currentPath !== path) return;
@@ -661,7 +675,7 @@ export async function renameMarkdownFile(path: string, nextName: string) {
 
 export async function renameCurrentMarkdownFile(nextName: string) {
 	const current = viewerStore.get();
-	if (!current.currentPath) return;
+	if (!current.currentPath || isChangelogPath(current.currentPath)) return;
 	await renameMarkdownFile(current.currentPath, nextName);
 }
 
@@ -1086,7 +1100,7 @@ export async function forceKeepLocalEdits() {
 	await savePathContent(current.currentPath, current.content, { force: true });
 }
 
-export const loadPath = latest(
+const { run: loadPath, invalidate: invalidateLoadPath } = latest(
 	async ({ isStale }, path: string, options?: LoadPathOptions) => {
 		const historyMode = options?.history ?? "push";
 		const missingMode = options?.missing ?? "toast";
@@ -1139,12 +1153,41 @@ export const loadPath = latest(
 		}
 	},
 );
+export { loadPath };
+
+/**
+ * Opens the app changelog as an ephemeral note. It never touches disk or
+ * history: `lastOpenedPath` and the workspace's `lastOpenedPaths` keep the
+ * real note so relaunch restores it, and the stack index stays put so back
+ * returns to the note the user was on. Returns whether it opened.
+ */
+export async function openChangelog(): Promise<boolean> {
+	const current = viewerStore.get();
+	if (isChangelogPath(current.currentPath)) return true;
+	if (current.currentPath) {
+		await savePathContent(current.currentPath, current.content);
+		if (viewerStore.get().externalChange.kind === "conflict") return false;
+	}
+	// An in-flight loadPath must not resolve over the changelog.
+	invalidateLoadPath();
+	viewerStore.set((state) => ({
+		...state,
+		currentPath: CHANGELOG_PATH,
+		...cleanFileState(prepareChangelogMarkdown(changelogRaw)),
+		viewMode: "rich",
+	}));
+	return true;
+}
 
 async function navigateHistory(delta: -1 | 1) {
 	if (!(delta < 0 ? canGoBack() : canGoForward())) return;
 
 	const current = viewerStore.get();
 	if (current.externalChange.kind === "conflict") return;
+	// The changelog note is never pushed, so back re-opens the entry the user
+	// was on (`entries[index]`, not `index - 1`). Forward never gets here:
+	// canGoForward is false on the changelog.
+	const fromChangelog = isChangelogPath(current.currentPath);
 
 	// Block concurrent history ops for the whole leave (save + load).
 	historyStore.set((state) => ({ ...state, isNavigating: true }));
@@ -1155,7 +1198,7 @@ async function navigateHistory(delta: -1 | 1) {
 		}
 
 		let working = activeHistory();
-		let nextIndex = working.index + delta;
+		let nextIndex = working.index + (fromChangelog ? 0 : delta);
 		while (nextIndex >= 0 && nextIndex < working.entries.length) {
 			const target = working.entries[nextIndex];
 			if (await desktopApi.pathExists(target)) {

--- a/apps/desktop/src/store/history.ts
+++ b/apps/desktop/src/store/history.ts
@@ -1,5 +1,7 @@
+import { isChangelogPath } from "../lib/changelogNote";
 import { pathInFolder, replacePathPrefix } from "../lib/filePath";
 import {
+	currentPathStore,
 	type HistoryStack,
 	type HistoryState,
 	historyStore,
@@ -128,16 +130,23 @@ export function pruneHistory(path: string, isFolder = false) {
 export function canGoBack(
 	history = historyStore.get(),
 	workspacePath = workspaceStore.get().workspacePath,
+	onChangelog = isChangelogPath(currentPathStore.get()),
 ) {
 	if (history.isNavigating) return false;
-	return stackFor(history, workspacePath).index > 0;
+	const stack = stackFor(history, workspacePath);
+	// The changelog note is never pushed, so back means "return to the current
+	// entry" and stays enabled whenever one exists.
+	if (onChangelog) return stack.index >= 0;
+	return stack.index > 0;
 }
 
 export function canGoForward(
 	history = historyStore.get(),
 	workspacePath = workspaceStore.get().workspacePath,
+	onChangelog = isChangelogPath(currentPathStore.get()),
 ) {
 	if (history.isNavigating) return false;
+	if (onChangelog) return false;
 	const { index, entries } = stackFor(history, workspacePath);
 	return index >= 0 && index < entries.length - 1;
 }

--- a/apps/desktop/src/store/hooks.ts
+++ b/apps/desktop/src/store/hooks.ts
@@ -1,18 +1,20 @@
 import { useStoreValue } from "@simplestack/store/react";
+import { isChangelogPath } from "../lib/changelogNote";
 import { canGoBack, canGoForward } from "./history";
-import { historyStore, workspacePathStore } from "./state";
+import { currentPathStore, historyStore, workspacePathStore } from "./state";
 
 // Back/forward enablement depends on two stores: the history stacks and the
 // workspace that picks the active stack. Boolean selectors re-render callers
 // only when enablement actually flips.
 export function useHistoryNav() {
 	const workspacePath = useStoreValue(workspacePathStore);
+	const onChangelog = useStoreValue(currentPathStore, isChangelogPath);
 	return {
 		canGoBack: useStoreValue(historyStore, (history) =>
-			canGoBack(history, workspacePath),
+			canGoBack(history, workspacePath, onChangelog),
 		),
 		canGoForward: useStoreValue(historyStore, (history) =>
-			canGoForward(history, workspacePath),
+			canGoForward(history, workspacePath, onChangelog),
 		),
 	};
 }

--- a/apps/desktop/src/store/persistence.ts
+++ b/apps/desktop/src/store/persistence.ts
@@ -25,6 +25,7 @@ type UiState = {
 
 type SettingsState = {
 	chatCommand: string;
+	lastSeenVersion: string | null;
 };
 
 export type DesktopState = {
@@ -47,7 +48,7 @@ type Persisted = {
 		isTerminalOpen?: boolean;
 		terminalPosition?: TerminalPosition;
 	};
-	settings?: { chatCommand?: string };
+	settings?: { chatCommand?: string; lastSeenVersion?: string | null };
 };
 
 export const STORAGE_KEY = "hubble-desktop-app";
@@ -101,6 +102,15 @@ export function getInitialState(): DesktopState {
 				typeof p?.settings?.chatCommand === "string"
 					? p.settings.chatCommand
 					: DEFAULT_CHAT_COMMAND,
+			// A missing field on an existing install means the user updated from
+			// a release that predates version tracking: treat the running version
+			// as news. Only a truly fresh install starts at null (no callout).
+			lastSeenVersion:
+				typeof p?.settings?.lastSeenVersion === "string"
+					? p.settings.lastSeenVersion
+					: p
+						? ""
+						: null,
 		},
 	};
 }
@@ -123,6 +133,7 @@ export function serialize(state: DesktopState): Persisted {
 		},
 		settings: {
 			chatCommand: state.settings.chatCommand,
+			lastSeenVersion: state.settings.lastSeenVersion,
 		},
 	};
 }

--- a/apps/desktop/src/store/state.ts
+++ b/apps/desktop/src/store/state.ts
@@ -176,3 +176,6 @@ export const pendingTerminalCommandStore = uiStore.select(
 export const chatCommandStore = appStore
 	.select("settings")
 	.select("chatCommand");
+export const lastSeenVersionStore = appStore
+	.select("settings")
+	.select("lastSeenVersion");

--- a/packages/ui/src/editor/EditorView.css
+++ b/packages/ui/src/editor/EditorView.css
@@ -553,6 +553,13 @@
 	cursor: pointer;
 }
 
+/* Read-only notes open links on a plain click, so hint it everywhere. */
+[data-hubble-editor]
+	.ProseMirror[contenteditable="false"]
+	span[data-link="true"] {
+	cursor: pointer;
+}
+
 [data-hubble-editor] .pm-ghost-text {
 	opacity: 0.35;
 	user-select: none;

--- a/packages/ui/src/editor/EditorView.tsx
+++ b/packages/ui/src/editor/EditorView.tsx
@@ -58,6 +58,7 @@ export type { WikiTarget };
 export type EditorViewProps = {
 	path: string;
 	initialMarkdown: string;
+	editable?: boolean;
 	wikiTargets?: WikiTarget[];
 	extensions?: EditorOptions["extensions"];
 	editorProps?: EditorOptions["editorProps"];
@@ -76,6 +77,7 @@ export type EditorViewProps = {
 export function EditorView({
 	path,
 	initialMarkdown,
+	editable = true,
 	wikiTargets = [],
 	extensions = [],
 	editorProps,
@@ -148,13 +150,18 @@ export function EditorView({
 	}, [onSave, saveDebounceMs]);
 
 	const editor = useEditor({
+		editable,
 		extensions: [
 			StarterKit.configure({ codeBlock: false, listItem: false }),
 			HubbleCodeBlock,
 			LinkExtension,
 			RichTextClipboardExtension,
 			SmartLinkExtension,
-			LinkClickExtension.configure({ onOpenExternalLink, onOpenWikiLink }),
+			LinkClickExtension.configure({
+				onOpenExternalLink,
+				onOpenWikiLink,
+				requireModifier: editable,
+			}),
 			LinkCreationGhostExtension,
 			FakeSelectionExtension,
 			FindExtension,
@@ -282,21 +289,23 @@ export function EditorView({
 				className="editorViewport relative min-h-0 flex-1 overflow-auto overscroll-contain"
 				ref={setEditorViewport}
 			>
-				<FilePropertiesPanel
-					path={path}
-					state={frontMatterState}
-					onChange={(nextState, frontMatter) => {
-						setFrontMatterState(nextState);
-						partsRef.current = { ...partsRef.current, frontMatter };
-						const markdown = combineMarkdownFrontMatter(
-							frontMatter,
-							partsRef.current.body,
-						);
-						latestMarkdownRef.current = markdown;
-						onLocalChange(pathRef.current, markdown);
-						scheduleSave();
-					}}
-				/>
+				{editable && (
+					<FilePropertiesPanel
+						path={path}
+						state={frontMatterState}
+						onChange={(nextState, frontMatter) => {
+							setFrontMatterState(nextState);
+							partsRef.current = { ...partsRef.current, frontMatter };
+							const markdown = combineMarkdownFrontMatter(
+								frontMatter,
+								partsRef.current.body,
+							);
+							latestMarkdownRef.current = markdown;
+							onLocalChange(pathRef.current, markdown);
+							scheduleSave();
+						}}
+					/>
+				)}
 				<EditorContent editor={editor} />
 				<VirtualCursor
 					editor={editor}
@@ -304,22 +313,29 @@ export function EditorView({
 					viewportRef={editorViewportRef}
 					modeOverride={cursorModeOverride}
 				/>
-				<LinkPopover
-					editor={editor}
-					containerRef={editorRootRef}
-					viewportRef={editorViewportRef}
-					wikiTargets={wikiTargets}
-					onOpenExternalLink={onOpenExternalLink}
-					onOpenWikiLink={onOpenWikiLink}
-					onMessage={onMessage}
-					onCursorModeChange={setCursorModeOverride}
-				/>
-				<SlashCommandMenu editor={editor} viewportRef={editorViewportRef} />
-				<SelectionFormattingToolbar
-					editor={editor}
-					viewportRef={editorViewportRef}
-				/>
-				<FormatCommandMenu editor={editor} viewportRef={editorViewportRef} />
+				{editable && (
+					<>
+						<LinkPopover
+							editor={editor}
+							containerRef={editorRootRef}
+							viewportRef={editorViewportRef}
+							wikiTargets={wikiTargets}
+							onOpenExternalLink={onOpenExternalLink}
+							onOpenWikiLink={onOpenWikiLink}
+							onMessage={onMessage}
+							onCursorModeChange={setCursorModeOverride}
+						/>
+						<SlashCommandMenu editor={editor} viewportRef={editorViewportRef} />
+						<SelectionFormattingToolbar
+							editor={editor}
+							viewportRef={editorViewportRef}
+						/>
+						<FormatCommandMenu
+							editor={editor}
+							viewportRef={editorViewportRef}
+						/>
+					</>
+				)}
 			</div>
 			<FindBar editor={editor} />
 			<FormattingStatusBar editor={editor} scrollContainer={editorViewportEl} />

--- a/packages/ui/src/editor/LinkClickExtension.ts
+++ b/packages/ui/src/editor/LinkClickExtension.ts
@@ -39,8 +39,12 @@ function setModHeld(el: HTMLElement, held: boolean) {
 export const LinkClickExtension = Extension.create<{
 	onOpenExternalLink?: (href: string) => void | Promise<void>;
 	onOpenWikiLink?: (target: string) => void | Promise<void>;
+	requireModifier?: boolean;
 }>({
 	name: "linkClick",
+	addOptions() {
+		return { requireModifier: true };
+	},
 	addProseMirrorPlugins() {
 		const root = this.editor.view.dom;
 
@@ -52,20 +56,38 @@ export const LinkClickExtension = Extension.create<{
 		window.addEventListener("keyup", onKey);
 		window.addEventListener("blur", onBlur);
 
+		const openLink = (link: LinkPayload) => {
+			if (link.kind === "wiki") {
+				void this.options.onOpenWikiLink?.(link.target ?? link.href);
+				return;
+			}
+			void this.options.onOpenExternalLink?.(link.href);
+		};
+
 		return [
 			new Plugin({
 				props: {
 					handleDOMEvents: {
 						mousedown: (view, event) => {
+							if (this.options.requireModifier === false) return false;
 							if (!event.metaKey && !event.ctrlKey) return false;
 							const link = findLinkAtEvent(view, event);
 							if (!link) return false;
 							event.preventDefault();
-							if (link.kind === "wiki") {
-								void this.options.onOpenWikiLink?.(link.target ?? link.href);
-								return true;
-							}
-							void this.options.onOpenExternalLink?.(link.href);
+							openLink(link);
+							return true;
+						},
+						// Without a required modifier, open on click instead of
+						// mousedown so a drag-selection starting on a link still
+						// selects text rather than opening it.
+						click: (view, event) => {
+							if (this.options.requireModifier !== false) return false;
+							if (event.button !== 0) return false;
+							if (!view.state.selection.empty) return false;
+							const link = findLinkAtEvent(view, event);
+							if (!link) return false;
+							event.preventDefault();
+							openLink(link);
 							return true;
 						},
 					},


### PR DESCRIPTION
## Description

Show release notes inside Hubble after desktop updates. Add persistent entrypoints in Help and Settings, keep the changelog read-only, and preserve note/history state while viewing it.

https://github.com/user-attachments/assets/979f2dad-bcd5-48ea-98bd-0917dce3e84c


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update

## Testing

- [x] Existing tests pass
- [x] Added new tests for changes
- [ ] Tested manually (describe below)

**Manual Testing Details:**

Not manually tested.

## Checklist

- [ ] I discussed this change in a GitHub issue before submitting this PR
- [x] I have run the linter, formatter, and tests to ensure my code is ready for review
