### PR TITLE
Restore macOS text context menu features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 
 ### Fixed
 
+- macOS text context menus now include Writing Tools, text services, and spelling suggestions. Thanks [@noahpatterson](https://github.com/noahpatterson) for the suggestion! [#164](https://github.com/bholmesdev/hubble.md/pull/164)
 - Update-check failures now show a concise, unobtrusive message instead of a raw error trace.
 
 ## [0.1.19] - 2026-07-11

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -717,8 +717,28 @@ function buildTextContextMenu(
 	webContents: Electron.WebContents,
 	params: Electron.ContextMenuParams,
 ) {
+	const spellingItems: Electron.MenuItemConstructorOptions[] =
+		params.misspelledWord.length > 0
+			? [
+					...(params.dictionarySuggestions.length > 0
+						? params.dictionarySuggestions.map((suggestion) => ({
+								label: suggestion,
+								click: () => webContents.replaceMisspelling(suggestion),
+							}))
+						: [{ label: "No Guesses Found", enabled: false }]),
+					{
+						label: "Add to Dictionary",
+						click: () =>
+							webContents.session.addWordToSpellCheckerDictionary(
+								params.misspelledWord,
+							),
+					},
+					{ type: "separator" },
+				]
+			: [];
+
 	// In source mode the text is already markdown, so plain copy covers it.
-	const template: Electron.MenuItemConstructorOptions[] = textContextMenuItems
+	const editItems: Electron.MenuItemConstructorOptions[] = textContextMenuItems
 		.filter(
 			(item) =>
 				!(
@@ -742,13 +762,17 @@ function buildTextContextMenu(
 					},
 		);
 
-	return Menu.buildFromTemplate(template);
+	return Menu.buildFromTemplate([...spellingItems, ...editItems]);
 }
 
 function registerTextContextMenu(window: BrowserWindow) {
 	window.webContents.on("context-menu", (_event, params) => {
 		if (!params.isEditable) return;
-		buildTextContextMenu(window.webContents, params).popup({ window });
+		buildTextContextMenu(window.webContents, params).popup({
+			window,
+			// macOS needs the originating frame to attach Writing Tools and text services.
+			frame: params.frame ?? undefined,
+		});
 	});
 }
 

--- a/packages/editor/src/ContextMenuSpellcheckExtension.test.ts
+++ b/packages/editor/src/ContextMenuSpellcheckExtension.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { wordRangeAtOffset } from "./ContextMenuSpellcheckExtension";
+
+describe("wordRangeAtOffset", () => {
+	it("selects the word before a caret at its end", () => {
+		expect(wordRangeAtOffset("This is amzing", 14)).toEqual({
+			from: 8,
+			to: 14,
+		});
+	});
+
+	it("selects the word containing the caret", () => {
+		expect(wordRangeAtOffset("This is amzing", 10)).toEqual({
+			from: 8,
+			to: 14,
+		});
+	});
+
+	it("supports Unicode letters and apostrophes", () => {
+		expect(wordRangeAtOffset("naïve l’école", 13)).toEqual({ from: 6, to: 13 });
+		expect(wordRangeAtOffset("a𐐷b", 3)).toEqual({ from: 0, to: 4 });
+	});
+
+	it("does not cross whitespace", () => {
+		expect(wordRangeAtOffset("one  two", 4)).toBeNull();
+	});
+});

--- a/packages/editor/src/ContextMenuSpellcheckExtension.ts
+++ b/packages/editor/src/ContextMenuSpellcheckExtension.ts
@@ -1,0 +1,129 @@
+import { Extension } from "@tiptap/core";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import { Plugin, TextSelection } from "@tiptap/pm/state";
+import type { EditorView } from "@tiptap/pm/view";
+import { nextCodePointIndex, previousCodePointIndex } from "./utils";
+
+const CURSOR_SCALE = 1.5;
+const WORD_CHARACTER = /[\p{L}\p{M}\p{N}_'’]/u;
+
+export type WordRange = { from: number; to: number };
+
+export function wordRangeAtOffset(
+	text: string,
+	offset: number,
+): WordRange | null {
+	let index = Math.min(Math.max(offset, 0), text.length);
+	if (index > 0 && isWordCharacterBefore(text, index)) {
+		index = previousCodePointIndex(text, index);
+	} else if (!isWordCharacterAt(text, index)) {
+		return null;
+	}
+
+	let from = index;
+	while (from > 0 && isWordCharacterBefore(text, from)) {
+		from = previousCodePointIndex(text, from);
+	}
+
+	let to = index;
+	while (to < text.length && isWordCharacterAt(text, to)) {
+		to = nextCodePointIndex(text, to);
+	}
+
+	return from < to ? { from, to } : null;
+}
+
+/**
+ * Expands a secondary-click on the rendered caret to its adjacent word.
+ * Chromium otherwise misses that word during context-menu hit testing, so
+ * Electron cannot offer spelling suggestions even when it underlines the word.
+ */
+export const ContextMenuSpellcheckExtension = Extension.create({
+	name: "contextMenuSpellcheck",
+
+	addProseMirrorPlugins() {
+		return [
+			new Plugin({
+				props: {
+					handleDOMEvents: {
+						mousedown: (view: EditorView, event: MouseEvent) => {
+							if (event.button !== 2 || !view.state.selection.empty)
+								return false;
+							const caret = view.coordsAtPos(view.state.selection.head);
+							if (!isWithinVirtualCaret(event, caret)) return false;
+
+							const range = wordRangeAtSelection(
+								view.state.doc,
+								view.state.selection.head,
+							);
+							if (!range) return false;
+
+							view.dispatch(
+								view.state.tr.setSelection(
+									TextSelection.create(view.state.doc, range.from, range.to),
+								),
+							);
+							return false;
+						},
+					},
+				},
+			}),
+		];
+	},
+});
+
+function wordRangeAtSelection(
+	doc: ProseMirrorNode,
+	position: number,
+): WordRange | null {
+	const $position = doc.resolve(position);
+	if (!$position.parent.isTextblock) return null;
+	const text = $position.parent.textBetween(
+		0,
+		$position.parent.content.size,
+		"\0",
+		"\0",
+	);
+	const range = wordRangeAtOffset(text, $position.parentOffset);
+	if (!range) return null;
+	const parentStart = $position.start();
+	return { from: parentStart + range.from, to: parentStart + range.to };
+}
+
+function isWithinVirtualCaret(
+	event: MouseEvent,
+	caret: { left: number; right: number; top: number; bottom: number },
+) {
+	const lineHeight = Math.max(caret.bottom - caret.top, 1);
+	const scaledHeight = lineHeight * CURSOR_SCALE;
+	const blockInset = (scaledHeight - lineHeight) / 2;
+	const width = scaledHeight * 0.02 + 2;
+	const inlineSlop = measureCh(event);
+	return (
+		event.clientX >= caret.left - inlineSlop &&
+		event.clientX <= caret.left + width + inlineSlop &&
+		event.clientY >= caret.top - blockInset &&
+		event.clientY <= caret.bottom + blockInset
+	);
+}
+
+function measureCh(event: MouseEvent) {
+	const target = event.target instanceof Element ? event.target : document.body;
+	const style = getComputedStyle(target);
+	const context = document.createElement("canvas").getContext("2d");
+	if (!context) return Number.parseFloat(style.fontSize) / 2;
+	context.font = `${style.fontStyle} ${style.fontVariant} ${style.fontWeight} ${style.fontSize} ${style.fontFamily}`;
+	return context.measureText("0").width;
+}
+
+function isWordCharacterAt(text: string, index: number) {
+	const codePoint = text.codePointAt(index);
+	return (
+		codePoint !== undefined &&
+		WORD_CHARACTER.test(String.fromCodePoint(codePoint))
+	);
+}
+
+function isWordCharacterBefore(text: string, index: number) {
+	return isWordCharacterAt(text, previousCodePointIndex(text, index));
+}

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -1,3 +1,4 @@
+export { ContextMenuSpellcheckExtension } from "./ContextMenuSpellcheckExtension";
 export { FakeSelectionExtension } from "./FakeSelectionExtension";
 export {
 	FindExtension,

--- a/packages/editor/src/utils.ts
+++ b/packages/editor/src/utils.ts
@@ -1,6 +1,17 @@
 import type { Node as PMNode, ResolvedPos } from "@tiptap/pm/model";
 import type { Selection as PMSelection } from "@tiptap/pm/state";
 
+export function previousCodePointIndex(text: string, index: number) {
+	if (index <= 0) return 0;
+	const previous = text.charCodeAt(index - 1);
+	return previous >= 0xdc00 && previous <= 0xdfff ? index - 2 : index - 1;
+}
+
+export function nextCodePointIndex(text: string, index: number) {
+	const codePoint = text.codePointAt(index);
+	return index + (codePoint !== undefined && codePoint > 0xffff ? 2 : 1);
+}
+
 /**
  * Get the position of where the first text node starts in the given node.
  */

--- a/packages/ui/src/editor/EditorView.tsx
+++ b/packages/ui/src/editor/EditorView.tsx
@@ -1,4 +1,5 @@
 import {
+	ContextMenuSpellcheckExtension,
 	combineMarkdownFrontMatter,
 	FakeSelectionExtension,
 	FindExtension,
@@ -156,6 +157,7 @@ export function EditorView({
 			SmartLinkExtension,
 			LinkClickExtension.configure({ onOpenExternalLink, onOpenWikiLink }),
 			LinkCreationGhostExtension,
+			ContextMenuSpellcheckExtension,
 			FakeSelectionExtension,
 			FindExtension,
 			HeadingExtension,


### PR DESCRIPTION
## Description
Restore macOS Writing Tools, text services, and spellcheck suggestions in editable desktop context menus. Smart-select the word at a collapsed caret so suggestions remain available near the caret boundary.


https://github.com/user-attachments/assets/66a2e7c5-2365-4c0d-8471-007eaf81f9d0



Closes #157

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update

## Testing
- [x] Existing tests pass
- [x] Added new tests for changes
- [x] Tested manually (describe below)

**Manual Testing Details:**
Verified the desktop app launches with native macOS text services and exercised context-menu behavior around misspelled words and the rendered caret.

## Checklist
- [ ] I discussed this change in a GitHub issue before submitting this PR
- [x] I have run the linter, formatter, and tests to ensure my code is ready for review