### PR TITLE
Add source mode for HTML apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 
 ### Changed
 
+- HTML Apps can now be edited in source mode from the file menu or keyboard shortcut.
 - Editor blocks now use a consistent reading rhythm, with tighter list grouping and clearer heading separation. [f6c44a2](https://github.com/bholmesdev/hubble.md/commit/f6c44a2)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 
 ### Changed
 
-- HTML Apps can now be edited in source mode from the file menu or keyboard shortcut.
+- HTML Apps can now be edited in source mode from the file menu or keyboard shortcut. [#178](https://github.com/bholmesdev/hubble.md/pull/178)
 - Editor blocks now use a consistent reading rhythm, with tighter list grouping and clearer heading separation. [f6c44a2](https://github.com/bholmesdev/hubble.md/commit/f6c44a2)
 
 ### Fixed

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -142,7 +142,7 @@ const launchWorkspacePath =
 		: null;
 let menuState: MenuState = {
 	hasWorkspace: false,
-	hasMarkdownNoteOpen: false,
+	hasSourceViewOpen: false,
 	isSourceMode: false,
 	canGoBack: false,
 	canGoForward: false,
@@ -898,7 +898,7 @@ function buildMenu() {
 					id: "toggle-source-mode",
 					label: "Toggle Source Mode",
 					accelerator: "Alt+CmdOrCtrl+U",
-					enabled: menuState.hasMarkdownNoteOpen,
+					enabled: menuState.hasSourceViewOpen,
 					click: () => sendToRenderer("desktop:menu-toggle-source-mode"),
 				},
 				...(isDev
@@ -1713,7 +1713,7 @@ function registerIpc() {
 	ipcMain.handle("desktop:set-menu-state", (_event, state: MenuState) => {
 		menuState = {
 			hasWorkspace: state.hasWorkspace === true,
-			hasMarkdownNoteOpen: state.hasMarkdownNoteOpen === true,
+			hasSourceViewOpen: state.hasSourceViewOpen === true,
 			isSourceMode: state.isSourceMode === true,
 			canGoBack: state.canGoBack === true,
 			canGoForward: state.canGoForward === true,

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -31,6 +31,7 @@ import { createHtmlFile, createMarkdownFile } from "./fileActions";
 import { isChangelogPath } from "./lib/changelogNote";
 import { copyText } from "./lib/clipboard";
 import {
+	hasDocumentExtension,
 	hasHtmlExtension,
 	hasMarkdownExtension,
 	relativeWorkspacePath,
@@ -256,8 +257,8 @@ function App() {
 		const currentPath = state.currentPath;
 		void desktopApi.setMenuState({
 			hasWorkspace,
-			hasMarkdownNoteOpen:
-				typeof currentPath === "string" && hasMarkdownExtension(currentPath),
+			hasSourceViewOpen:
+				typeof currentPath === "string" && hasDocumentExtension(currentPath),
 			isSourceMode: state.viewMode === "source",
 			canGoBack: menuCanGoBack,
 			canGoForward: menuCanGoForward,
@@ -385,7 +386,7 @@ function App() {
 				const current = viewerStore.get();
 				if (
 					!current.currentPath ||
-					!hasMarkdownExtension(current.currentPath)
+					!hasDocumentExtension(current.currentPath)
 				) {
 					return;
 				}
@@ -601,6 +602,21 @@ function DocumentViewer({
 	viewMode: ViewMode;
 	onScrollContainerChange?: (el: HTMLDivElement | null) => void;
 }) {
+	if (viewMode === "source" && hasDocumentExtension(path)) {
+		const isHtml = hasHtmlExtension(path);
+		return (
+			<MarkdownSourceEditor
+				key={`${path}:source:${HMR_REV}`}
+				path={path}
+				initialMarkdown={content}
+				sourceLanguage={isHtml ? "html" : "md"}
+				onLocalChange={updateEditorContent}
+				onSave={savePathContent}
+				onScrollContainerChange={onScrollContainerChange}
+			/>
+		);
+	}
+
 	if (hasHtmlExtension(path)) {
 		return (
 			<HtmlDocumentViewer
@@ -615,26 +631,13 @@ function DocumentViewer({
 	}
 
 	return (
-		<>
-			{viewMode === "source" ? (
-				<MarkdownSourceEditor
-					key={`${path}:source:${HMR_REV}`}
-					path={path}
-					initialMarkdown={content}
-					onLocalChange={updateEditorContent}
-					onSave={savePathContent}
-					onScrollContainerChange={onScrollContainerChange}
-				/>
-			) : (
-				<MarkdownEditor
-					key={`${path}:rich:${HMR_REV}`}
-					path={path}
-					initialMarkdown={content}
-					copyAsMarkdownRequest={copyAsMarkdownRequest}
-					onScrollContainerChange={onScrollContainerChange}
-				/>
-			)}
-		</>
+		<MarkdownEditor
+			key={`${path}:rich:${HMR_REV}`}
+			path={path}
+			initialMarkdown={content}
+			copyAsMarkdownRequest={copyAsMarkdownRequest}
+			onScrollContainerChange={onScrollContainerChange}
+		/>
 	);
 }
 

--- a/apps/desktop/src/components/Toolbar.tsx
+++ b/apps/desktop/src/components/Toolbar.tsx
@@ -17,7 +17,7 @@ import MingcuteTerminalLine from "~icons/mingcute/terminal-line";
 import { desktopApi } from "../desktopApi";
 import { isChangelogPath } from "../lib/changelogNote";
 import { copyText } from "../lib/clipboard";
-import { hasMarkdownExtension } from "../lib/filePath";
+import { hasDocumentExtension, hasHtmlExtension } from "../lib/filePath";
 import { revealFileLabel } from "../lib/revealFile";
 import {
 	goBack,
@@ -142,6 +142,12 @@ function NoteActionsMenu({
 }) {
 	const { viewMode } = useStoreValue(viewerStore);
 	const isSourceMode = viewMode === "source";
+	const isHtml = hasHtmlExtension(path);
+	const sourceModeLabel = isSourceMode
+		? isHtml
+			? "View app"
+			: "Edit rich text"
+		: "Edit source";
 
 	async function revealFile() {
 		try {
@@ -187,15 +193,13 @@ function NoteActionsMenu({
 								<ShortcutHint spec="CmdOrCtrl+Shift+J" />
 							</Menu.Item>
 						)}
-						{hasMarkdownExtension(path) && (
+						{hasDocumentExtension(path) && (
 							<Menu.Item
 								className="flex w-full cursor-pointer items-center gap-2 rounded-sm [padding-block:0.375rem] [padding-inline:0.5rem] text-start text-[11px] outline-hidden select-none data-highlighted:bg-accent"
 								onClick={() => setViewerMode(isSourceMode ? "rich" : "source")}
 							>
 								<MingcuteCodeLine className="size-3 shrink-0" />
-								<span className="min-w-0 flex-1">
-									{isSourceMode ? "Edit rich text" : "Edit source"}
-								</span>
+								<span className="min-w-0 flex-1">{sourceModeLabel}</span>
 								<ShortcutHint spec="Alt+CmdOrCtrl+U" />
 							</Menu.Item>
 						)}

--- a/apps/desktop/src/desktopApi/types.ts
+++ b/apps/desktop/src/desktopApi/types.ts
@@ -69,7 +69,7 @@ export type Unsubscribe = () => void;
 
 export type MenuState = {
 	hasWorkspace: boolean;
-	hasMarkdownNoteOpen: boolean;
+	hasSourceViewOpen: boolean;
 	isSourceMode: boolean;
 	canGoBack: boolean;
 	canGoForward: boolean;

--- a/apps/desktop/src/lib/filePath.test.ts
+++ b/apps/desktop/src/lib/filePath.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { isHiddenSidebarFolderName } from "./filePath";
+import { hasDocumentExtension, isHiddenSidebarFolderName } from "./filePath";
+
+describe("hasDocumentExtension", () => {
+	it("matches files with rich and source viewer modes", () => {
+		expect(hasDocumentExtension("note.md")).toBe(true);
+		expect(hasDocumentExtension("app.html")).toBe(true);
+		expect(hasDocumentExtension("app.HTM")).toBe(true);
+		expect(hasDocumentExtension("image.png")).toBe(false);
+	});
+});
 
 describe("isHiddenSidebarFolderName", () => {
 	it("matches app-owned directories excluded from the sidebar", () => {

--- a/packages/ui/src/editor/MarkdownSourceEditor.test.ts
+++ b/packages/ui/src/editor/MarkdownSourceEditor.test.ts
@@ -34,6 +34,21 @@ describe("MarkdownSourceEditor document helpers", () => {
 		});
 	});
 
+	it("stores HTML with HTML syntax highlighting", () => {
+		const html = "<!doctype html>\n<title>Test</title>";
+
+		expect(sourceDocFromMarkdown(html, "html")).toEqual({
+			type: "doc",
+			content: [
+				{
+					type: "codeBlock",
+					attrs: { language: "html" },
+					content: [{ type: "text", text: html }],
+				},
+			],
+		});
+	});
+
 	it("reads the whole markdown file back from the code block", () => {
 		const markdown = "---\ntitle: Test\n---\n\n# Hello\n\nBody";
 		const editor = new Editor({

--- a/packages/ui/src/editor/MarkdownSourceEditor.tsx
+++ b/packages/ui/src/editor/MarkdownSourceEditor.tsx
@@ -17,6 +17,7 @@ const SourceDocument = Document.extend({ content: "codeBlock" });
 export type MarkdownSourceEditorProps = {
 	path: string;
 	initialMarkdown: string;
+	sourceLanguage?: "html" | "md";
 	saveDebounceMs?: number;
 	onLocalChange: (path: string, markdown: string) => void;
 	onSave: (path: string, markdown: string) => void | Promise<void>;
@@ -26,6 +27,7 @@ export type MarkdownSourceEditorProps = {
 export function MarkdownSourceEditor({
 	path,
 	initialMarkdown,
+	sourceLanguage = "md",
 	saveDebounceMs = DEFAULT_SAVE_DEBOUNCE_MS,
 	onLocalChange,
 	onSave,
@@ -56,9 +58,9 @@ export function MarkdownSourceEditor({
 		extensions: [
 			SourceDocument,
 			StarterKit.configure({ codeBlock: false, document: false }),
-			HubbleCodeBlock.configure({ defaultLanguage: "md" }),
+			HubbleCodeBlock.configure({ defaultLanguage: sourceLanguage }),
 		],
-		content: sourceDocFromMarkdown(initialMarkdown),
+		content: sourceDocFromMarkdown(initialMarkdown, sourceLanguage),
 		onUpdate: ({ editor: current }) => {
 			const markdown = markdownFromSourceDoc(current);
 			latestMarkdownRef.current = markdown;
@@ -68,7 +70,8 @@ export function MarkdownSourceEditor({
 		editorProps: {
 			attributes: {
 				"data-editor-input": "",
-				"aria-label": "Markdown source",
+				"aria-label":
+					sourceLanguage === "html" ? "HTML source" : "Markdown source",
 			},
 		},
 	});
@@ -82,10 +85,13 @@ export function MarkdownSourceEditor({
 		if (!editor) return;
 		if (initialMarkdown === latestMarkdownRef.current) return;
 		latestMarkdownRef.current = initialMarkdown;
-		editor.commands.setContent(sourceDocFromMarkdown(initialMarkdown), {
-			emitUpdate: false,
-		});
-	}, [editor, initialMarkdown]);
+		editor.commands.setContent(
+			sourceDocFromMarkdown(initialMarkdown, sourceLanguage),
+			{
+				emitUpdate: false,
+			},
+		);
+	}, [editor, initialMarkdown, sourceLanguage]);
 
 	useEffect(() => {
 		// Path changes flush the pending edit before the next document takes over.
@@ -111,13 +117,16 @@ export function MarkdownSourceEditor({
 	);
 }
 
-export function sourceDocFromMarkdown(markdown: string): JSONContent {
+export function sourceDocFromMarkdown(
+	markdown: string,
+	language: "html" | "md" = "md",
+): JSONContent {
 	return {
 		type: "doc",
 		content: [
 			{
 				type: "codeBlock",
-				attrs: { language: "md" },
+				attrs: { language },
 				content: markdown.length > 0 ? [{ type: "text", text: markdown }] : [],
 			},
 		],


### PR DESCRIPTION
## Description

Allow HTML Apps to switch between the rendered app and editable HTML source through the file menu or source-mode shortcut. Source editing uses HTML highlighting and an accessible HTML label.

https://github.com/user-attachments/assets/1af77bdb-e026-4cda-8de7-1b2c84706d57


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update

## Testing

- [x] Existing tests pass
- [x] Added new tests for changes
- [ ] Tested manually

**Manual Testing Details:**

Not manually tested.

## Checklist

- [ ] I discussed this change in a GitHub issue before submitting this PR
- [x] I have run the linter, formatter, and tests to ensure my code is ready for review