### PR TITLE
Migrate React surfaces to React Compiler

### DIFF
--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: review-pr
+description: Review a pull request or local branch diff for correctness, security, lifecycle, error handling, tests, and meaningful performance risks. Use when asked to review PR changes, a branch, a commit range, or the current working tree and return a structured review.
+---
+
+# Review PR
+
+Review the requested change set and return one structured JSON review as the final response.
+
+## Establish scope
+
+1. Use the base branch, commit, or range named by the user.
+2. Otherwise determine the merge base with the repository's default branch.
+3. Include committed branch changes plus relevant staged, unstaged, and untracked files.
+4. Use available change descriptions, specifications, and review context.
+5. Focus on changed code and the unchanged call sites needed to prove or disprove a finding.
+
+## Review priorities
+
+Prioritize:
+
+1. Correctness, data loss, security, crashes, and broken user behavior.
+2. Lifecycle, concurrency, stale state, cleanup, and error-handling problems.
+3. Material performance regressions on demonstrated hot paths.
+4. Missing tests only when they cover a distinct behavior or edge case.
+
+Avoid speculative findings. Trace relevant callers, state transitions, cleanup paths, and existing tests before reporting an issue. Do not flag untouched code unless the change makes it unsafe.
+
+Treat robustness ideas as suggestions unless they present a concrete correctness, security, or data-loss risk. Do not request tests that merely vary constructor inputs or fields already covered by the same behavior.
+
+## Finding rules
+
+Use these severities:
+
+- `critical`: security issue, data loss, crash, or broadly broken behavior.
+- `important`: concrete logic, lifecycle, edge-case, or error-handling bug.
+- `suggestion`: worthwhile non-blocking improvement.
+- `nit`: precise cleanup with a concrete replacement.
+
+For every finding:
+
+- Cite a repository-relative path.
+- Cite an exact changed line when possible; otherwise use `null`.
+- Explain the failure mode and when it occurs.
+- Give a concrete fix direction.
+- Keep the body concise and actionable.
+
+Return `REQUEST_CHANGES` only when at least one `critical` or `important` finding remains. Suggestions and nits do not block approval.
+
+## Output
+
+Return only valid JSON with this shape. Do not wrap it in a Markdown fence and do not write it to disk.
+
+```json
+{
+  "verdict": "REQUEST_CHANGES",
+  "overview": "Short description of the reviewed change and overall assessment.",
+  "findings": [
+    {
+      "severity": "important",
+      "path": "path/to/file.ts",
+      "line": 42,
+      "title": "Short finding title",
+      "body": "Failure mode, evidence, and concrete fix direction."
+    }
+  ],
+  "counts": {
+    "critical": 0,
+    "important": 1,
+    "suggestion": 0,
+    "nit": 0
+  }
+}
+```
+
+`verdict` must be exactly `APPROVE` or `REQUEST_CHANGES`. `findings` must be empty when no issues remain. Counts must match the findings array.
+
+Do not modify the repository or publish the review unless the user separately asks.

--- a/.claude/skills/review-pr
+++ b/.claude/skills/review-pr
@@ -1,0 +1,1 @@
+../../.agents/skills/review-pr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,5 +66,8 @@ jobs:
       - name: Build packages
         run: pnpm --filter "./packages/**" --if-present build
 
+      - name: Audit React Compiler coverage
+        run: pnpm check:react-compiler
+
       - name: Run tests
         run: pnpm test

--- a/.github/workflows/review-pull-requests.yml
+++ b/.github/workflows/review-pull-requests.yml
@@ -5,7 +5,7 @@ name: Review Pull Requests
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review, synchronize]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -28,6 +28,10 @@ jobs:
       head_sha: ${{ steps.pr.outputs.head_sha }}
       pr_number: ${{ steps.pr.outputs.pr_number }}
     steps:
+      - name: Wait for pushes to settle
+        if: github.event_name == 'pull_request'
+        run: sleep 60
+
       - name: Resolve PR metadata
         id: pr
         env:

--- a/.github/workflows/review-pull-requests.yml
+++ b/.github/workflows/review-pull-requests.yml
@@ -298,8 +298,8 @@ jobs:
                       raise SystemExit(f"Comment {index} has invalid range")
                   if start_line not in locations.get(path, {}).get(side, set()):
                       raise SystemExit(f"Comment {index} range starts outside the diff")
-                  if start_line > line or line - start_line >= 10:
-                      raise SystemExit(f"Comment {index} range exceeds 10 lines")
+                  if start_line > line:
+                      raise SystemExit(f"Comment {index} has an inverted range")
               normalized.append(item)
 
           payload = {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 
 ### Fixed
 
+- Switching between notes now keeps navigation controls stable and saves pending edits to the correct file. [#167](https://github.com/bholmesdev/hubble.md/pull/167)
 - macOS text context menus now include Writing Tools, text services, and spelling suggestions. Thanks [@noahpatterson](https://github.com/noahpatterson) for the suggestion! [#164](https://github.com/bholmesdev/hubble.md/pull/164)
 - Update-check failures now show a concise, unobtrusive message instead of a raw error trace.
 

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -30,7 +30,11 @@ export default defineConfig({
 	renderer: {
 		root: ".",
 		plugins: [
-			react(),
+			react({
+				babel: {
+					plugins: ["babel-plugin-react-compiler"],
+				},
+			}),
 			icons({
 				compiler: "jsx",
 				jsx: "react",

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -3,6 +3,7 @@ import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig, externalizeDepsPlugin } from "electron-vite";
 import icons from "unplugin-icons/vite";
+import { reactCompilerPlugin } from "../../config/react-compiler-audit";
 
 const devPort = Number(process.env.PORT ?? 1420);
 
@@ -32,7 +33,7 @@ export default defineConfig({
 		plugins: [
 			react({
 				babel: {
-					plugins: ["babel-plugin-react-compiler"],
+					plugins: [reactCompilerPlugin("desktop")],
 				},
 			}),
 			icons({

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -68,6 +68,7 @@
 		"@types/react": "^19.1.8",
 		"@types/react-dom": "^19.1.6",
 		"@vitejs/plugin-react": "^4.6.0",
+		"babel-plugin-react-compiler": "^1.0.0",
 		"chokidar": "^4.0.3",
 		"electron": "^42.3.1",
 		"electron-builder": "^26.8.1",

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -11,7 +11,7 @@ import {
 } from "@hubble.md/ui";
 import { useStoreValue } from "@simplestack/store/react";
 import { keymatch } from "keymatch";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import MingcutePencilLine from "~icons/mingcute/pencil-line";
 import { HtmlAppEmptyState } from "./components/HtmlAppEmptyState";
@@ -103,6 +103,18 @@ async function revealPath(path: string | null) {
 	}
 }
 
+async function openFilePicker() {
+	const currentPath = viewerStore.get().currentPath;
+	const defaultPath =
+		(isChangelogPath(currentPath) ? null : currentPath) ??
+		workspaceStore.get().workspacePath ??
+		undefined;
+	const selected = await desktopApi.openFilePicker({ defaultPath });
+	if (typeof selected === "string") {
+		await loadPath(selected);
+	}
+}
+
 let nextSearchRequestId = 0;
 
 /**
@@ -141,15 +153,11 @@ function App() {
 	const [dismissedVersion, setDismissedVersion] = useState<string | null>(null);
 	const [searchOpen, setSearchOpen] = useState(false);
 	const workspaceFiles = useStoreValue(workspaceStore).files;
-	const paletteFiles: PaletteFile[] = useMemo(
-		() =>
-			workspaceFiles.map((file) => ({
-				path: file.path,
-				relativePath: relativeWorkspacePath(file.path, workspacePath ?? null),
-				modifiedAt: file.modified_at,
-			})),
-		[workspaceFiles, workspacePath],
-	);
+	const paletteFiles: PaletteFile[] = workspaceFiles.map((file) => ({
+		path: file.path,
+		relativePath: relativeWorkspacePath(file.path, workspacePath ?? null),
+		modifiedAt: file.modified_at,
+	}));
 	const lastSeenVersion = useStoreValue(lastSeenVersionStore);
 
 	const readyVersion =
@@ -168,9 +176,9 @@ function App() {
 		lastSeenVersion !== currentVersion
 			? currentVersion
 			: null;
-	const markWhatsNewSeen = useCallback(() => {
+	const markWhatsNewSeen = () => {
 		if (currentVersion) setLastSeenVersion(currentVersion);
-	}, [currentVersion]);
+	};
 
 	useEffect(() => {
 		// First install has no update to announce; just record the version.
@@ -179,15 +187,12 @@ function App() {
 		}
 	}, [currentVersion, lastSeenVersion]);
 
-	const openSettings = useCallback(() => {
-		setSettingsOpen(true);
-	}, []);
-	const openWhatsNew = useCallback(() => {
+	const openWhatsNew = () => {
 		setSettingsOpen(false);
 		void openChangelog();
-	}, []);
+	};
 
-	const installUpdate = useCallback(async () => {
+	const installUpdate = async () => {
 		try {
 			await desktopApi.installUpdate();
 		} catch (error) {
@@ -195,16 +200,16 @@ function App() {
 				description: error instanceof Error ? error.message : String(error),
 			});
 		}
-	}, []);
+	};
 
-	const triggerPrimaryUpdateAction = useCallback(async () => {
+	const triggerPrimaryUpdateAction = async () => {
 		if (!updateState?.isSupported) return;
 		if (updateState.status === "ready") {
 			await installUpdate();
 			return;
 		}
 		await desktopApi.checkForUpdates();
-	}, [installUpdate, updateState]);
+	};
 
 	useEffect(() => {
 		const currentPath = state.currentPath;
@@ -247,18 +252,6 @@ function App() {
 		};
 	}, [state.currentPath]);
 
-	const openFilePicker = useCallback(async () => {
-		const currentPath = viewerStore.get().currentPath;
-		const defaultPath =
-			(isChangelogPath(currentPath) ? null : currentPath) ??
-			workspaceStore.get().workspacePath ??
-			undefined;
-		const selected = await desktopApi.openFilePicker({ defaultPath });
-		if (typeof selected === "string") {
-			await loadPath(selected);
-		}
-	}, []);
-
 	useEffect(() => {
 		const currentPath = state.currentPath;
 		void desktopApi.setMenuState({
@@ -296,7 +289,7 @@ function App() {
 				await createMarkdownFile();
 			} else if (keymatch(event, "CmdOrCtrl+,")) {
 				event.preventDefault();
-				openSettings();
+				setSettingsOpen(true);
 			} else if (keymatch(event, "CmdOrCtrl+Shift+O")) {
 				if (!workspaceStore.get().workspacePath) return;
 				event.preventDefault();
@@ -341,7 +334,7 @@ function App() {
 		};
 		window.addEventListener("keydown", onKeyDown);
 		return () => window.removeEventListener("keydown", onKeyDown);
-	}, [focusedSidebarPath, openFilePicker, openSettings]);
+	}, [focusedSidebarPath]);
 
 	useEffect(() => {
 		let active = true;
@@ -372,8 +365,11 @@ function App() {
 			desktopApi.onMenuCreateHtmlFile(() => void createHtmlFile()),
 			desktopApi.onMenuOpenFile(() => void openFilePicker()),
 			desktopApi.onMenuOpenFolder(() => void openWorkspaceWithSidebar()),
-			desktopApi.onMenuOpenSettings(() => openSettings()),
-			desktopApi.onMenuOpenChangelog(openWhatsNew),
+			desktopApi.onMenuOpenSettings(() => setSettingsOpen(true)),
+			desktopApi.onMenuOpenChangelog(() => {
+				setSettingsOpen(false);
+				void openChangelog();
+			}),
 			desktopApi.onMenuCopyAsMarkdown(() =>
 				setCopyAsMarkdownRequest((request) => request + 1),
 			),
@@ -399,7 +395,7 @@ function App() {
 		return () => {
 			for (const dispose of disposers) dispose();
 		};
-	}, [openFilePicker, openSettings, openWhatsNew]);
+	}, []);
 
 	useEffect(() => {
 		// Window focus can fire in bursts when switching apps, so debounce the
@@ -731,40 +727,34 @@ function MarkdownEditor({
 			title: wikiDisplayNameForTarget(target),
 		};
 	});
-	const openExternalLink = useCallback(
-		async (href: string) => {
-			if (classifyHref(href) === "external") {
-				await desktopApi.openExternalUrl(href);
+	const openExternalLink = async (href: string) => {
+		if (classifyHref(href) === "external") {
+			await desktopApi.openExternalUrl(href);
+			return;
+		}
+		const resolved = resolveRelativeLinkPath({
+			href,
+			currentFilePath: path,
+			workspacePath: workspace.workspacePath,
+		});
+		try {
+			const result = await desktopApi.openPathFromLink(resolved);
+			if (result.kind === "markdown") await loadPath(result.path);
+		} catch (error) {
+			if (error instanceof Error && error.message.includes("Open cancelled")) {
 				return;
 			}
-			const resolved = resolveRelativeLinkPath({
-				href,
-				currentFilePath: path,
-				workspacePath: workspace.workspacePath,
-			});
-			try {
-				const result = await desktopApi.openPathFromLink(resolved);
-				if (result.kind === "markdown") await loadPath(result.path);
-			} catch (error) {
-				if (
-					error instanceof Error &&
-					error.message.includes("Open cancelled")
-				) {
-					return;
-				}
-				if (
-					hasMarkdownExtension(resolved) &&
-					error instanceof Error &&
-					error.message.includes("FILE_NOT_FOUND")
-				) {
-					toast.error(`File not found: ${href.split("#", 1)[0] ?? href}`);
-					return;
-				}
-				throw error;
+			if (
+				hasMarkdownExtension(resolved) &&
+				error instanceof Error &&
+				error.message.includes("FILE_NOT_FOUND")
+			) {
+				toast.error(`File not found: ${href.split("#", 1)[0] ?? href}`);
+				return;
 			}
-		},
-		[path, workspace.workspacePath],
-	);
+			throw error;
+		}
+	};
 	return (
 		<EditorView
 			path={path}

--- a/apps/desktop/src/components/TerminalPanel.tsx
+++ b/apps/desktop/src/components/TerminalPanel.tsx
@@ -32,6 +32,8 @@ type Session = {
 	title: string;
 };
 
+type StartSessionOptions = { initialCommand?: string };
+
 type TerminalState = {
 	sessions: Session[];
 	activeSessionId: string | null;
@@ -135,6 +137,30 @@ function cssColorToRgba(color: string): string {
 	ctx.fillRect(0, 0, 1, 1);
 	const [r, g, b, a] = ctx.getImageData(0, 0, 1, 1).data;
 	return `rgba(${r}, ${g}, ${b}, ${a / 255})`;
+}
+
+async function startTerminalSession(
+	title: string,
+	options: StartSessionOptions,
+	onStart: (session: Session) => void,
+) {
+	while (true) {
+		const requestedWorkspacePath = workspacePathStore.get();
+		if (!requestedWorkspacePath) return;
+		const notePath = viewerStore.get().currentPath ?? undefined;
+		const sessionId = await desktopApi.terminalStart(requestedWorkspacePath, {
+			...(notePath ? { notePath } : {}),
+			...options,
+		});
+		if (workspacePathStore.get() === requestedWorkspacePath) {
+			onStart({ id: sessionId, title });
+			return;
+		}
+		// The workspace changed while this shell booted. Adopting it would
+		// show a shell cwd'd to the old workspace, so drop it and retry.
+		void desktopApi.terminalStop(sessionId);
+		if (!terminalOpenStore.get()) return;
+	}
 }
 
 const LIGHT_THEME = {
@@ -256,6 +282,23 @@ export function TerminalPanel() {
 		);
 	}, [sessions, workspacePath]);
 
+	const startSession = async (
+		title: string,
+		options: StartSessionOptions = {},
+	) => {
+		setStartError(null);
+		try {
+			await startTerminalSession(title, options, (session) => {
+				dispatch({ type: "add", session });
+			});
+		} catch (error) {
+			console.error("Failed to start terminal session:", error);
+			setStartError(
+				"Terminal unavailable. The bundled shell module failed to load.",
+			);
+		}
+	};
+
 	// Start sessions while the panel is open: a pending chat command gets its
 	// own tab; otherwise an empty panel boots a plain shell. sessions.length
 	// retries a chat launch that arrived while another session was starting.
@@ -265,59 +308,21 @@ export function TerminalPanel() {
 		if (!pendingTerminalCommand && sessions.length > 0) return;
 
 		isInitializingRef.current = true;
-		void (async () => {
-			try {
-				if (pendingTerminalCommand) {
-					await startSession(
-						pendingTerminalCommand.split(/\s+/, 1)[0] || "chat",
-						{ initialCommand: pendingTerminalCommand },
-					);
-					clearPendingTerminalCommand();
-				} else {
-					await startSession("bash");
-				}
-			} finally {
+		const sessionPromise = pendingTerminalCommand
+			? startSession(pendingTerminalCommand.split(/\s+/, 1)[0] || "chat", {
+					initialCommand: pendingTerminalCommand,
+				})
+			: startSession("bash");
+		void sessionPromise.then(
+			() => {
+				if (pendingTerminalCommand) clearPendingTerminalCommand();
 				isInitializingRef.current = false;
-			}
-		})();
+			},
+			() => {
+				isInitializingRef.current = false;
+			},
+		);
 	}, [isOpen, pendingTerminalCommand, workspacePath, sessions.length]);
-
-	const startSession = async (
-		title: string,
-		options: { initialCommand?: string } = {},
-	) => {
-		setStartError(null);
-		try {
-			while (true) {
-				const requestedWorkspacePath = workspacePathStore.get();
-				if (!requestedWorkspacePath) return;
-				const notePath = viewerStore.get().currentPath ?? undefined;
-				const sessionId = await desktopApi.terminalStart(
-					requestedWorkspacePath,
-					{
-						...(notePath ? { notePath } : {}),
-						...options,
-					},
-				);
-				if (workspacePathStore.get() === requestedWorkspacePath) {
-					dispatch({
-						type: "add",
-						session: { id: sessionId, title },
-					});
-					return;
-				}
-				// The workspace changed while this shell booted. Adopting it would
-				// show a shell cwd'd to the old workspace, so drop it and retry.
-				void desktopApi.terminalStop(sessionId);
-				if (!terminalOpenStore.get()) return;
-			}
-		} catch (error) {
-			console.error("Failed to start terminal session:", error);
-			setStartError(
-				"Terminal unavailable. The bundled shell module failed to load.",
-			);
-		}
-	};
 
 	const handleCloseSession = async (sessionId: string) => {
 		await desktopApi.terminalStop(sessionId);
@@ -567,9 +572,11 @@ function TerminalInstance({
 	const containerRef = useRef<HTMLDivElement>(null);
 	const termRef = useRef<Terminal | null>(null);
 	const fitAddonRef = useRef<FitAddon | null>(null);
-	// Read via ref so an unstable callback prop can never remount xterm.
+	// Read via ref so callback changes never remount xterm.
 	const onExitRef = useRef(onExit);
-	onExitRef.current = onExit;
+	useEffect(() => {
+		onExitRef.current = onExit;
+	}, [onExit]);
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional
 	useEffect(() => {
@@ -676,11 +683,18 @@ function TerminalInstance({
 			fitAddonRef.current &&
 			containerRef.current?.offsetParent !== null
 		) {
+			const fitAddon = fitAddonRef.current;
+			const term = termRef.current;
 			try {
-				fitAddonRef.current.fit();
-				termRef.current?.focus();
+				fitAddon.fit();
 			} catch {
-				//
+				// Layout may disappear while the debounced fit is running.
+			}
+			if (!term) return;
+			try {
+				term.focus();
+			} catch {
+				// The terminal may be disposed during panel teardown.
 			}
 		}
 	}, [isActive]);

--- a/apps/desktop/src/components/TerminalPanel.tsx
+++ b/apps/desktop/src/components/TerminalPanel.tsx
@@ -3,7 +3,14 @@ import { useResizeSeparator } from "@hubble.md/ui";
 import { useStoreValue } from "@simplestack/store/react";
 import { FitAddon } from "@xterm/addon-fit";
 import { Terminal } from "@xterm/xterm";
-import { type ReactNode, useEffect, useReducer, useRef, useState } from "react";
+import {
+	type ReactNode,
+	useEffect,
+	useLayoutEffect,
+	useReducer,
+	useRef,
+	useState,
+} from "react";
 import { desktopApi } from "../desktopApi";
 import { cn } from "../lib/utils";
 import {
@@ -572,9 +579,10 @@ function TerminalInstance({
 	const containerRef = useRef<HTMLDivElement>(null);
 	const termRef = useRef<Terminal | null>(null);
 	const fitAddonRef = useRef<FitAddon | null>(null);
-	// Read via ref so callback changes never remount xterm.
+	// Sync before paint so xterm never sees a stale callback after a render;
+	// keeping it in a ref avoids remounting the terminal when the callback changes.
 	const onExitRef = useRef(onExit);
-	useEffect(() => {
+	useLayoutEffect(() => {
 		onExitRef.current = onExit;
 	}, [onExit]);
 

--- a/apps/desktop/src/components/useSidebarKeyboardNav.ts
+++ b/apps/desktop/src/components/useSidebarKeyboardNav.ts
@@ -1,4 +1,4 @@
-import { type RefObject, useCallback, useEffect, useState } from "react";
+import { type RefObject, useEffect, useState } from "react";
 import { EDITOR_INPUT_SELECTOR } from "../selectors";
 
 export function useSidebarKeyboardNav<T>({
@@ -13,10 +13,6 @@ export function useSidebarKeyboardNav<T>({
 	activeIndex?: number;
 }) {
 	const [focusedIndex, setFocusedIndex] = useState<number | null>(null);
-	const getActionIndex = useCallback(
-		() => focusedIndex ?? (activeIndex >= 0 ? activeIndex : null),
-		[activeIndex, focusedIndex],
-	);
 
 	useEffect(() => {
 		if (focusedIndex === null) return;
@@ -25,39 +21,36 @@ export function useSidebarKeyboardNav<T>({
 			?.scrollIntoView({ block: "nearest" });
 	}, [focusedIndex, navRef]);
 
-	const onKeyDown = useCallback(
-		(event: React.KeyboardEvent) => {
-			if (items.length === 0) return;
+	const onKeyDown = (event: React.KeyboardEvent) => {
+		if (items.length === 0) return;
 
-			switch (event.key) {
-				case "ArrowDown":
-				case "ArrowUp": {
-					event.preventDefault();
-					const delta = event.key === "ArrowDown" ? 1 : -1;
-					setFocusedIndex((prev) => {
-						const start = prev ?? (activeIndex >= 0 ? activeIndex : -1);
-						return Math.max(0, Math.min(start + delta, items.length - 1));
-					});
-					break;
-				}
-				case "Enter": {
-					const idx = getActionIndex();
-					if (idx !== null && items[idx]) {
-						event.preventDefault();
-						onSelect(items[idx]);
-					}
-					break;
-				}
-				case "Escape": {
-					event.preventDefault();
-					setFocusedIndex(null);
-					document.querySelector<HTMLElement>(EDITOR_INPUT_SELECTOR)?.focus();
-					break;
-				}
+		switch (event.key) {
+			case "ArrowDown":
+			case "ArrowUp": {
+				event.preventDefault();
+				const delta = event.key === "ArrowDown" ? 1 : -1;
+				setFocusedIndex((prev) => {
+					const start = prev ?? (activeIndex >= 0 ? activeIndex : -1);
+					return Math.max(0, Math.min(start + delta, items.length - 1));
+				});
+				break;
 			}
-		},
-		[items, onSelect, activeIndex, getActionIndex],
-	);
+			case "Enter": {
+				const idx = focusedIndex ?? (activeIndex >= 0 ? activeIndex : null);
+				if (idx !== null && items[idx]) {
+					event.preventDefault();
+					onSelect(items[idx]);
+				}
+				break;
+			}
+			case "Escape": {
+				event.preventDefault();
+				setFocusedIndex(null);
+				document.querySelector<HTMLElement>(EDITOR_INPUT_SELECTOR)?.focus();
+				break;
+			}
+		}
+	};
 
 	return { focusedIndex, setFocusedIndex, onKeyDown };
 }

--- a/apps/desktop/src/editor/IframeView.tsx
+++ b/apps/desktop/src/editor/IframeView.tsx
@@ -87,7 +87,7 @@ export function IframeView({
 	onHeightChange,
 }: IframeViewProps) {
 	const iframeRef = useRef<HTMLIFrameElement | null>(null);
-	const tokenRef = useRef(crypto.randomUUID());
+	const [token] = useState(() => crypto.randomUUID());
 	const [error, setError] = useState<string | null>(null);
 
 	useEffect(() => {
@@ -144,7 +144,7 @@ export function IframeView({
 		<iframe
 			ref={iframeRef}
 			className={className}
-			name={tokenRef.current}
+			name={token}
 			scrolling="auto"
 			title={title}
 			sandbox="allow-scripts allow-forms"

--- a/apps/desktop/src/store/actions.test.ts
+++ b/apps/desktop/src/store/actions.test.ts
@@ -1022,6 +1022,43 @@ describe("desktop loadPath", () => {
 		expect(canGoForward()).toBe(false);
 	});
 
+	it("keeps history availability stable while blocking concurrent navigation", async () => {
+		const api = createDesktopApi();
+		api.readFileText.mockImplementation(
+			async (path: string) => `content:${path}`,
+		);
+		let resolvePathExists: ((exists: boolean) => void) | undefined;
+		api.pathExists.mockImplementation(
+			() =>
+				new Promise<boolean>((resolve) => {
+					resolvePathExists = resolve;
+				}),
+		);
+		const {
+			canGoBack,
+			canGoForward,
+			goBack,
+			historyStore,
+			loadPath,
+			viewerStore,
+		} = await loadStoreActions(api);
+
+		await loadPath("/workspace/a.md");
+		await loadPath("/workspace/b.md");
+		await loadPath("/workspace/c.md");
+
+		const firstNavigation = goBack();
+		await vi.waitFor(() => expect(historyStore.get().isNavigating).toBe(true));
+		expect(canGoBack()).toBe(true);
+		expect(canGoForward()).toBe(false);
+		await goBack();
+		expect(api.pathExists).toHaveBeenCalledTimes(1);
+
+		resolvePathExists?.(true);
+		await firstNavigation;
+		expect(viewerStore.get().currentPath).toBe("/workspace/b.md");
+	});
+
 	it("stays on the current file when opening a missing file fails", async () => {
 		const api = createDesktopApi();
 		api.pathExists.mockResolvedValue(true);

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -1180,6 +1180,9 @@ export async function openChangelog(): Promise<boolean> {
 }
 
 async function navigateHistory(delta: -1 | 1) {
+	// Keep the toolbar's stack-derived availability stable while preventing a
+	// second navigation from racing the in-flight save and load.
+	if (historyStore.get().isNavigating) return;
 	if (!(delta < 0 ? canGoBack() : canGoForward())) return;
 
 	const current = viewerStore.get();

--- a/apps/desktop/src/store/history.ts
+++ b/apps/desktop/src/store/history.ts
@@ -132,7 +132,6 @@ export function canGoBack(
 	workspacePath = workspaceStore.get().workspacePath,
 	onChangelog = isChangelogPath(currentPathStore.get()),
 ) {
-	if (history.isNavigating) return false;
 	const stack = stackFor(history, workspacePath);
 	// The changelog note is never pushed, so back means "return to the current
 	// entry" and stays enabled whenever one exists.
@@ -145,7 +144,6 @@ export function canGoForward(
 	workspacePath = workspaceStore.get().workspacePath,
 	onChangelog = isChangelogPath(currentPathStore.get()),
 ) {
-	if (history.isNavigating) return false;
 	if (onChangelog) return false;
 	const { index, entries } = stackFor(history, workspacePath);
 	return index >= 0 && index < entries.length - 1;

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -9,7 +9,11 @@ const devPort = Number(process.env.PORT ?? 1420);
 // https://vite.dev/config/
 export default defineConfig(async () => ({
 	plugins: [
-		react(),
+		react({
+			babel: {
+				plugins: ["babel-plugin-react-compiler"],
+			},
+		}),
 		icons({
 			compiler: "jsx",
 			jsx: "react",

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -3,6 +3,7 @@ import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import icons from "unplugin-icons/vite";
 import { defineConfig } from "vite";
+import { reactCompilerPlugin } from "../../config/react-compiler-audit";
 
 const devPort = Number(process.env.PORT ?? 1420);
 
@@ -11,7 +12,7 @@ export default defineConfig(async () => ({
 	plugins: [
 		react({
 			babel: {
-				plugins: ["babel-plugin-react-compiler"],
+				plugins: [reactCompilerPlugin("desktop")],
 			},
 		}),
 		icons({

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -46,6 +46,7 @@
 		"@types/react": "^19.1.8",
 		"@types/react-dom": "^19.1.6",
 		"@vitejs/plugin-react": "^4.6.0",
+		"babel-plugin-react-compiler": "^1.0.0",
 		"tailwindcss": "^4.1.18",
 		"typescript": "~5.8.3",
 		"unplugin-icons": "^23.0.1",

--- a/apps/www/src/screens/ConnectScreen.tsx
+++ b/apps/www/src/screens/ConnectScreen.tsx
@@ -27,10 +27,10 @@ export function ConnectScreen({ onConnected }: Props) {
 			});
 			saveConnectionUrl(trimmed);
 			ensureDeviceId();
+			setBusy(false);
 			onConnected(trimmed);
 		} catch (err) {
 			setError(describeError(categorizeError(err)));
-		} finally {
 			setBusy(false);
 		}
 	};

--- a/apps/www/src/screens/OpenWorkspaceScreen.tsx
+++ b/apps/www/src/screens/OpenWorkspaceScreen.tsx
@@ -19,6 +19,10 @@ export function OpenWorkspaceScreen({ url, onSelected, onDisconnect }: Props) {
 	const [error, setError] = useState<string | null>(null);
 	const [name, setName] = useState("");
 	const [busy, setBusy] = useState(false);
+	const select = (id: string) => {
+		saveWorkspace(id);
+		onSelected(id);
+	};
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: select uses stable saveWorkspace + props
 	useEffect(() => {
@@ -40,11 +44,6 @@ export function OpenWorkspaceScreen({ url, onSelected, onDisconnect }: Props) {
 			cancelled = true;
 		};
 	}, [client]);
-
-	const select = (id: string) => {
-		saveWorkspace(id);
-		onSelected(id);
-	};
 
 	const handleCreate = async (event: React.FormEvent) => {
 		event.preventDefault();

--- a/apps/www/src/shell/AppShell.tsx
+++ b/apps/www/src/shell/AppShell.tsx
@@ -32,6 +32,34 @@ type Props = {
 	onDisconnect: () => void;
 };
 
+async function onRemoteFilesChanged() {
+	const ctx = getActionCtx();
+	if (!ctx) return;
+	const remote = await ctx.backend.getFiles(ctx.workspaceId, {
+		includeDeleted: true,
+	});
+	// One tombstone-inclusive fetch updates the sidebar and detects whether
+	// the current file was deleted.
+	const visible = remote
+		.filter((file) => !file.deleted)
+		.map((file) => ({
+			path: file.path,
+			contentHash: file.contentHash,
+			updatedAt: file.updatedAt,
+			deleted: file.deleted,
+		}));
+	workspaceStore.set((state) => ({ ...state, files: visible }));
+
+	const viewer = viewerStore.get();
+	if (!viewer.currentPath) return;
+	const current = remote.find((file) => file.path === viewer.currentPath);
+	if (!current || current.deleted) {
+		markRemoteDeleted(viewer.currentPath);
+		return;
+	}
+	applyRemoteChange(viewer.currentPath, current.content, current.contentHash);
+}
+
 export function AppShell({
 	url,
 	workspaceId,
@@ -71,7 +99,6 @@ export function AppShell({
 		};
 	}, []);
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: subscription owns its lifecycle by url+workspaceId
 	useEffect(() => {
 		if (!workspace.snapshot) return;
 		const subscriber = createConvexSubscriber(url);
@@ -129,34 +156,6 @@ export function AppShell({
 		setNewNoteSubmitted(false);
 		await refreshFiles();
 		onSelectFile(path);
-	};
-
-	const onRemoteFilesChanged = async () => {
-		const ctx = getActionCtx();
-		if (!ctx) return;
-		const remote = await ctx.backend.getFiles(ctx.workspaceId, {
-			includeDeleted: true,
-		});
-		// One tombstone-inclusive fetch updates the sidebar and detects whether
-		// the current file was deleted.
-		const visible = remote
-			.filter((f) => !f.deleted)
-			.map((f) => ({
-				path: f.path,
-				contentHash: f.contentHash,
-				updatedAt: f.updatedAt,
-				deleted: f.deleted,
-			}));
-		workspaceStore.set((state) => ({ ...state, files: visible }));
-
-		const v = viewerStore.get();
-		if (!v.currentPath) return;
-		const current = remote.find((f) => f.path === v.currentPath);
-		if (!current || current.deleted) {
-			markRemoteDeleted(v.currentPath);
-			return;
-		}
-		applyRemoteChange(v.currentPath, current.content, current.contentHash);
 	};
 
 	if (!workspace.snapshot) {

--- a/apps/www/vite.config.ts
+++ b/apps/www/vite.config.ts
@@ -5,7 +5,11 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
 	plugins: [
-		react(),
+		react({
+			babel: {
+				plugins: ["babel-plugin-react-compiler"],
+			},
+		}),
 		icons({
 			compiler: "jsx",
 			jsx: "react",

--- a/apps/www/vite.config.ts
+++ b/apps/www/vite.config.ts
@@ -2,12 +2,13 @@ import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import icons from "unplugin-icons/vite";
 import { defineConfig } from "vite";
+import { reactCompilerPlugin } from "../../config/react-compiler-audit";
 
 export default defineConfig({
 	plugins: [
 		react({
 			babel: {
-				plugins: ["babel-plugin-react-compiler"],
+				plugins: [reactCompilerPlugin("www")],
 			},
 		}),
 		icons({

--- a/biome.json
+++ b/biome.json
@@ -30,7 +30,11 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true
+			"recommended": true,
+			"correctness": {
+				"useExhaustiveDependencies": "error",
+				"useHookAtTopLevel": "error"
+			}
 		}
 	},
 	"overrides": [

--- a/config/react-compiler-audit.ts
+++ b/config/react-compiler-audit.ts
@@ -1,0 +1,91 @@
+// Biome checks hook usage; this catches React Compiler skips and zero output in real builds.
+type SourceLocation = {
+	start?: { line?: number; column?: number } | null;
+};
+
+type CompilerEvent = {
+	kind: string;
+	fnLoc?: SourceLocation | null;
+	loc?: SourceLocation | null;
+	reason?: string;
+	detail?: {
+		reason?: string;
+		description?: string | null;
+		options?: { reason?: string; description?: string | null };
+	};
+	data?: string;
+};
+
+type CompilerLogger = {
+	logEvent(filename: string | null, event: CompilerEvent): void;
+};
+
+type CompilerOptions = {
+	compilationMode: "infer";
+	logger?: CompilerLogger;
+	target: "19";
+};
+
+type BabelPlugin = [string, CompilerOptions];
+
+const AUDIT_ENABLED = process.env.REACT_COMPILER_AUDIT === "1";
+
+const formatLocation = (
+	filename: string | null,
+	event: CompilerEvent,
+): string => {
+	const start = event.fnLoc?.start ?? event.loc?.start;
+	return `${filename ?? "unknown"}${start?.line ? `:${start.line}:${(start.column ?? 0) + 1}` : ""}`;
+};
+
+const formatReason = (event: CompilerEvent): string =>
+	event.reason ??
+	event.detail?.reason ??
+	event.detail?.options?.reason ??
+	event.detail?.description ??
+	event.detail?.options?.description ??
+	event.data ??
+	"unknown reason";
+
+export const reactCompilerPlugin = (scope: string): BabelPlugin => {
+	const options: CompilerOptions = {
+		compilationMode: "infer",
+		target: "19",
+	};
+	if (!AUDIT_ENABLED) return ["babel-plugin-react-compiler", options];
+
+	let successes = 0;
+	const failures: string[] = [];
+	const logger: CompilerLogger = {
+		logEvent(filename, event) {
+			if (event.kind === "CompileSuccess") {
+				successes += 1;
+				return;
+			}
+
+			if (
+				event.kind === "CompileDiagnostic" ||
+				event.kind === "CompileSkip" ||
+				event.kind === "CompileError" ||
+				event.kind === "PipelineError"
+			) {
+				failures.push(
+					`${event.kind} ${formatLocation(filename, event)}: ${formatReason(event)}`,
+				);
+			}
+		},
+	};
+
+	process.once("beforeExit", () => {
+		const summary = `React Compiler audit (${scope}): ${successes} compiled, ${failures.length} failed`;
+		if (successes > 0 && failures.length === 0) {
+			console.log(summary);
+			return;
+		}
+
+		console.error([summary, ...failures].join("\n"));
+		process.exitCode = 1;
+	});
+
+	return ["babel-plugin-react-compiler", { ...options, logger }];
+};

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 	"bugs": "https://github.com/bholmesdev/hubble.md/issues",
 	"scripts": {
 		"check": "biome check .",
+		"check:react-compiler": "node scripts/audit-react-compiler.mjs",
 		"check:fix": "biome check . --write",
 		"test": "pnpm -r --if-present test",
 		"typecheck": "pnpm -r --if-present typecheck",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -66,6 +66,8 @@
 	"devDependencies": {
 		"@iconify-json/mingcute": "^1.2.7",
 		"@types/react": "^19.1.8",
+		"@vitejs/plugin-react": "^4.6.0",
+		"babel-plugin-react-compiler": "^1.0.0",
 		"happy-dom": "^20.10.3",
 		"typescript": "~5.8.3",
 		"unplugin-icons": "^23.0.1",

--- a/packages/ui/src/components/GlobalSearchPalette.tsx
+++ b/packages/ui/src/components/GlobalSearchPalette.tsx
@@ -1,6 +1,6 @@
 import { Dialog } from "@base-ui/react/dialog";
 import { Command } from "cmdk";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import MingcuteCornerDownLeftLine from "~icons/mingcute/corner-down-left-line";
 import MingcuteFileLine from "~icons/mingcute/file-line";
 import MingcuteSearch2Line from "~icons/mingcute/search-2-line";
@@ -72,22 +72,18 @@ function folderPath(relativePath: string) {
 	return slash === -1 ? "" : relativePath.slice(0, slash);
 }
 
-function useNameResults(files: PaletteFile[], query: string) {
-	return useMemo(() => {
-		if (query.trim() === "") {
-			return [...files]
-				.sort((a, b) => b.modifiedAt - a.modifiedAt)
-				.slice(0, MAX_RECENT_FILES);
-		}
-		return files
-			.map((file) => ({ file, score: scorePath(query, file.relativePath) }))
-			.filter((entry) => entry.score > 0)
-			.sort(
-				(a, b) => b.score - a.score || b.file.modifiedAt - a.file.modifiedAt,
-			)
-			.slice(0, MAX_NAME_RESULTS)
-			.map((entry) => entry.file);
-	}, [files, query]);
+function getNameResults(files: PaletteFile[], query: string) {
+	if (query.trim() === "") {
+		return [...files]
+			.sort((a, b) => b.modifiedAt - a.modifiedAt)
+			.slice(0, MAX_RECENT_FILES);
+	}
+	return files
+		.map((file) => ({ file, score: scorePath(query, file.relativePath) }))
+		.filter((entry) => entry.score > 0)
+		.sort((a, b) => b.score - a.score || b.file.modifiedAt - a.file.modifiedAt)
+		.slice(0, MAX_NAME_RESULTS)
+		.map((entry) => entry.file);
 }
 
 /**
@@ -103,7 +99,10 @@ function useContentResults(
 	const [result, setResult] = useState<PaletteContentResult | null>(null);
 	const [searching, setSearching] = useState(false);
 	const searchRef = useRef(searchContents);
-	searchRef.current = searchContents;
+
+	useLayoutEffect(() => {
+		searchRef.current = searchContents;
+	}, [searchContents]);
 
 	useEffect(() => {
 		if (!open || query.trim().length < MIN_CONTENT_QUERY_LENGTH) {
@@ -147,21 +146,17 @@ function GlobalSearchPalette({
 }: GlobalSearchPaletteProps) {
 	const [query, setQuery] = useState("");
 	const inputRef = useRef<HTMLInputElement | null>(null);
-	const nameResults = useNameResults(files, query);
+	const nameResults = getNameResults(files, query);
 	const { result, searching } = useContentResults(query, open, searchContents);
 
 	useEffect(() => {
 		if (!open) setQuery("");
 	}, [open]);
 
-	const relativeByPath = useMemo(
-		() => new Map(files.map((file) => [file.path, file.relativePath])),
-		[files],
+	const relativeByPath = new Map(
+		files.map((file) => [file.path, file.relativePath]),
 	);
-	const namePaths = useMemo(
-		() => new Set(nameResults.map((file) => file.path)),
-		[nameResults],
-	);
+	const namePaths = new Set(nameResults.map((file) => file.path));
 	// A file that already matched by name appears once, in the name group.
 	const contentResults = (result?.results ?? []).filter(
 		(entry) => !namePaths.has(entry.path),

--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -21,7 +21,6 @@ import {
 	forwardRef,
 	type KeyboardEvent as ReactKeyboardEvent,
 	type ReactNode,
-	useCallback,
 	useEffect,
 	useRef,
 	useState,
@@ -351,6 +350,10 @@ const segmentFirstCollision: CollisionDetection = (args) => {
 	return segmentCollisions.length > 0 ? segmentCollisions : pointerCollisions;
 };
 
+function defaultGetDisplayPath(path: string) {
+	return path;
+}
+
 export function Sidebar({
 	files,
 	folders = [],
@@ -361,7 +364,7 @@ export function Sidebar({
 	header,
 	footer,
 	emptyState,
-	getDisplayPath = (path) => path,
+	getDisplayPath = defaultGetDisplayPath,
 	onCollapse,
 	onSortModeChange,
 	onSelectFile,
@@ -451,169 +454,139 @@ export function Sidebar({
 	const sensors = useSensors(
 		useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
 	);
-	const beginRename = useCallback(
-		(
-			item: RenameItem,
-			label: string,
-			options?: { deleteOnUnchangedCancel?: boolean },
-		) => {
-			const name = splitFileName(label).name;
-			setOpenActionsPath(null);
-			setRenamingItem(item);
-			setRenameDraft(name);
-			setDeleteOnCancel(
-				options?.deleteOnUnchangedCancel
-					? { kind: item.kind, path: item.path, draft: name }
-					: null,
-			);
-			setRenameError(null);
-		},
-		[],
-	);
-	const createFile = useCallback(
-		async (folderId: string | null) => {
-			if (!onCreateFile) return;
-			setOpenActionsPath(null);
-			if (folderId) expandFolder(folderId);
-			const path = await onCreateFile(folderId);
-			if (!path) return;
-			beginRename(
-				{ kind: "file", path },
-				fileNameFromPath(getDisplayPath(path)),
-				{
-					deleteOnUnchangedCancel: true,
-				},
-			);
-		},
-		[beginRename, expandFolder, getDisplayPath, onCreateFile],
-	);
-	const createHtmlFile = useCallback(
-		async (folderId: string | null) => {
-			if (!onCreateHtmlFile) return;
-			setOpenActionsPath(null);
-			if (folderId) expandFolder(folderId);
-			const path = await onCreateHtmlFile(folderId);
-			if (!path) return;
-			beginRename(
-				{ kind: "file", path },
-				fileNameFromPath(getDisplayPath(path)),
-				{
-					deleteOnUnchangedCancel: true,
-				},
-			);
-		},
-		[beginRename, expandFolder, getDisplayPath, onCreateHtmlFile],
-	);
-	const createFolder = useCallback(
-		async (folderId: string | null) => {
-			if (!onCreateFolder) return;
-			setOpenActionsPath(null);
-			if (folderId) expandFolder(folderId);
-			const path = await onCreateFolder(folderId);
-			if (!path) return;
-			const displayPath = normalizeDisplayPath(getDisplayPath(path));
-			const id = displayPath.endsWith("/") ? displayPath : `${displayPath}/`;
+	const beginRename = (
+		item: RenameItem,
+		label: string,
+		options?: { deleteOnUnchangedCancel?: boolean },
+	) => {
+		const name = splitFileName(label).name;
+		setOpenActionsPath(null);
+		setRenamingItem(item);
+		setRenameDraft(name);
+		setDeleteOnCancel(
+			options?.deleteOnUnchangedCancel
+				? { kind: item.kind, path: item.path, draft: name }
+				: null,
+		);
+		setRenameError(null);
+	};
+	const createFile = async (folderId: string | null) => {
+		if (!onCreateFile) return;
+		setOpenActionsPath(null);
+		if (folderId) expandFolder(folderId);
+		const path = await onCreateFile(folderId);
+		if (!path) return;
+		beginRename(
+			{ kind: "file", path },
+			fileNameFromPath(getDisplayPath(path)),
+			{
+				deleteOnUnchangedCancel: true,
+			},
+		);
+	};
+	const createHtmlFile = async (folderId: string | null) => {
+		if (!onCreateHtmlFile) return;
+		setOpenActionsPath(null);
+		if (folderId) expandFolder(folderId);
+		const path = await onCreateHtmlFile(folderId);
+		if (!path) return;
+		beginRename(
+			{ kind: "file", path },
+			fileNameFromPath(getDisplayPath(path)),
+			{
+				deleteOnUnchangedCancel: true,
+			},
+		);
+	};
+	const createFolder = async (folderId: string | null) => {
+		if (!onCreateFolder) return;
+		setOpenActionsPath(null);
+		if (folderId) expandFolder(folderId);
+		const path = await onCreateFolder(folderId);
+		if (!path) return;
+		const displayPath = normalizeDisplayPath(getDisplayPath(path));
+		const id = displayPath.endsWith("/") ? displayPath : `${displayPath}/`;
+		beginRename(
+			{
+				kind: "folder",
+				path: id,
+				displayPath,
+				parentDisplayPath: dirname(displayPath),
+			},
+			fileNameFromPath(displayPath),
+			{
+				deleteOnUnchangedCancel: true,
+			},
+		);
+	};
+	const activateRow = (row: SidebarRow) => {
+		if (row.kind === "file") onSelectFile(row.file.path);
+		else if (row.kind === "folder") toggleFolder(row.id);
+	};
+	const updateSelection = (row: SidebarRow, mode: SidebarSelectionMode) => {
+		const targetKey = sidebarRowKey(row);
+		setSelection((current) =>
+			applySidebarSelection({
+				anchorKey: current.anchorKey,
+				mode,
+				rows,
+				selectedKeys: current.selectedKeys,
+				targetKey,
+			}),
+		);
+	};
+	const replaceSelection = (row: SidebarRow) => {
+		const targetKey = sidebarRowKey(row);
+		setSelection((current) =>
+			applySidebarSelection({
+				anchorKey: current.anchorKey,
+				mode: "replace",
+				rows,
+				selectedKeys: current.selectedKeys,
+				targetKey,
+			}),
+		);
+	};
+	const handleRowClick = (
+		row: SidebarSelectableRow,
+		event: React.MouseEvent<HTMLButtonElement>,
+	) => {
+		const mode: SidebarSelectionMode = event.shiftKey
+			? "range"
+			: event.metaKey || event.ctrlKey
+				? "toggle"
+				: "replace";
+		updateSelection(row, mode);
+		if (mode !== "replace") {
+			event.preventDefault();
+			return;
+		}
+		if (row.kind === "file" && event.detail > 1) return;
+		activateRow(row);
+		requestAnimationFrame(() => navRef.current?.focus());
+	};
+	const enterRowEdit = (row: SidebarRow) => {
+		if (row.kind === "file" && onRenameFile)
+			beginRename({ kind: "file", path: row.file.path }, row.label);
+		else if (row.kind === "folder" && onRenameFolder)
 			beginRename(
 				{
 					kind: "folder",
-					path: id,
-					displayPath,
-					parentDisplayPath: dirname(displayPath),
+					path: row.id,
+					displayPath: folderDisplayPath(row),
+					parentDisplayPath: folderRenameParentDisplayPath(row),
 				},
-				fileNameFromPath(displayPath),
-				{
-					deleteOnUnchangedCancel: true,
-				},
+				row.label,
 			);
-		},
-		[beginRename, expandFolder, getDisplayPath, onCreateFolder],
-	);
-	const activateRow = useCallback(
-		(row: SidebarRow) => {
-			if (row.kind === "file") onSelectFile(row.file.path);
-			else if (row.kind === "folder") toggleFolder(row.id);
-		},
-		[onSelectFile, toggleFolder],
-	);
-	const updateSelection = useCallback(
-		(row: SidebarRow, mode: SidebarSelectionMode) => {
-			const targetKey = sidebarRowKey(row);
-			setSelection((current) =>
-				applySidebarSelection({
-					anchorKey: current.anchorKey,
-					mode,
-					rows,
-					selectedKeys: current.selectedKeys,
-					targetKey,
-				}),
-			);
-		},
-		[rows],
-	);
-	const replaceSelection = useCallback(
-		(row: SidebarRow) => {
-			const targetKey = sidebarRowKey(row);
-			setSelection((current) =>
-				applySidebarSelection({
-					anchorKey: current.anchorKey,
-					mode: "replace",
-					rows,
-					selectedKeys: current.selectedKeys,
-					targetKey,
-				}),
-			);
-		},
-		[rows],
-	);
-	const handleRowClick = useCallback(
-		(row: SidebarSelectableRow, event: React.MouseEvent<HTMLButtonElement>) => {
-			const mode: SidebarSelectionMode = event.shiftKey
-				? "range"
-				: event.metaKey || event.ctrlKey
-					? "toggle"
-					: "replace";
-			updateSelection(row, mode);
-			if (mode !== "replace") {
-				event.preventDefault();
-				return;
-			}
-			if (row.kind === "file" && event.detail > 1) return;
-			activateRow(row);
-			requestAnimationFrame(() => navRef.current?.focus());
-		},
-		[activateRow, updateSelection],
-	);
-	const enterRowEdit = useCallback(
-		(row: SidebarRow) => {
-			if (row.kind === "file" && onRenameFile)
-				beginRename({ kind: "file", path: row.file.path }, row.label);
-			else if (row.kind === "folder" && onRenameFolder)
-				beginRename(
-					{
-						kind: "folder",
-						path: row.id,
-						displayPath: folderDisplayPath(row),
-						parentDisplayPath: folderRenameParentDisplayPath(row),
-					},
-					row.label,
-				);
-			else if (row.kind === "section") return;
-			else activateRow(row);
-		},
-		[activateRow, beginRename, onRenameFile, onRenameFolder],
-	);
-	const expandRow = useCallback(
-		(row: SidebarRow) => {
-			if (row.kind === "folder") expandFolder(row.id);
-		},
-		[expandFolder],
-	);
-	const collapseRow = useCallback(
-		(row: SidebarRow) => {
-			if (row.kind === "folder") collapseFolder(row.id);
-		},
-		[collapseFolder],
-	);
+		else if (row.kind === "section") return;
+		else activateRow(row);
+	};
+	const expandRow = (row: SidebarRow) => {
+		if (row.kind === "folder") expandFolder(row.id);
+	};
+	const collapseRow = (row: SidebarRow) => {
+		if (row.kind === "folder") collapseFolder(row.id);
+	};
 	const activeIndex = rows.findIndex(
 		(row) => row.kind === "file" && row.file.path === highlightPath,
 	);
@@ -626,61 +599,48 @@ export function Sidebar({
 		navRef,
 		activeIndex,
 	});
-	const handleDeleteSelection = useCallback(
-		(targetSelection: SidebarActionSelection) => {
-			const actionable = sidebarDeleteSelection(
-				targetSelection,
-				getDisplayPath,
-				Boolean(onDeleteFile),
-				Boolean(onDeleteFolder),
-			);
-			if (actionable.count === 0) return;
-			if (
-				!window.confirm(
-					`Delete ${actionable.count} ${actionable.count === 1 ? "item" : "items"}?`,
-				)
+	const handleDeleteSelection = (targetSelection: SidebarActionSelection) => {
+		const actionable = sidebarDeleteSelection(
+			targetSelection,
+			getDisplayPath,
+			Boolean(onDeleteFile),
+			Boolean(onDeleteFolder),
+		);
+		if (actionable.count === 0) return;
+		if (
+			!window.confirm(
+				`Delete ${actionable.count} ${actionable.count === 1 ? "item" : "items"}?`,
 			)
+		)
+			return;
+		for (const file of actionable.files) onDeleteFile?.(file.path);
+		for (const folderId of actionable.folders) onDeleteFolder?.(folderId);
+	};
+	const handleTreeKeyDown = (event: React.KeyboardEvent) => {
+		if (
+			!isEditableEventTarget(event.target) &&
+			keymatch(event.nativeEvent, "CmdOrCtrl+Backspace")
+		) {
+			const focusedRow = focusedIndex === null ? null : rows[focusedIndex];
+			const focusedKey = focusedRow ? sidebarRowKey(focusedRow) : null;
+			const activeKey = sidebarRowKey(rows[activeIndex]);
+			const keys = focusedKey
+				? selectedKeys.has(focusedKey)
+					? selectedKeys
+					: new Set([focusedKey])
+				: selectedKeys.size > 0
+					? selectedKeys
+					: activeKey
+						? new Set([activeKey])
+						: selectedKeys;
+			if (keys.size > 0) {
+				event.preventDefault();
+				handleDeleteSelection(sidebarActionSelection(rows, keys));
 				return;
-			for (const file of actionable.files) onDeleteFile?.(file.path);
-			for (const folderId of actionable.folders) onDeleteFolder?.(folderId);
-		},
-		[getDisplayPath, onDeleteFile, onDeleteFolder],
-	);
-	const handleTreeKeyDown = useCallback(
-		(event: React.KeyboardEvent) => {
-			if (
-				!isEditableEventTarget(event.target) &&
-				keymatch(event.nativeEvent, "CmdOrCtrl+Backspace")
-			) {
-				const focusedRow = focusedIndex === null ? null : rows[focusedIndex];
-				const focusedKey = focusedRow ? sidebarRowKey(focusedRow) : null;
-				const activeKey = sidebarRowKey(rows[activeIndex]);
-				const keys = focusedKey
-					? selectedKeys.has(focusedKey)
-						? selectedKeys
-						: new Set([focusedKey])
-					: selectedKeys.size > 0
-						? selectedKeys
-						: activeKey
-							? new Set([activeKey])
-							: selectedKeys;
-				if (keys.size > 0) {
-					event.preventDefault();
-					handleDeleteSelection(sidebarActionSelection(rows, keys));
-					return;
-				}
 			}
-			onKeyDown(event);
-		},
-		[
-			activeIndex,
-			focusedIndex,
-			handleDeleteSelection,
-			onKeyDown,
-			rows,
-			selectedKeys,
-		],
-	);
+		}
+		onKeyDown(event);
+	};
 	useEffect(() => {
 		const row = focusedIndex === null ? null : rows[focusedIndex];
 		if (!row || row.kind === "section") {
@@ -715,52 +675,46 @@ export function Sidebar({
 		setSelection((current) => snapSidebarSelection(current, highlightPath));
 	}, [highlightPath]);
 
-	const handleDragStart = useCallback(
-		(event: DragStartEvent) => {
-			const data = event.active.data.current as DragItemData | undefined;
-			setActiveDragLabel(data?.label ?? null);
-			setActiveDragKeys(
-				data
-					? new Set(selectedKeys.has(data.key) ? selectedKeys : [data.key])
-					: new Set(),
-			);
-		},
-		[selectedKeys],
-	);
-	const handleDragEnd = useCallback(
-		(event: DragEndEvent) => {
-			setActiveDragLabel(null);
-			setActiveDragKeys(new Set());
-			setDropTarget(null);
-			if (!onMoveItem || !event.over) return;
-			const item = event.active.data.current as DragItemData | undefined;
-			const target = event.over.data.current as DropTargetData | undefined;
-			if (!item || !target) return;
-			const targetFolderId = target.folderId;
-			const items = sidebarMoveItemsForDrag({
-				draggedItem: item,
-				getDisplayPath,
-				rows,
-				selectedKeys,
-				targetFolderId,
-			});
-			if (items.length === 0) return;
-			void onMoveItem({
-				items,
-				targetFolderId,
-			});
-			setSelection({ selectedKeys: new Set(), anchorKey: null });
-		},
-		[getDisplayPath, onMoveItem, rows, selectedKeys],
-	);
-	const handleDragOver = useCallback((event: DragOverEvent) => {
+	const handleDragStart = (event: DragStartEvent) => {
+		const data = event.active.data.current as DragItemData | undefined;
+		setActiveDragLabel(data?.label ?? null);
+		setActiveDragKeys(
+			data
+				? new Set(selectedKeys.has(data.key) ? selectedKeys : [data.key])
+				: new Set(),
+		);
+	};
+	const handleDragEnd = (event: DragEndEvent) => {
+		setActiveDragLabel(null);
+		setActiveDragKeys(new Set());
+		setDropTarget(null);
+		if (!onMoveItem || !event.over) return;
+		const item = event.active.data.current as DragItemData | undefined;
+		const target = event.over.data.current as DropTargetData | undefined;
+		if (!item || !target) return;
+		const targetFolderId = target.folderId;
+		const items = sidebarMoveItemsForDrag({
+			draggedItem: item,
+			getDisplayPath,
+			rows,
+			selectedKeys,
+			targetFolderId,
+		});
+		if (items.length === 0) return;
+		void onMoveItem({
+			items,
+			targetFolderId,
+		});
+		setSelection({ selectedKeys: new Set(), anchorKey: null });
+	};
+	const handleDragOver = (event: DragOverEvent) => {
 		const target = event.over?.data.current as DropTargetData | undefined;
 		setDropTarget(
 			event.over
 				? { id: String(event.over.id), folderId: target?.folderId ?? null }
 				: null,
 		);
-	}, []);
+	};
 
 	useEffect(() => {
 		if (!activeDragLabel || !dropTarget?.folderId) return;
@@ -809,14 +763,14 @@ export function Sidebar({
 		};
 	}, []);
 
-	const resetRename = useCallback(() => {
+	const resetRename = () => {
 		setRenamingItem(null);
 		setRenameDraft("");
 		setDeleteOnCancel(null);
 		setRenameError(null);
-	}, []);
+	};
 
-	const cancelRename = useCallback(() => {
+	const cancelRename = () => {
 		const shouldDelete =
 			deleteOnCancel &&
 			renamingItem &&
@@ -830,69 +784,48 @@ export function Sidebar({
 				onDeleteFolder(deleteOnCancel.path);
 		}
 		resetRename();
-	}, [
-		deleteOnCancel,
-		onDeleteFile,
-		onDeleteFolder,
-		renameDraft,
-		renamingItem,
-		resetRename,
-	]);
+	};
 
-	const getRenameError = useCallback(
-		(item: RenameItem, draft: string) => {
-			const nextName = draft.trim();
-			if (!nextName) return null;
-			const targetName = renameTargetName(item, nextName, getDisplayPath);
-			if (!renameTargetExists(item, nextName, files, folders, getDisplayPath)) {
-				return null;
-			}
-			return `A ${item.kind} ${targetName} already exists at this location.`;
-		},
-		[files, folders, getDisplayPath],
-	);
+	const getRenameError = (item: RenameItem, draft: string) => {
+		const nextName = draft.trim();
+		if (!nextName) return null;
+		const targetName = renameTargetName(item, nextName, getDisplayPath);
+		if (!renameTargetExists(item, nextName, files, folders, getDisplayPath)) {
+			return null;
+		}
+		return `A ${item.kind} ${targetName} already exists at this location.`;
+	};
 
-	const commitRename = useCallback(
-		(focusTree = false) => {
-			const item = renamingItem;
-			if (!item) return;
-			const nextName = renameDraft.trim();
-			if (!nextName) {
-				resetRename();
-				if (focusTree) requestAnimationFrame(() => navRef.current?.focus());
-				return;
-			}
-			const error = getRenameError(item, nextName);
-			if (error) {
-				setRenameError(error);
-				requestAnimationFrame(() => renameInputRef.current?.focus());
-				return;
-			}
-			if (focusTree) {
-				setPendingFocusDisplayPath(
-					renameTargetDisplayPath(item, nextName, getDisplayPath),
-				);
-				requestAnimationFrame(() => navRef.current?.focus());
-			}
+	const commitRename = (focusTree = false) => {
+		const item = renamingItem;
+		if (!item) return;
+		const nextName = renameDraft.trim();
+		if (!nextName) {
 			resetRename();
-			if (item.kind === "file") onRenameFile?.(item.path, nextName);
-			else
-				onRenameFolder?.(
-					item.path,
-					nextName,
-					renameTargetDisplayPath(item, nextName, getDisplayPath),
-				);
-		},
-		[
-			getRenameError,
-			onRenameFile,
-			onRenameFolder,
-			renameDraft,
-			renamingItem,
-			resetRename,
-			getDisplayPath,
-		],
-	);
+			if (focusTree) requestAnimationFrame(() => navRef.current?.focus());
+			return;
+		}
+		const error = getRenameError(item, nextName);
+		if (error) {
+			setRenameError(error);
+			requestAnimationFrame(() => renameInputRef.current?.focus());
+			return;
+		}
+		if (focusTree) {
+			setPendingFocusDisplayPath(
+				renameTargetDisplayPath(item, nextName, getDisplayPath),
+			);
+			requestAnimationFrame(() => navRef.current?.focus());
+		}
+		resetRename();
+		if (item.kind === "file") onRenameFile?.(item.path, nextName);
+		else
+			onRenameFolder?.(
+				item.path,
+				nextName,
+				renameTargetDisplayPath(item, nextName, getDisplayPath),
+			);
+	};
 
 	const tree = (
 		<DndContext
@@ -1390,14 +1323,11 @@ const DroppableSidebarNav = forwardRef<
 		data: { folderId: null } satisfies DropTargetData,
 		disabled: !enabled,
 	});
-	const setRefs = useCallback(
-		(node: HTMLDivElement | null) => {
-			setNodeRef(node);
-			if (typeof ref === "function") ref(node);
-			else if (ref) ref.current = node;
-		},
-		[ref, setNodeRef],
-	);
+	const setRefs = (node: HTMLDivElement | null) => {
+		setNodeRef(node);
+		if (typeof ref === "function") ref(node);
+		else if (ref) ref.current = node;
+	};
 	return (
 		<div
 			ref={setRefs}
@@ -1515,13 +1445,10 @@ function FolderSegment({
 		data: { folderId: segment.id } satisfies DropTargetData,
 		disabled: !enabled,
 	});
-	const setRefs = useCallback(
-		(node: HTMLSpanElement | null) => {
-			setDragRef(node);
-			setNodeRef(node);
-		},
-		[setDragRef, setNodeRef],
-	);
+	const setRefs = (node: HTMLSpanElement | null) => {
+		setDragRef(node);
+		setNodeRef(node);
+	};
 	return (
 		<>
 			{separator ? <span className="text-muted-foreground">/</span> : null}

--- a/packages/ui/src/components/useSidebarKeyboardNav.ts
+++ b/packages/ui/src/components/useSidebarKeyboardNav.ts
@@ -1,4 +1,4 @@
-import { type RefObject, useCallback, useEffect, useState } from "react";
+import { type RefObject, useEffect, useState } from "react";
 import { isEditableEventTarget } from "../lib/dom";
 
 export const EDITOR_INPUT_SELECTOR = "[data-editor-input]";
@@ -21,10 +21,8 @@ export function useSidebarKeyboardNav<T>({
 	activeIndex?: number;
 }) {
 	const [focusedIndex, setFocusedIndex] = useState<number | null>(null);
-	const getActionIndex = useCallback(
-		() => focusedIndex ?? (activeIndex >= 0 ? activeIndex : null),
-		[activeIndex, focusedIndex],
-	);
+	const getActionIndex = () =>
+		focusedIndex ?? (activeIndex >= 0 ? activeIndex : null);
 
 	useEffect(() => {
 		if (focusedIndex === null) return;
@@ -33,72 +31,61 @@ export function useSidebarKeyboardNav<T>({
 			?.scrollIntoView({ block: "nearest" });
 	}, [focusedIndex, navRef]);
 
-	const onKeyDown = useCallback(
-		(event: React.KeyboardEvent) => {
-			if (items.length === 0) return;
-			if (isEditableEventTarget(event.target)) return;
+	const onKeyDown = (event: React.KeyboardEvent) => {
+		if (items.length === 0) return;
+		if (isEditableEventTarget(event.target)) return;
 
-			switch (event.key) {
-				case "ArrowDown":
-				case "ArrowUp": {
-					event.preventDefault();
-					const delta = event.key === "ArrowDown" ? 1 : -1;
-					setFocusedIndex((prev) => {
-						const start = prev ?? (activeIndex >= 0 ? activeIndex : -1);
-						return Math.max(0, Math.min(start + delta, items.length - 1));
-					});
-					break;
-				}
-				case "Enter": {
-					const idx = getActionIndex();
-					if (idx !== null && items[idx]) {
-						event.preventDefault();
-						(onEnter ?? onSelect)(items[idx]);
-					}
-					break;
-				}
-				case " ": {
-					const idx = getActionIndex();
-					if (idx !== null && items[idx]) {
-						event.preventDefault();
-						onSelect(items[idx]);
-					}
-					break;
-				}
-				case "ArrowRight": {
-					const idx = getActionIndex();
-					if (idx !== null && items[idx] && onExpand) {
-						event.preventDefault();
-						onExpand(items[idx]);
-					}
-					break;
-				}
-				case "ArrowLeft": {
-					const idx = getActionIndex();
-					if (idx !== null && items[idx] && onCollapse) {
-						event.preventDefault();
-						onCollapse(items[idx]);
-					}
-					break;
-				}
-				case "Escape": {
-					event.preventDefault();
-					setFocusedIndex(null);
-					document.querySelector<HTMLElement>(EDITOR_INPUT_SELECTOR)?.focus();
-					break;
-				}
+		switch (event.key) {
+			case "ArrowDown":
+			case "ArrowUp": {
+				event.preventDefault();
+				const delta = event.key === "ArrowDown" ? 1 : -1;
+				setFocusedIndex((prev) => {
+					const start = prev ?? (activeIndex >= 0 ? activeIndex : -1);
+					return Math.max(0, Math.min(start + delta, items.length - 1));
+				});
+				break;
 			}
-		},
-		[
-			items,
-			onEnter,
-			onSelect,
-			onExpand,
-			onCollapse,
-			activeIndex,
-			getActionIndex,
-		],
-	);
+			case "Enter": {
+				const idx = getActionIndex();
+				if (idx !== null && items[idx]) {
+					event.preventDefault();
+					(onEnter ?? onSelect)(items[idx]);
+				}
+				break;
+			}
+			case " ": {
+				const idx = getActionIndex();
+				if (idx !== null && items[idx]) {
+					event.preventDefault();
+					onSelect(items[idx]);
+				}
+				break;
+			}
+			case "ArrowRight": {
+				const idx = getActionIndex();
+				if (idx !== null && items[idx] && onExpand) {
+					event.preventDefault();
+					onExpand(items[idx]);
+				}
+				break;
+			}
+			case "ArrowLeft": {
+				const idx = getActionIndex();
+				if (idx !== null && items[idx] && onCollapse) {
+					event.preventDefault();
+					onCollapse(items[idx]);
+				}
+				break;
+			}
+			case "Escape": {
+				event.preventDefault();
+				setFocusedIndex(null);
+				document.querySelector<HTMLElement>(EDITOR_INPUT_SELECTOR)?.focus();
+				break;
+			}
+		}
+	};
 
 	return { focusedIndex, setFocusedIndex, onKeyDown };
 }

--- a/packages/ui/src/components/useSidebarTree.test.ts
+++ b/packages/ui/src/components/useSidebarTree.test.ts
@@ -1,5 +1,41 @@
-import { describe, expect, it } from "vitest";
-import { buildFileTree, flattenRows } from "./useSidebarTree";
+// @vitest-environment happy-dom
+
+import { act, createElement, type ReactNode } from "react";
+// @ts-expect-error This package does not ship @types/react-dom; the test only
+// needs createRoot's render/unmount surface.
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	buildFileTree,
+	flattenRows,
+	type SidebarFile,
+	type SidebarRow,
+	useSidebarTree,
+} from "./useSidebarTree";
+
+type Root = {
+	render(children: ReactNode): void;
+	unmount(): void;
+};
+
+type TreeProps = Parameters<typeof useSidebarTree>[0];
+type TreeResult = ReturnType<typeof useSidebarTree>;
+
+const roots: Root[] = [];
+const getDisplayPath = (path: string) => path.replace("/workspace/", "");
+
+(
+	globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+afterEach(() => {
+	act(() => {
+		for (const root of roots) root.unmount();
+	});
+	roots.length = 0;
+	localStorage.clear();
+	document.body.replaceChildren();
+});
 
 function folderNames(node: ReturnType<typeof buildFileTree>) {
 	return [...node.folders.values()].map((folder) => folder.name);
@@ -88,3 +124,95 @@ describe("flattenRows", () => {
 		expect(rows.map((row) => row.label)).toEqual(["empty/new-folder"]);
 	});
 });
+
+describe("useSidebarTree", () => {
+	it("keeps selected-file ancestors collapsed across unrelated rerenders", () => {
+		const harness = renderTree({
+			files: nestedFiles,
+			highlightPath: "/workspace/alpha/beta/one.md",
+		});
+
+		expect(filePaths(harness.current.rows)).toContain(
+			"/workspace/alpha/beta/one.md",
+		);
+
+		act(() => harness.current.collapseFolder("alpha/beta/"));
+		expect(filePaths(harness.current.rows)).not.toContain(
+			"/workspace/alpha/beta/one.md",
+		);
+
+		harness.rerender({ files: [...nestedFiles] });
+
+		expect(filePaths(harness.current.rows)).not.toContain(
+			"/workspace/alpha/beta/one.md",
+		);
+		expect(folderRow(harness.current.rows, "alpha/beta/").expanded).toBe(false);
+	});
+
+	it("auto-expands the ancestor chain when highlightPath changes", () => {
+		const harness = renderTree({
+			files: nestedFiles,
+			highlightPath: "/workspace/alpha/beta/one.md",
+		});
+
+		harness.rerender({
+			highlightPath: "/workspace/gamma/delta/two.md",
+		});
+
+		expect(filePaths(harness.current.rows)).toContain(
+			"/workspace/gamma/delta/two.md",
+		);
+		expect(folderRow(harness.current.rows, "gamma/delta/").expanded).toBe(true);
+	});
+});
+
+const nestedFiles: SidebarFile[] = [
+	{ path: "/workspace/alpha/beta/one.md", modifiedAt: 1 },
+	{ path: "/workspace/gamma/delta/two.md", modifiedAt: 2 },
+];
+
+function renderTree(overrides: Partial<TreeProps>) {
+	let props: TreeProps = {
+		files: [],
+		getDisplayPath,
+		highlightPath: null,
+		sortMode: "alpha",
+		...overrides,
+	};
+	let current: TreeResult | null = null;
+	const rootElement = document.createElement("div");
+	document.body.append(rootElement);
+	const root = createRoot(rootElement);
+	roots.push(root);
+
+	function Harness() {
+		current = useSidebarTree(props);
+		return null;
+	}
+
+	const render = () => {
+		act(() => root.render(createElement(Harness)));
+	};
+	render();
+
+	return {
+		get current(): TreeResult {
+			if (!current) throw new Error("Hook did not render");
+			return current;
+		},
+		rerender(next: Partial<TreeProps>) {
+			props = { ...props, ...next };
+			render();
+		},
+	};
+}
+
+function filePaths(rows: SidebarRow[]) {
+	return rows.flatMap((row) => (row.kind === "file" ? [row.file.path] : []));
+}
+
+function folderRow(rows: SidebarRow[], id: string) {
+	const row = rows.find((row) => row.kind === "folder" && row.id === id);
+	if (!row || row.kind !== "folder") throw new Error(`Missing folder ${id}`);
+	return row;
+}

--- a/packages/ui/src/components/useSidebarTree.ts
+++ b/packages/ui/src/components/useSidebarTree.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { z } from "zod/v4";
 import { fileNameFromPath, normalizeDisplayPath } from "../lib/filePath";
 
@@ -99,29 +99,18 @@ export function useSidebarTree({
 		writeExpandedFolders(storageKey, expandedState.folders);
 	}, [storageKey, expandedState]);
 
-	const tree = useMemo(
-		() => buildFileTree(files, folders, getDisplayPath),
-		[files, folders, getDisplayPath],
-	);
-	const activeAncestorIds = useMemo(
-		() =>
-			highlightPath
-				? getFolderAncestorIds(getDisplayPath(highlightPath))
-				: new Set<string>(),
-		[highlightPath, getDisplayPath],
-	);
-	const rows = useMemo(
-		() =>
-			flattenRows({
-				files,
-				getDisplayPath,
-				tree,
-				sortMode,
-				expandedFolders,
-				uncompactFolderId,
-			}),
-		[expandedFolders, files, getDisplayPath, sortMode, tree, uncompactFolderId],
-	);
+	const tree = buildFileTree(files, folders, getDisplayPath);
+	const activeAncestorIds = highlightPath
+		? getFolderAncestorIds(getDisplayPath(highlightPath))
+		: new Set<string>();
+	const rows = flattenRows({
+		files,
+		getDisplayPath,
+		tree,
+		sortMode,
+		expandedFolders,
+		uncompactFolderId,
+	});
 
 	useEffect(() => {
 		if (!highlightPath || revealedPathRef.current === highlightPath) return;
@@ -144,33 +133,22 @@ export function useSidebarTree({
 		});
 	}, [activeAncestorIds, highlightPath, storageKey]);
 
-	const setExpanded = useCallback(
-		(id: string, expanded: boolean) => {
-			setExpandedState((current) => {
-				const next = new Set(
-					current.key === storageKey
-						? current.folders
-						: readExpandedFolders(storageKey),
-				);
-				if (expanded) next.add(id);
-				else next.delete(id);
-				return { key: storageKey, folders: next };
-			});
-		},
-		[storageKey],
-	);
-	const expandFolder = useCallback(
-		(id: string) => setExpanded(id, true),
-		[setExpanded],
-	);
-	const collapseFolder = useCallback(
-		(id: string) => setExpanded(id, false),
-		[setExpanded],
-	);
-	const toggleFolder = useCallback(
-		(id: string) => setExpanded(id, !expandedFolders.has(id)),
-		[expandedFolders, setExpanded],
-	);
+	const setExpanded = (id: string, expanded: boolean) => {
+		setExpandedState((current) => {
+			const next = new Set(
+				current.key === storageKey
+					? current.folders
+					: readExpandedFolders(storageKey),
+			);
+			if (expanded) next.add(id);
+			else next.delete(id);
+			return { key: storageKey, folders: next };
+		});
+	};
+	const expandFolder = (id: string) => setExpanded(id, true);
+	const collapseFolder = (id: string) => setExpanded(id, false);
+	const toggleFolder = (id: string) =>
+		setExpanded(id, !expandedFolders.has(id));
 
 	return { collapseFolder, expandFolder, rows, toggleFolder };
 }

--- a/packages/ui/src/components/useSidebarTree.ts
+++ b/packages/ui/src/components/useSidebarTree.ts
@@ -100,9 +100,6 @@ export function useSidebarTree({
 	}, [storageKey, expandedState]);
 
 	const tree = buildFileTree(files, folders, getDisplayPath);
-	const activeAncestorIds = highlightPath
-		? getFolderAncestorIds(getDisplayPath(highlightPath))
-		: new Set<string>();
 	const rows = flattenRows({
 		files,
 		getDisplayPath,
@@ -115,6 +112,9 @@ export function useSidebarTree({
 	useEffect(() => {
 		if (!highlightPath || revealedPathRef.current === highlightPath) return;
 		revealedPathRef.current = highlightPath;
+		const activeAncestorIds = getFolderAncestorIds(
+			getDisplayPath(highlightPath),
+		);
 		if (activeAncestorIds.size === 0) return;
 		// Auto-expand ancestors once per selected file so manual collapse still works.
 		setExpandedState((current) => {
@@ -131,7 +131,7 @@ export function useSidebarTree({
 			}
 			return changed ? { key: storageKey, folders: next } : current;
 		});
-	}, [activeAncestorIds, highlightPath, storageKey]);
+	}, [getDisplayPath, highlightPath, storageKey]);
 
 	const setExpanded = (id: string, expanded: boolean) => {
 		setExpandedState((current) => {

--- a/packages/ui/src/editor/EditorPathAttribution.test.tsx
+++ b/packages/ui/src/editor/EditorPathAttribution.test.tsx
@@ -1,0 +1,202 @@
+// @vitest-environment happy-dom
+
+import { Editor } from "@tiptap/core";
+import { act, type ReactNode, useLayoutEffect } from "react";
+// @ts-expect-error This package does not ship @types/react-dom; the test only
+// needs createRoot's render/unmount surface.
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EditorView } from "./EditorView";
+import { MarkdownSourceEditor } from "./MarkdownSourceEditor";
+
+type Root = {
+	render(children: ReactNode): void;
+	unmount(): void;
+};
+
+const roots: Root[] = [];
+const LONG_SAVE_DEBOUNCE_MS = 60_000;
+
+(
+	globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+afterEach(() => {
+	act(() => {
+		for (const root of roots) root.unmount();
+	});
+	roots.length = 0;
+	document.body.replaceChildren();
+	vi.restoreAllMocks();
+});
+
+describe("editor path attribution", () => {
+	it("attributes a rich editor change and save to the new path", async () => {
+		const onLocalChange = vi.fn();
+		const onSave = vi.fn();
+		const root = createTestRoot();
+		const getEditor = captureEditorCreation();
+
+		await renderRichEditor(
+			root,
+			"/old.md",
+			"old",
+			onLocalChange,
+			onSave,
+			getEditor,
+		);
+		act(() => changeEditorText(getEditor(), "old edited"));
+		onLocalChange.mockClear();
+		onSave.mockClear();
+		await renderRichEditor(
+			root,
+			"/new.md",
+			"new",
+			onLocalChange,
+			onSave,
+			getEditor,
+			"edited",
+		);
+
+		expect(onLocalChange).toHaveBeenCalledTimes(1);
+		expect(onLocalChange).toHaveBeenCalledWith("/new.md", "edited");
+		expect(onSave).toHaveBeenCalledTimes(2);
+		expect(onSave).toHaveBeenNthCalledWith(1, "/old.md", "old edited");
+		expect(onSave).toHaveBeenNthCalledWith(2, "/new.md", "edited");
+	});
+
+	it("attributes a source editor change and save to the new path", async () => {
+		const onLocalChange = vi.fn();
+		const onSave = vi.fn();
+		const root = createTestRoot();
+		const getEditor = captureEditorCreation();
+
+		await renderSourceEditor(
+			root,
+			"/old.md",
+			"old",
+			onLocalChange,
+			onSave,
+			getEditor,
+		);
+		act(() => changeEditorText(getEditor(), "old edited"));
+		onLocalChange.mockClear();
+		onSave.mockClear();
+		await renderSourceEditor(
+			root,
+			"/new.md",
+			"new",
+			onLocalChange,
+			onSave,
+			getEditor,
+			"edited",
+		);
+
+		expect(onLocalChange).toHaveBeenCalledTimes(1);
+		expect(onLocalChange).toHaveBeenCalledWith("/new.md", "edited");
+		expect(onSave).toHaveBeenCalledTimes(2);
+		expect(onSave).toHaveBeenNthCalledWith(1, "/old.md", "old edited");
+		expect(onSave).toHaveBeenNthCalledWith(2, "/new.md", "edited");
+	});
+});
+
+function createTestRoot() {
+	const container = document.createElement("div");
+	document.body.append(container);
+	const root = createRoot(container);
+	roots.push(root);
+	return root;
+}
+
+async function renderRichEditor(
+	root: Root,
+	path: string,
+	initialMarkdown: string,
+	onLocalChange: ReturnType<typeof vi.fn>,
+	onSave: ReturnType<typeof vi.fn>,
+	getEditor: () => Editor,
+	editText: string | null = null,
+) {
+	await act(async () => {
+		root.render(
+			<EditAfterChildLayout editText={editText} getEditor={getEditor}>
+				<EditorView
+					path={path}
+					initialMarkdown={initialMarkdown}
+					editable={false}
+					saveDebounceMs={LONG_SAVE_DEBOUNCE_MS}
+					onLocalChange={onLocalChange}
+					onSave={onSave}
+					onOpenExternalLink={() => {}}
+					onOpenWikiLink={() => {}}
+				/>
+			</EditAfterChildLayout>,
+		);
+	});
+}
+
+async function renderSourceEditor(
+	root: Root,
+	path: string,
+	initialMarkdown: string,
+	onLocalChange: ReturnType<typeof vi.fn>,
+	onSave: ReturnType<typeof vi.fn>,
+	getEditor: () => Editor,
+	editText: string | null = null,
+) {
+	await act(async () => {
+		root.render(
+			<EditAfterChildLayout editText={editText} getEditor={getEditor}>
+				<MarkdownSourceEditor
+					path={path}
+					initialMarkdown={initialMarkdown}
+					saveDebounceMs={LONG_SAVE_DEBOUNCE_MS}
+					onLocalChange={onLocalChange}
+					onSave={onSave}
+				/>
+			</EditAfterChildLayout>,
+		);
+	});
+}
+
+function EditAfterChildLayout({
+	children,
+	editText,
+	getEditor,
+}: {
+	children: ReactNode;
+	editText: string | null;
+	getEditor: () => Editor;
+}) {
+	useLayoutEffect(() => {
+		if (editText === null) return;
+		changeEditorText(getEditor(), editText);
+	}, [editText, getEditor]);
+	return children;
+}
+
+function captureEditorCreation() {
+	let editor: Editor | null = null;
+	type EditorPrototypeWithCreateView = {
+		createView(this: Editor, element: HTMLElement): void;
+	};
+	const prototype =
+		Editor.prototype as unknown as EditorPrototypeWithCreateView;
+	const createView = prototype.createView;
+	vi.spyOn(prototype, "createView").mockImplementation(function (
+		this: Editor,
+		element,
+	) {
+		editor = this;
+		createView.call(this, element);
+	});
+	return () => {
+		expect(editor).toBeInstanceOf(Editor);
+		return editor as Editor;
+	};
+}
+
+function changeEditorText(editor: Editor, text: string) {
+	editor.commands.selectAll();
+	editor.commands.insertContent(text);
+}

--- a/packages/ui/src/editor/EditorView.tsx
+++ b/packages/ui/src/editor/EditorView.tsx
@@ -26,7 +26,7 @@ import {
 	useEditor,
 } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { CODE_BLOCK_COPY_EVENT, HubbleCodeBlock } from "./CodeBlockExtension";
 import { copySelectionAsMarkdown } from "./copyAsMarkdown";
 import { LinkClickExtension } from "./LinkClickExtension";
@@ -93,20 +93,15 @@ export function EditorView({
 	onOpenWikiLink,
 	onMessage,
 }: EditorViewProps) {
-	const initialFrontMatter = useMemo(
-		() => parseMarkdownFrontMatter(initialMarkdown),
-		[initialMarkdown],
-	);
+	const initialFrontMatter = parseMarkdownFrontMatter(initialMarkdown);
+	const initialFrontMatterRaw =
+		initialFrontMatter.type === "none" ? "" : initialFrontMatter.raw;
 	const partsRef = useRef({
 		body: initialFrontMatter.body,
-		frontMatter:
-			initialFrontMatter.type === "none" ? "" : initialFrontMatter.raw,
+		frontMatter: initialFrontMatterRaw,
 	});
 	const latestMarkdownRef = useRef(
-		combineMarkdownFrontMatter(
-			partsRef.current.frontMatter,
-			partsRef.current.body,
-		),
+		combineMarkdownFrontMatter(initialFrontMatterRaw, initialFrontMatter.body),
 	);
 	const saveTimerRef = useRef<number | null>(null);
 	const editorRootRef = useRef<HTMLDivElement | null>(null);
@@ -121,25 +116,22 @@ export function EditorView({
 	);
 	const pathRef = useRef(path);
 	const editorRef = useRef<Editor | null>(null);
-	pathRef.current = path;
+	useLayoutEffect(() => {
+		pathRef.current = path;
+	}, [path]);
 
-	const setEditorViewport = useCallback(
-		(node: HTMLDivElement | null) => {
-			editorViewportRef.current = node;
-			setEditorViewportEl(node);
-			onScrollContainerChange?.(node);
-		},
-		[onScrollContainerChange],
-	);
+	const setEditorViewport = (node: HTMLDivElement | null) => {
+		editorViewportRef.current = node;
+		setEditorViewportEl(node);
+		onScrollContainerChange?.(node);
+	};
 
 	// Only used at editor creation. Later file loads sync through setContent.
-	// biome-ignore lint/correctness/useExhaustiveDependencies: editor instance persists across file switches.
-	const initialDoc = useMemo(
-		() => markdownToTiptapDoc(initialFrontMatter.body),
-		[],
+	const [initialDoc] = useState(() =>
+		markdownToTiptapDoc(initialFrontMatter.body),
 	);
 
-	const scheduleSave = useCallback(() => {
+	const scheduleSave = () => {
 		const savePath = pathRef.current;
 		if (saveTimerRef.current !== null) {
 			window.clearTimeout(saveTimerRef.current);
@@ -148,7 +140,7 @@ export function EditorView({
 			saveTimerRef.current = null;
 			void onSave(savePath, latestMarkdownRef.current);
 		}, saveDebounceMs);
-	}, [onSave, saveDebounceMs]);
+	};
 
 	const editor = useEditor({
 		editable,
@@ -213,7 +205,9 @@ export function EditorView({
 			},
 		},
 	});
-	editorRef.current = editor;
+	useLayoutEffect(() => {
+		editorRef.current = editor;
+	}, [editor]);
 
 	useEffect(() => {
 		if (!editor || !editorViewportEl) return;

--- a/packages/ui/src/editor/EditorView.tsx
+++ b/packages/ui/src/editor/EditorView.tsx
@@ -32,6 +32,11 @@ import { copySelectionAsMarkdown } from "./copyAsMarkdown";
 import { LinkClickExtension } from "./LinkClickExtension";
 import { LinkCreationGhostExtension } from "./LinkCreationGhostExtension";
 import { LinkPopover, type WikiTarget } from "./LinkPopover";
+import {
+	flushPendingSave,
+	type PendingSave,
+	schedulePendingSave,
+} from "./pendingSave";
 import { SlashCommandMenu } from "./SlashCommandMenu";
 import { SmartLinkExtension } from "./SmartLinkExtension";
 import { TableCellSelectionExtension } from "./TableCellSelectionExtension";
@@ -103,7 +108,7 @@ export function EditorView({
 	const latestMarkdownRef = useRef(
 		combineMarkdownFrontMatter(initialFrontMatterRaw, initialFrontMatter.body),
 	);
-	const saveTimerRef = useRef<number | null>(null);
+	const pendingSaveRef = useRef<PendingSave | null>(null);
 	const editorRootRef = useRef<HTMLDivElement | null>(null);
 	const editorViewportRef = useRef<HTMLDivElement | null>(null);
 	const lastCopyAsMarkdownRequestRef = useRef(copyAsMarkdownRequest);
@@ -132,14 +137,13 @@ export function EditorView({
 	);
 
 	const scheduleSave = () => {
-		const savePath = pathRef.current;
-		if (saveTimerRef.current !== null) {
-			window.clearTimeout(saveTimerRef.current);
-		}
-		saveTimerRef.current = window.setTimeout(() => {
-			saveTimerRef.current = null;
-			void onSave(savePath, latestMarkdownRef.current);
-		}, saveDebounceMs);
+		schedulePendingSave({
+			delay: saveDebounceMs,
+			markdown: latestMarkdownRef.current,
+			path: pathRef.current,
+			ref: pendingSaveRef,
+			save: onSave,
+		});
 	};
 
 	const editor = useEditor({
@@ -242,14 +246,12 @@ export function EditorView({
 	}, [editor, initialMarkdown]);
 
 	useEffect(() => {
+		// Path changes flush the pending edit before the next document takes over.
+		void path;
 		return () => {
-			if (saveTimerRef.current !== null) {
-				window.clearTimeout(saveTimerRef.current);
-				saveTimerRef.current = null;
-				void onSave(path, latestMarkdownRef.current);
-			}
+			flushPendingSave(pendingSaveRef);
 		};
-	}, [path, onSave]);
+	}, [path]);
 
 	useEffect(() => {
 		if (!onMessage) return;

--- a/packages/ui/src/editor/FindBar.tsx
+++ b/packages/ui/src/editor/FindBar.tsx
@@ -5,13 +5,7 @@ import {
 } from "@hubble.md/editor";
 import type { Editor } from "@tiptap/core";
 import { keymatch } from "keymatch";
-import {
-	type ReactNode,
-	useCallback,
-	useEffect,
-	useRef,
-	useState,
-} from "react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
 import MingcuteCloseLine from "~icons/mingcute/close-line";
 import MingcuteDownLine from "~icons/mingcute/down-line";
 import MingcuteSearchLine from "~icons/mingcute/search-line";
@@ -27,18 +21,18 @@ export function FindBar({ editor }: { editor: Editor | null }) {
 	});
 	const inputRef = useRef<HTMLInputElement | null>(null);
 
-	const syncFindState = useCallback(() => {
+	const syncFindState = () => {
 		if (!editor) return;
 		setFindState(getFindState(editor.state));
-	}, [editor]);
+	};
 
-	const close = useCallback(() => {
+	const close = () => {
 		setOpen(false);
 		editor?.commands.clearFindQuery();
 		editor?.commands.focus(undefined, { scrollIntoView: false });
-	}, [editor]);
+	};
 
-	const openFind = useCallback(() => {
+	const openFind = () => {
 		if (!editor) return;
 		const selectedText = editor.state.selection.empty
 			? ""
@@ -53,32 +47,40 @@ export function FindBar({ editor }: { editor: Editor | null }) {
 			inputRef.current?.focus();
 			inputRef.current?.select();
 		});
-	}, [editor]);
+	};
 
-	useEffect(() => {
-		if (!editor) return;
-		syncFindState();
-		editor.on("transaction", syncFindState);
-		return () => {
-			editor.off("transaction", syncFindState);
-		};
-	}, [editor, syncFindState]);
+	useEffect(
+		() => {
+			if (!editor) return;
+			syncFindState();
+			editor.on("transaction", syncFindState);
+			return () => {
+				editor.off("transaction", syncFindState);
+			};
+		},
+		// biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler stabilizes render-local callbacks.
+		[editor, syncFindState],
+	);
 
-	useEffect(() => {
-		const handleKeyDown = (event: KeyboardEvent) => {
-			if (open && event.key === "Escape") {
+	useEffect(
+		() => {
+			const handleKeyDown = (event: KeyboardEvent) => {
+				if (open && event.key === "Escape") {
+					event.preventDefault();
+					close();
+					return;
+				}
+				if (!keymatch(event, "CmdOrCtrl+f")) return;
+				if (!editor?.isFocused && !open) return;
 				event.preventDefault();
-				close();
-				return;
-			}
-			if (!keymatch(event, "CmdOrCtrl+f")) return;
-			if (!editor?.isFocused && !open) return;
-			event.preventDefault();
-			openFind();
-		};
-		window.addEventListener("keydown", handleKeyDown);
-		return () => window.removeEventListener("keydown", handleKeyDown);
-	}, [close, editor, open, openFind]);
+				openFind();
+			};
+			window.addEventListener("keydown", handleKeyDown);
+			return () => window.removeEventListener("keydown", handleKeyDown);
+		},
+		// biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler stabilizes render-local callbacks.
+		[close, editor, open, openFind],
+	);
 
 	if (!editor || !open) return null;
 

--- a/packages/ui/src/editor/FormatCommandMenu.tsx
+++ b/packages/ui/src/editor/FormatCommandMenu.tsx
@@ -4,7 +4,6 @@ import { keymatch } from "keymatch";
 import {
 	type ComponentType,
 	type RefObject,
-	useCallback,
 	useEffect,
 	useRef,
 	useState,
@@ -188,15 +187,15 @@ export function FormatCommandMenu({
 	)
 		? selectedKind
 		: visibleCommands[0]?.kind;
-	const closeMenu = useCallback(() => {
+	const closeMenu = () => {
 		setOpen(false);
 		setQuery("");
 		setPosition(null);
 		// Drop the frozen highlight and restore the real selection so a chosen
 		// command formats the range the user was looking at.
 		editor?.commands.restoreSelection({ focus: false });
-	}, [editor]);
-	const openMenu = useCallback(() => {
+	};
+	const openMenu = () => {
 		const viewport = viewportRef.current;
 		if (!viewport) return;
 		// Focus moves to the menu input, which visually drops the editor
@@ -208,36 +207,47 @@ export function FormatCommandMenu({
 		setPosition(null);
 		setOpen(true);
 		requestAnimationFrame(() => inputRef.current?.focus());
-	}, [editor, viewportRef]);
+	};
 
-	useEffect(() => {
-		if (!editor) return;
+	useEffect(
+		() => {
+			if (!editor) return;
 
-		const handleKeyDown = (event: KeyboardEvent) => {
-			if (!keymatch(event, "CmdOrCtrl+/")) return;
-			if (!editor.isFocused && !open) return;
-			event.preventDefault();
-			if (open) {
-				closeMenu();
-				return;
-			}
-			openMenu();
-		};
+			const handleKeyDown = (event: KeyboardEvent) => {
+				if (!keymatch(event, "CmdOrCtrl+/")) return;
+				if (!editor.isFocused && !open) return;
+				event.preventDefault();
+				if (open) {
+					closeMenu();
+					return;
+				}
+				openMenu();
+			};
 
-		window.addEventListener("keydown", handleKeyDown);
-		return () => window.removeEventListener("keydown", handleKeyDown);
-	}, [closeMenu, editor, open, openMenu]);
+			window.addEventListener("keydown", handleKeyDown);
+			return () => window.removeEventListener("keydown", handleKeyDown);
+		},
+		// biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler stabilizes render-local callbacks.
+		[closeMenu, editor, open, openMenu],
+	);
 
-	useEffect(() => {
-		if (!editor) return;
-		const handleOpenRequest = () => openMenu();
-		window.addEventListener(OPEN_FORMAT_COMMAND_MENU_EVENT, handleOpenRequest);
-		return () =>
-			window.removeEventListener(
+	useEffect(
+		() => {
+			if (!editor) return;
+			const handleOpenRequest = () => openMenu();
+			window.addEventListener(
 				OPEN_FORMAT_COMMAND_MENU_EVENT,
 				handleOpenRequest,
 			);
-	}, [editor, openMenu]);
+			return () =>
+				window.removeEventListener(
+					OPEN_FORMAT_COMMAND_MENU_EVENT,
+					handleOpenRequest,
+				);
+		},
+		// biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler stabilizes the render-local callback.
+		[editor, openMenu],
+	);
 
 	useCommandMenuPosition({
 		editor,

--- a/packages/ui/src/editor/LinkPopover.tsx
+++ b/packages/ui/src/editor/LinkPopover.tsx
@@ -15,10 +15,8 @@ import { TextSelection } from "@tiptap/pm/state";
 import { keymatch } from "keymatch";
 import {
 	type RefObject,
-	useCallback,
 	useEffect,
 	useLayoutEffect,
-	useMemo,
 	useReducer,
 	useRef,
 	useState,
@@ -521,7 +519,7 @@ function usePreviewRevealAnimation({
 	const previousPopoverModeRef = useRef<PopoverMode>(mode);
 	const previousPreviewKeyRef = useRef<string | null>(activeKey);
 
-	const playPreviewReveal = useCallback(() => {
+	const playPreviewReveal = () => {
 		const previewButton = previewButtonRef.current;
 		if (!previewButton) return;
 		if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
@@ -547,7 +545,7 @@ function usePreviewRevealAnimation({
 			},
 			{ once: true },
 		);
-	}, [positionUpdateRef]);
+	};
 
 	useEffect(() => {
 		return () => {
@@ -555,26 +553,30 @@ function usePreviewRevealAnimation({
 		};
 	}, []);
 
-	useEffect(() => {
-		const previousMode = previousPopoverModeRef.current;
-		const previousPreviewKey = previousPreviewKeyRef.current;
-		const shouldRevealFromHidden =
-			previousMode === "hidden" && mode === "preview";
-		const shouldReplayPreviewReveal =
-			previousMode === "preview" &&
-			mode === "preview" &&
-			inputMode === "pointer" &&
-			previousPreviewKey !== null &&
-			activeKey !== null &&
-			previousPreviewKey !== activeKey;
+	useEffect(
+		() => {
+			const previousMode = previousPopoverModeRef.current;
+			const previousPreviewKey = previousPreviewKeyRef.current;
+			const shouldRevealFromHidden =
+				previousMode === "hidden" && mode === "preview";
+			const shouldReplayPreviewReveal =
+				previousMode === "preview" &&
+				mode === "preview" &&
+				inputMode === "pointer" &&
+				previousPreviewKey !== null &&
+				activeKey !== null &&
+				previousPreviewKey !== activeKey;
 
-		if (shouldRevealFromHidden || shouldReplayPreviewReveal) {
-			playPreviewReveal();
-		}
+			if (shouldRevealFromHidden || shouldReplayPreviewReveal) {
+				playPreviewReveal();
+			}
 
-		previousPopoverModeRef.current = mode;
-		previousPreviewKeyRef.current = activeKey;
-	}, [mode, activeKey, inputMode, playPreviewReveal]);
+			previousPopoverModeRef.current = mode;
+			previousPreviewKeyRef.current = activeKey;
+		},
+		// biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler stabilizes the render-local callback.
+		[mode, activeKey, inputMode, playPreviewReveal],
+	);
 
 	return previewButtonRef;
 }
@@ -583,27 +585,31 @@ function PreviewLabel({ text }: { text: string }) {
 	const textRef = useRef<HTMLSpanElement | null>(null);
 	const [overflows, setOverflows] = useState(false);
 
-	const measureOverflow = useCallback(() => {
+	const measureOverflow = () => {
 		const element = textRef.current;
 		setOverflows(
 			Boolean(element && element.scrollWidth > element.clientWidth + 1),
 		);
-	}, []);
+	};
 
-	useLayoutEffect(() => {
-		const element = textRef.current;
-		if (!element) {
-			setOverflows(false);
-			return;
-		}
-		measureOverflow();
-		// CSS cannot tell us whether the text is actually clipped. Measure overflow
-		// so the fade mask only appears when there is hidden text to fade out.
-		// Hover padding and reveal animation also change the available label width.
-		const observer = new ResizeObserver(measureOverflow);
-		observer.observe(element);
-		return () => observer.disconnect();
-	}, [measureOverflow]);
+	useLayoutEffect(
+		() => {
+			const element = textRef.current;
+			if (!element) {
+				setOverflows(false);
+				return;
+			}
+			measureOverflow();
+			// CSS cannot tell us whether the text is actually clipped. Measure overflow
+			// so the fade mask only appears when there is hidden text to fade out.
+			// Hover padding and reveal animation also change the available label width.
+			const observer = new ResizeObserver(measureOverflow);
+			observer.observe(element);
+			return () => observer.disconnect();
+		},
+		// biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler stabilizes the render-local callback.
+		[measureOverflow],
+	);
 
 	return (
 		<span
@@ -680,17 +686,15 @@ export function LinkPopover({
 	const [creationHref, setCreationHref] = useState("");
 	const [activeSuggestionIndex, setActiveSuggestionIndex] = useState(0);
 	const wikiQuery = machineState.mode === "creating" ? creationHref : hrefValue;
-	const wikiSuggestions = useMemo(() => {
-		const query = normalizedSearchValue(wikiQuery);
-		return wikiTargets
-			.filter((file) => {
-				if (!query) return true;
-				const haystack = `${file.title} ${file.target}`.toLocaleLowerCase();
-				return haystack.includes(query);
-			})
-			.sort((a, b) => a.title.localeCompare(b.title))
-			.slice(0, 6);
-	}, [wikiQuery, wikiTargets]);
+	const wikiSuggestionQuery = normalizedSearchValue(wikiQuery);
+	const wikiSuggestions = wikiTargets
+		.filter((file) => {
+			if (!wikiSuggestionQuery) return true;
+			const haystack = `${file.title} ${file.target}`.toLocaleLowerCase();
+			return haystack.includes(wikiSuggestionQuery);
+		})
+		.sort((a, b) => a.title.localeCompare(b.title))
+		.slice(0, 6);
 	const boundedActiveSuggestionIndex =
 		wikiSuggestions.length === 0
 			? 0
@@ -711,20 +715,17 @@ export function LinkPopover({
 		positionUpdateRef.current?.("layout");
 	}, [machineState.mode]);
 
-	const dispatchMachineEvent = useCallback(
-		(event: MachineEvent) => {
-			const previousState = machineStateRef.current;
-			const nextState = machineReducer(previousState, event);
-			machineStateRef.current = nextState;
-			onCursorModeChange?.(getCursorModeForMachineState(nextState));
-			dispatch(event);
-		},
-		[onCursorModeChange],
-	);
-	const setAnchorState = useCallback((event: LinkAnchorEvent) => {
+	const dispatchMachineEvent = (event: MachineEvent) => {
+		const previousState = machineStateRef.current;
+		const nextState = machineReducer(previousState, event);
+		machineStateRef.current = nextState;
+		onCursorModeChange?.(getCursorModeForMachineState(nextState));
+		dispatch(event);
+	};
+	const setAnchorState = (event: LinkAnchorEvent) => {
 		anchorRef.current = linkAnchorReducer(anchorRef.current, event);
-	}, []);
-	const openCreationTitleInput = useCallback(() => {
+	};
+	const openCreationTitleInput = () => {
 		if (!editor || creationCursorPos === null) return;
 		clearGhostText(editor);
 		if (creationHref) {
@@ -732,108 +733,96 @@ export function LinkPopover({
 		}
 		dispatchMachineEvent({ type: "TITLE_INPUT_REQUESTED" });
 		editor.commands.focus(undefined, { scrollIntoView: false });
-	}, [editor, creationCursorPos, creationHref, dispatchMachineEvent]);
-	const applyWikiSuggestionToExistingLink = useCallback(
-		(suggestion: (typeof wikiSuggestions)[number]) => {
-			if (!editor || !activeLink) return;
-			const linkType = editor.state.schema.marks.link;
-			if (!linkType) return;
+	};
+	const applyWikiSuggestionToExistingLink = (
+		suggestion: (typeof wikiSuggestions)[number],
+	) => {
+		if (!editor || !activeLink) return;
+		const linkType = editor.state.schema.marks.link;
+		if (!linkType) return;
 
-			const nextLink = {
-				...activeLink,
-				href: suggestion.path,
-				kind: "wiki" as const,
-				target: suggestion.target,
-			};
-			const attrs = {
-				href: suggestion.path,
-				kind: "wiki",
-				target: suggestion.target,
-			};
-			if (activeLink.from === activeLink.to) {
-				const marks = (
-					editor.state.storedMarks ?? editor.state.selection.$from.marks()
-				).filter((mark) => mark.type !== linkType);
-				editor.view.dispatch(
-					editor.state.tr.setStoredMarks([...marks, linkType.create(attrs)]),
-				);
-			} else {
-				const currentText = editor.state.doc.textBetween(
+		const nextLink = {
+			...activeLink,
+			href: suggestion.path,
+			kind: "wiki" as const,
+			target: suggestion.target,
+		};
+		const attrs = {
+			href: suggestion.path,
+			kind: "wiki",
+			target: suggestion.target,
+		};
+		if (activeLink.from === activeLink.to) {
+			const marks = (
+				editor.state.storedMarks ?? editor.state.selection.$from.marks()
+			).filter((mark) => mark.type !== linkType);
+			editor.view.dispatch(
+				editor.state.tr.setStoredMarks([...marks, linkType.create(attrs)]),
+			);
+		} else {
+			const currentText = editor.state.doc.textBetween(
+				activeLink.from,
+				activeLink.to,
+				"",
+			);
+			// Update inline text only when it still matches the linked file name.
+			const oldTarget =
+				originalWikiTargetRef.current?.activeKey ===
+				machineStateRef.current.activeKey
+					? originalWikiTargetRef.current.target
+					: activeLink.target || activeLink.href;
+			const oldAutoTitle = wikiDisplayNameForTarget(oldTarget);
+			if (currentText === oldAutoTitle) {
+				const tr = editor.state.tr.replaceWith(
 					activeLink.from,
 					activeLink.to,
-					"",
+					editor.state.schema.text(suggestion.title, [linkType.create(attrs)]),
 				);
-				// Update inline text only when it still matches the linked file name.
-				const oldTarget =
-					originalWikiTargetRef.current?.activeKey ===
-					machineStateRef.current.activeKey
-						? originalWikiTargetRef.current.target
-						: activeLink.target || activeLink.href;
-				const oldAutoTitle = wikiDisplayNameForTarget(oldTarget);
-				if (currentText === oldAutoTitle) {
-					const tr = editor.state.tr.replaceWith(
-						activeLink.from,
-						activeLink.to,
-						editor.state.schema.text(suggestion.title, [
-							linkType.create(attrs),
-						]),
-					);
-					editor.view.dispatch(tr);
-				} else {
-					const tr = editor.state.tr.removeMark(
-						activeLink.from,
-						activeLink.to,
-						linkType,
-					);
-					tr.addMark(activeLink.from, activeLink.to, linkType.create(attrs));
-					editor.view.dispatch(tr);
-				}
-			}
-			// Edits can close before selection sync runs, so keep preview/open state
-			// aligned with the transaction we just dispatched.
-			setActiveLink(nextLink);
-			setHrefValue(suggestion.target);
-			dispatchMachineEvent({ type: "ESCAPE_REQUESTED" });
-		},
-		[editor, activeLink, dispatchMachineEvent],
-	);
-	const applyWikiSuggestion = useCallback(
-		(suggestion: (typeof wikiSuggestions)[number]) => {
-			if (!editor) return;
-			if (machineStateRef.current.mode === "creating") {
-				if (creationCursorPos === null) return;
-				clearGhostText(editor);
-				insertWikiLinkedText(
-					editor,
-					creationCursorPos,
-					suggestion.title,
-					suggestion.path,
-					suggestion.target,
+				editor.view.dispatch(tr);
+			} else {
+				const tr = editor.state.tr.removeMark(
+					activeLink.from,
+					activeLink.to,
+					linkType,
 				);
-				dispatchMachineEvent({ type: "CREATION_CONFIRMED" });
-				editor.commands.focus(undefined, { scrollIntoView: false });
-				return;
+				tr.addMark(activeLink.from, activeLink.to, linkType.create(attrs));
+				editor.view.dispatch(tr);
 			}
-			applyWikiSuggestionToExistingLink(suggestion);
-		},
-		[
-			editor,
-			creationCursorPos,
-			dispatchMachineEvent,
-			applyWikiSuggestionToExistingLink,
-		],
-	);
-	const moveSuggestion = useCallback(
-		(delta: 1 | -1) => {
-			const count = wikiSuggestions.length;
-			if (count === 0) return;
-			setActiveSuggestionIndex((index) => {
-				const boundedIndex = Math.min(index, count - 1);
-				return (boundedIndex + delta + count) % count;
-			});
-		},
-		[wikiSuggestions.length],
-	);
+		}
+		// Edits can close before selection sync runs, so keep preview/open state
+		// aligned with the transaction we just dispatched.
+		setActiveLink(nextLink);
+		setHrefValue(suggestion.target);
+		dispatchMachineEvent({ type: "ESCAPE_REQUESTED" });
+	};
+	const applyWikiSuggestion = (
+		suggestion: (typeof wikiSuggestions)[number],
+	) => {
+		if (!editor) return;
+		if (machineStateRef.current.mode === "creating") {
+			if (creationCursorPos === null) return;
+			clearGhostText(editor);
+			insertWikiLinkedText(
+				editor,
+				creationCursorPos,
+				suggestion.title,
+				suggestion.path,
+				suggestion.target,
+			);
+			dispatchMachineEvent({ type: "CREATION_CONFIRMED" });
+			editor.commands.focus(undefined, { scrollIntoView: false });
+			return;
+		}
+		applyWikiSuggestionToExistingLink(suggestion);
+	};
+	const moveSuggestion = (delta: 1 | -1) => {
+		const count = wikiSuggestions.length;
+		if (count === 0) return;
+		setActiveSuggestionIndex((index) => {
+			const boundedIndex = Math.min(index, count - 1);
+			return (boundedIndex + delta + count) % count;
+		});
+	};
 
 	// ── Link detection + positioning for existing links ─────────────
 	useEffect(() => {
@@ -937,64 +926,77 @@ export function LinkPopover({
 	}, [
 		editor,
 		viewportRef,
+		// biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler stabilizes this render-local callback.
 		dispatchMachineEvent,
+		// biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler stabilizes this render-local callback.
 		setAnchorState,
 		creationCursorPos,
 		inputMode,
 	]);
 
 	// ── Listen for FOCUS_LINK_POPOVER_EVENT (selection-based flow) ──
-	useEffect(() => {
-		const onFocusRequest = () => {
-			expandNextLinkSessionRef.current = true;
-			dispatchMachineEvent({ type: "EXPAND_REQUESTED" });
-			// SmartLinkExtension fires this right after dispatching a transaction
-			// that may create an empty link. Read the session after that state lands.
-			queueMicrotask(() => {
-				if (!editor) return;
-				const { link } = getLinkSession(editor);
-				if (!link || link.href) return;
-				void navigator.clipboard
-					.readText()
-					.then((clipboardValue) => {
-						const href = clipboardValue.trim();
-						if (!canAutofillLinkFromClipboard(href)) return;
-						updateLinkMark(editor, link, href);
-						setHrefValue(href);
-						setActiveLink({ ...link, ...linkAttrsForHref(href) });
-						dispatchMachineEvent({ type: "EXPAND_REQUESTED" });
-					})
-					.catch(() => {});
-			});
-		};
-		window.addEventListener(
-			FOCUS_LINK_POPOVER_EVENT,
-			onFocusRequest as EventListener,
-		);
-		return () => {
-			window.removeEventListener(
+	useEffect(
+		() => {
+			const onFocusRequest = () => {
+				expandNextLinkSessionRef.current = true;
+				dispatchMachineEvent({ type: "EXPAND_REQUESTED" });
+				// SmartLinkExtension fires this right after dispatching a transaction
+				// that may create an empty link. Read the session after that state lands.
+				queueMicrotask(() => {
+					if (!editor) return;
+					const { link } = getLinkSession(editor);
+					if (!link || link.href) return;
+					void navigator.clipboard
+						.readText()
+						.then((clipboardValue) => {
+							const href = clipboardValue.trim();
+							if (!canAutofillLinkFromClipboard(href)) return;
+							updateLinkMark(editor, link, href);
+							setHrefValue(href);
+							setActiveLink({ ...link, ...linkAttrsForHref(href) });
+							dispatchMachineEvent({ type: "EXPAND_REQUESTED" });
+						})
+						.catch(() => {});
+				});
+			};
+			window.addEventListener(
 				FOCUS_LINK_POPOVER_EVENT,
 				onFocusRequest as EventListener,
 			);
-		};
-	}, [editor, dispatchMachineEvent]);
+			return () => {
+				window.removeEventListener(
+					FOCUS_LINK_POPOVER_EVENT,
+					onFocusRequest as EventListener,
+				);
+			};
+		},
+		// biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler stabilizes the render-local callback.
+		[editor, dispatchMachineEvent],
+	);
 
 	// ── Listen for LINK_CREATION_REQUESTED_EVENT (empty-selection Cmd+K) ──
-	useEffect(() => {
-		const onCreationRequested = (event: Event) => {
-			const pos = (event as CustomEvent<{ pos: number }>).detail.pos;
-			setCreationCursorPos(pos);
-			setCreationHref("");
-			dispatchMachineEvent({ type: "CREATION_REQUESTED" });
-		};
-		window.addEventListener(LINK_CREATION_REQUESTED_EVENT, onCreationRequested);
-		return () => {
-			window.removeEventListener(
+	useEffect(
+		() => {
+			const onCreationRequested = (event: Event) => {
+				const pos = (event as CustomEvent<{ pos: number }>).detail.pos;
+				setCreationCursorPos(pos);
+				setCreationHref("");
+				dispatchMachineEvent({ type: "CREATION_REQUESTED" });
+			};
+			window.addEventListener(
 				LINK_CREATION_REQUESTED_EVENT,
 				onCreationRequested,
 			);
-		};
-	}, [dispatchMachineEvent]);
+			return () => {
+				window.removeEventListener(
+					LINK_CREATION_REQUESTED_EVENT,
+					onCreationRequested,
+				);
+			};
+		},
+		// biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler stabilizes the render-local callback.
+		[dispatchMachineEvent],
+	);
 
 	// ── Focus input when entering creating or actions mode ──────────
 	useEffect(() => {
@@ -1064,7 +1066,9 @@ export function LinkPopover({
 		editor,
 		machineState.mode,
 		creationCursorPos,
+		// biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler stabilizes this render-local callback.
 		openCreationTitleInput,
+		// biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler stabilizes this render-local callback.
 		dispatchMachineEvent,
 	]);
 
@@ -1130,9 +1134,13 @@ export function LinkPopover({
 		machineState.mode,
 		creationHref,
 		creationCursorPos,
+		// biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler stabilizes this render-local callback.
 		dispatchMachineEvent,
+		// biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler stabilizes this render-local callback.
 		openCreationTitleInput,
+		// biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler stabilizes this render-local callback.
 		applyWikiSuggestion,
+		// biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler stabilizes this render-local callback.
 		moveSuggestion,
 		wikiSuggestions,
 		boundedActiveSuggestionIndex,
@@ -1224,9 +1232,12 @@ export function LinkPopover({
 		activeLink,
 		machineState.mode,
 		machineState.pendingCreation,
+		// biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler stabilizes this render-local callback.
 		dispatchMachineEvent,
 		hrefValue,
+		// biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler stabilizes this render-local callback.
 		applyWikiSuggestion,
+		// biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler stabilizes this render-local callback.
 		moveSuggestion,
 		wikiSuggestions,
 		boundedActiveSuggestionIndex,

--- a/packages/ui/src/editor/MarkdownSourceEditor.tsx
+++ b/packages/ui/src/editor/MarkdownSourceEditor.tsx
@@ -2,7 +2,7 @@ import type { Editor } from "@tiptap/core";
 import Document from "@tiptap/extension-document";
 import { EditorContent, type JSONContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
-import { useCallback, useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 import { HubbleCodeBlock } from "./CodeBlockExtension";
 import "./EditorView.css";
 
@@ -29,16 +29,15 @@ export function MarkdownSourceEditor({
 	const pathRef = useRef(path);
 	const latestMarkdownRef = useRef(initialMarkdown);
 	const saveTimerRef = useRef<number | null>(null);
-	pathRef.current = path;
+	useLayoutEffect(() => {
+		pathRef.current = path;
+	}, [path]);
 
-	const setEditorViewport = useCallback(
-		(node: HTMLDivElement | null) => {
-			onScrollContainerChange?.(node);
-		},
-		[onScrollContainerChange],
-	);
+	const setEditorViewport = (node: HTMLDivElement | null) => {
+		onScrollContainerChange?.(node);
+	};
 
-	const scheduleSave = useCallback(() => {
+	const scheduleSave = () => {
 		const savePath = pathRef.current;
 		if (saveTimerRef.current !== null) {
 			window.clearTimeout(saveTimerRef.current);
@@ -47,7 +46,7 @@ export function MarkdownSourceEditor({
 			saveTimerRef.current = null;
 			void onSave(savePath, latestMarkdownRef.current);
 		}, saveDebounceMs);
-	}, [onSave, saveDebounceMs]);
+	};
 
 	const editor = useEditor({
 		extensions: [

--- a/packages/ui/src/editor/MarkdownSourceEditor.tsx
+++ b/packages/ui/src/editor/MarkdownSourceEditor.tsx
@@ -4,6 +4,11 @@ import { EditorContent, type JSONContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import { useEffect, useLayoutEffect, useRef } from "react";
 import { HubbleCodeBlock } from "./CodeBlockExtension";
+import {
+	flushPendingSave,
+	type PendingSave,
+	schedulePendingSave,
+} from "./pendingSave";
 import "./EditorView.css";
 
 const DEFAULT_SAVE_DEBOUNCE_MS = 120;
@@ -28,7 +33,7 @@ export function MarkdownSourceEditor({
 }: MarkdownSourceEditorProps) {
 	const pathRef = useRef(path);
 	const latestMarkdownRef = useRef(initialMarkdown);
-	const saveTimerRef = useRef<number | null>(null);
+	const pendingSaveRef = useRef<PendingSave | null>(null);
 	useLayoutEffect(() => {
 		pathRef.current = path;
 	}, [path]);
@@ -38,14 +43,13 @@ export function MarkdownSourceEditor({
 	};
 
 	const scheduleSave = () => {
-		const savePath = pathRef.current;
-		if (saveTimerRef.current !== null) {
-			window.clearTimeout(saveTimerRef.current);
-		}
-		saveTimerRef.current = window.setTimeout(() => {
-			saveTimerRef.current = null;
-			void onSave(savePath, latestMarkdownRef.current);
-		}, saveDebounceMs);
+		schedulePendingSave({
+			delay: saveDebounceMs,
+			markdown: latestMarkdownRef.current,
+			path: pathRef.current,
+			ref: pendingSaveRef,
+			save: onSave,
+		});
 	};
 
 	const editor = useEditor({
@@ -84,14 +88,12 @@ export function MarkdownSourceEditor({
 	}, [editor, initialMarkdown]);
 
 	useEffect(() => {
+		// Path changes flush the pending edit before the next document takes over.
+		void path;
 		return () => {
-			if (saveTimerRef.current !== null) {
-				window.clearTimeout(saveTimerRef.current);
-				saveTimerRef.current = null;
-				void onSave(path, latestMarkdownRef.current);
-			}
+			flushPendingSave(pendingSaveRef);
 		};
-	}, [path, onSave]);
+	}, [path]);
 
 	return (
 		<div

--- a/packages/ui/src/editor/SelectionFormattingToolbar.tsx
+++ b/packages/ui/src/editor/SelectionFormattingToolbar.tsx
@@ -198,7 +198,16 @@ export function SelectionFormattingToolbar({
 						width: right - left,
 						height: bottom - top,
 						toJSON() {
-							return this;
+							return {
+								x: left,
+								y: top,
+								left,
+								top,
+								right,
+								bottom,
+								width: right - left,
+								height: bottom - top,
+							};
 						},
 					};
 				},

--- a/packages/ui/src/editor/SelectionFormattingToolbar.tsx
+++ b/packages/ui/src/editor/SelectionFormattingToolbar.tsx
@@ -198,6 +198,8 @@ export function SelectionFormattingToolbar({
 						width: right - left,
 						height: bottom - top,
 						toJSON() {
+							// Floating UI expects a plain DOMRect snapshot; returning `this`
+							// leaks the mutable reference and violates compiler purity.
 							return {
 								x: left,
 								y: top,

--- a/packages/ui/src/editor/pendingSave.ts
+++ b/packages/ui/src/editor/pendingSave.ts
@@ -9,6 +9,7 @@ export type PendingSave = {
 
 type PendingSaveRef = { current: PendingSave | null };
 
+/** Cancels the timer first so cleanup and the debounce cannot save the same edit twice. */
 export function flushPendingSave(ref: PendingSaveRef) {
 	const pending = ref.current;
 	if (!pending) return;
@@ -17,7 +18,6 @@ export function flushPendingSave(ref: PendingSaveRef) {
 	void pending.save(pending.path, pending.markdown);
 }
 
-/** Keeps each delayed edit bound to the file path it was created for. */
 export function schedulePendingSave({
 	delay,
 	markdown,

--- a/packages/ui/src/editor/pendingSave.ts
+++ b/packages/ui/src/editor/pendingSave.ts
@@ -1,0 +1,51 @@
+type SaveMarkdown = (path: string, markdown: string) => void | Promise<void>;
+
+export type PendingSave = {
+	markdown: string;
+	path: string;
+	save: SaveMarkdown;
+	timer: number;
+};
+
+type PendingSaveRef = { current: PendingSave | null };
+
+export function flushPendingSave(ref: PendingSaveRef) {
+	const pending = ref.current;
+	if (!pending) return;
+	window.clearTimeout(pending.timer);
+	ref.current = null;
+	void pending.save(pending.path, pending.markdown);
+}
+
+/** Keeps each delayed edit bound to the file path it was created for. */
+export function schedulePendingSave({
+	delay,
+	markdown,
+	path,
+	ref,
+	save,
+}: {
+	delay: number;
+	markdown: string;
+	path: string;
+	ref: PendingSaveRef;
+	save: SaveMarkdown;
+}) {
+	const existing = ref.current;
+	if (existing) {
+		if (existing.path !== path) {
+			flushPendingSave(ref);
+		} else {
+			window.clearTimeout(existing.timer);
+			ref.current = null;
+		}
+	}
+
+	const pending: PendingSave = { markdown, path, save, timer: 0 };
+	pending.timer = window.setTimeout(() => {
+		if (ref.current !== pending) return;
+		ref.current = null;
+		void pending.save(pending.path, pending.markdown);
+	}, delay);
+	ref.current = pending;
+}

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -1,5 +1,6 @@
 import { isAbsolute } from "node:path";
 import { fileURLToPath, URL } from "node:url";
+import react from "@vitejs/plugin-react";
 import icons from "unplugin-icons/vite";
 import { defineConfig } from "vite";
 
@@ -12,6 +13,11 @@ const isExternal = (id: string) =>
 
 export default defineConfig({
 	plugins: [
+		react({
+			babel: {
+				plugins: ["babel-plugin-react-compiler"],
+			},
+		}),
 		icons({
 			compiler: "jsx",
 			jsx: "react",

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -3,6 +3,7 @@ import { fileURLToPath, URL } from "node:url";
 import react from "@vitejs/plugin-react";
 import icons from "unplugin-icons/vite";
 import { defineConfig } from "vite";
+import { reactCompilerPlugin } from "../../config/react-compiler-audit";
 
 const resolve = (path: string) => fileURLToPath(new URL(path, import.meta.url));
 const isExternal = (id: string) =>
@@ -15,7 +16,7 @@ export default defineConfig({
 	plugins: [
 		react({
 			babel: {
-				plugins: ["babel-plugin-react-compiler"],
+				plugins: [reactCompilerPlugin("ui")],
 			},
 		}),
 		icons({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.6.0
         version: 4.7.0(vite@7.3.5(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.9.0))
+      babel-plugin-react-compiler:
+        specifier: ^1.0.0
+        version: 1.0.0
       chokidar:
         specifier: ^4.0.3
         version: 4.0.3
@@ -253,6 +256,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.6.0
         version: 4.7.0(vite@7.3.5(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.9.0))
+      babel-plugin-react-compiler:
+        specifier: ^1.0.0
+        version: 1.0.0
       tailwindcss:
         specifier: ^4.1.18
         version: 4.1.18
@@ -470,6 +476,12 @@ importers:
       '@types/react':
         specifier: ^19.1.8
         version: 19.2.14
+      '@vitejs/plugin-react':
+        specifier: ^4.6.0
+        version: 4.7.0(vite@7.3.5(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.9.0))
+      babel-plugin-react-compiler:
+        specifier: ^1.0.0
+        version: 1.0.0
       happy-dom:
         specifier: ^20.10.3
         version: 20.10.3
@@ -584,16 +596,8 @@ packages:
     resolution: {integrity: sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.29.7':
@@ -676,10 +680,6 @@ packages:
 
   '@babel/traverse@7.29.0':
     resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.29.0':
-    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
@@ -2631,6 +2631,9 @@ packages:
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
+
+  babel-plugin-react-compiler@1.0.0:
+    resolution: {integrity: sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -5886,7 +5889,7 @@ snapshots:
 
   '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/helper-compilation-targets@7.28.6':
     dependencies:
@@ -5914,7 +5917,7 @@ snapshots:
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -5936,7 +5939,7 @@ snapshots:
 
   '@babel/helper-optimise-call-expression@7.27.1':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/helper-plugin-utils@7.28.6': {}
 
@@ -5954,15 +5957,11 @@ snapshots:
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-string-parser@7.27.1': {}
-
   '@babel/helper-string-parser@7.29.7': {}
-
-  '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
@@ -5975,7 +5974,7 @@ snapshots:
 
   '@babel/parser@7.29.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/parser@7.29.7':
     dependencies:
@@ -6055,11 +6054,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/types@7.29.0':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.29.7':
     dependencies:
@@ -7135,7 +7129,7 @@ snapshots:
 
   '@svgr/hast-util-to-babel-ast@8.0.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       entities: 4.5.0
 
   '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.8.3))':
@@ -7436,24 +7430,24 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       '@types/babel__generator': 7.27.0
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.28.0
 
   '@types/babel__generator@7.27.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
   '@types/babel__traverse@7.28.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@types/cacheable-request@6.0.3':
     dependencies:
@@ -7854,6 +7848,10 @@ snapshots:
   at-least-node@1.0.0: {}
 
   axobject-query@4.1.0: {}
+
+  babel-plugin-react-compiler@1.0.0:
+    dependencies:
+      '@babel/types': 7.29.7
 
   bail@2.0.2: {}
 
@@ -9417,7 +9415,7 @@ snapshots:
   magicast@0.5.3:
     dependencies:
       '@babel/parser': 7.29.7
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       source-map-js: 1.2.1
 
   markdown-it@14.1.1:

--- a/scripts/audit-react-compiler.mjs
+++ b/scripts/audit-react-compiler.mjs
@@ -1,0 +1,25 @@
+import { spawnSync } from "node:child_process";
+
+const pnpmCli = process.env.npm_execpath;
+if (!pnpmCli) {
+	throw new Error("Run this audit through `pnpm check:react-compiler`.");
+}
+
+const builds = [
+	["--filter", "@hubble.md/ui", "run", "build"],
+	["--filter", "@hubble.md/desktop", "run", "build"],
+	["--filter", "@hubble.md/www", "run", "build"],
+];
+
+for (const args of builds) {
+	// Build scripts run the React Compiler through each package's production Vite config.
+	// Audit mode adds a compiler logger that catches diagnostics, including code the
+	// React Compiler skips because it is incompatible.
+	const result = spawnSync(process.execPath, [pnpmCli, ...args], {
+		env: { ...process.env, REACT_COMPILER_AUDIT: "1" },
+		stdio: "inherit",
+	});
+
+	if (result.error) throw result.error;
+	if (result.status !== 0) process.exit(result.status ?? 1);
+}

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -13,6 +13,12 @@
 			"skillPath": "skills/productivity/handoff/SKILL.md",
 			"computedHash": "1a78d774f8a59db5daa6e65e20a6596872fa8cde769f9a6e3a09b678dd5ae8cc"
 		},
+		"review-pr": {
+			"source": "warpdotdev/common-skills",
+			"sourceType": "github",
+			"skillPath": ".agents/skills/review-pr/SKILL.md",
+			"computedHash": "f27bfc9743fa0d240763a26519b25112a0ad8652c9a2b2b52daeb7af2d2a862c"
+		},
 		"to-issues": {
 			"source": "mattpocock/skills",
 			"sourceType": "github",


### PR DESCRIPTION
## Description

Migrates the desktop app, web app, and shared UI package to React Compiler.

- Removes unnecessary manual memoization across React surfaces.
- Adds compiler compatibility fixes for editor, sidebar, terminal, search, and link workflows.
- Audits real production builds for compiler skips and zero compiler output.
- Fixes navigation-history button flicker and preserves pending edits across file changes.
- Adds structured local PR review guidance.

Related issue: none.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update

## Testing

- [x] Existing tests pass
- [x] Added new tests for changes
- [x] Tested manually (describe below)

**Manual Testing Details:**

Desktop E2E covered sidebar expansion, back/forward history, search, rich/source editing, Find/Format, wiki popovers, terminal, and iframe flows. Web runtime verification was explicitly waived.

Automated validation:
- pnpm build:desktop
- pnpm check
- pnpm test (228 tests)
- pnpm check:react-compiler (109 compiled, zero failures)

## Checklist

- [ ] I discussed this change in a GitHub issue before submitting this PR
- [x] I have run the linter, formatter, and tests to ensure my code is ready for review