### PR TITLE
Polish sidebar drag-and-drop feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 
 ### Changed
 
+- Dragging files in the sidebar now shows what you're moving: a "Move 3 items" label for a selected group, the whole group dimmed as it travels, and a clearer highlight on the folder or workspace root you're dropping into. [#155](https://github.com/bholmesdev/hubble.md/issues/155)
+
 ### Fixed
 
 ## [0.1.21] - 2026-07-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 
 ### Changed
 
-- Dragging files in the sidebar now shows what you're moving: a "Move 3 items" label for a selected group, the whole group dimmed as it travels, and a clearer highlight on the folder or workspace root you're dropping into. [#155](https://github.com/bholmesdev/hubble.md/issues/155)
+- Dragging files in the sidebar now shows what you're moving: a "Move 3 items" label for a selected group, the whole group dimmed as it travels, and a clearer highlight on the folder or workspace root you're dropping into. Thanks [@zcuric](https://github.com/zcuric)! [#198](https://github.com/bholmesdev/hubble.md/pull/198)
 
 ### Fixed
 

--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -1422,7 +1422,7 @@ function FolderSegmentLabel({
 				<FolderSegment
 					active={isActiveSegmentDrop(dropTarget, segment.id)}
 					key={segment.id}
-					enabled={enabled}
+					enabled={enabled && row.segments.length > 1}
 					segment={segment}
 					separator={index > 0}
 				/>

--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -845,6 +845,7 @@ export function Sidebar({
 		>
 			<DroppableSidebarNav
 				ref={navRef}
+				active={isRootDropTarget(dropTarget)}
 				enabled={Boolean(onMoveItem)}
 				onKeyDown={handleTreeKeyDown}
 			>
@@ -933,6 +934,7 @@ export function Sidebar({
 									data-selected={isSelected ? "true" : undefined}
 									className={cn(
 										"group/sidebar-row relative flex w-full items-center text-sidebar-foreground",
+										"transition-[background-color,opacity,filter] duration-150 ease-out motion-reduce:transition-none",
 										!isActive &&
 											isSelected &&
 											"bg-selected text-selected-foreground",
@@ -959,10 +961,12 @@ export function Sidebar({
 												: "rounded-[var(--radius-row)]",
 										isRenaming && "relative z-30",
 										isPinnedSectionEnd && "mb-3",
+										// Fade the whole dragged group so a multi-row drag reads
+										// as one move, not just the row under the cursor
 										rowKey &&
 											activeDragKeys.has(rowKey) &&
 											!dropGroup &&
-											"grayscale",
+											"opacity-60 grayscale",
 										isDragging && "opacity-50",
 									)}
 									onPointerEnter={() => setFocusedIndex(index)}
@@ -1185,7 +1189,9 @@ export function Sidebar({
 			>
 				{activeDragLabel ? (
 					<div className="inline-flex w-max max-w-48 truncate rounded-sm border border-sidebar-border bg-sidebar px-1.5 py-0.5 text-[10px] text-sidebar-foreground shadow-overlay">
-						{fileNameFromPath(activeDragLabel)}
+						{activeDragKeys.size > 1
+							? `Move ${activeDragKeys.size} items`
+							: fileNameFromPath(activeDragLabel)}
 					</div>
 				) : null}
 			</DragOverlay>
@@ -1319,11 +1325,12 @@ function DraggableSidebarRow({
 const DroppableSidebarNav = forwardRef<
 	HTMLDivElement,
 	{
+		active: boolean;
 		children: ReactNode;
 		enabled: boolean;
 		onKeyDown: (event: ReactKeyboardEvent<HTMLDivElement>) => void;
 	}
->(function DroppableSidebarNav({ children, enabled, onKeyDown }, ref) {
+>(function DroppableSidebarNav({ active, children, enabled, onKeyDown }, ref) {
 	const { setNodeRef } = useDroppable({
 		id: "sidebar-drop:root",
 		data: { folderId: null } satisfies DropTargetData,
@@ -1338,7 +1345,11 @@ const DroppableSidebarNav = forwardRef<
 		<div
 			ref={setRefs}
 			role="tree"
-			className="flex-1 overflow-y-auto overscroll-contain px-1.5 py-1 outline-none"
+			className={cn(
+				"flex-1 overflow-y-auto overscroll-contain px-1.5 py-1 outline-none",
+				"rounded-[var(--radius-row)] inset-ring-1 inset-ring-transparent transition-[box-shadow] duration-150 ease-out motion-reduce:transition-none",
+				active && "inset-ring-sidebar-accent/70",
+			)}
 			tabIndex={0}
 			onKeyDown={onKeyDown}
 			data-sidebar-nav
@@ -1461,7 +1472,7 @@ function FolderSegment({
 			<span
 				ref={setRefs}
 				className={cn(
-					"min-w-0 truncate rounded-sm",
+					"min-w-0 truncate rounded-sm transition-colors duration-150 ease-out motion-reduce:transition-none",
 					active && "bg-sidebar-accent/70",
 				)}
 				{...attributes}
@@ -1471,6 +1482,11 @@ function FolderSegment({
 			</span>
 		</>
 	);
+}
+
+// Root drops have no folder to highlight, so the tree itself becomes the target
+function isRootDropTarget(target: DropTarget | null) {
+	return target !== null && target.folderId === null;
 }
 
 function isActiveSegmentDrop(target: DropTarget | null, segmentId: string) {


### PR DESCRIPTION
## Description

Visual-only polish for sidebar drag-and-drop, so a drag communicates what it will move before you drop it.

- The drag overlay reads `Move N items` when a multi-selected group is dragged; single-row drags keep the filename/folder label.
- The whole dragged group fades (`opacity-60 grayscale`), not just the row under the cursor, so a group move reads as one move.
- Drop-target highlights (rows, folder path segments) transition instead of snapping.
- Dropping into the workspace root now rings the tree itself, so root feels like a deliberate target rather than "not over a folder".
- All added transitions are wrapped in `motion-reduce:transition-none`.

No behavior change: which files/folders move, how selection works, and invalid-move filtering are untouched.

Closes #155

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update

## Testing

- [x] Existing tests pass
- [ ] Added new tests for changes
- [x] Tested manually (describe below)

**Manual Testing Details:**

`pnpm check` and `pnpm build:desktop` (biome, builds, typecheck) pass.

Manually verified in the running desktop app (`HUBBLE_DESKTOP_ENABLE_CDP=1 pnpm dev:desktop`, driven over CDP with real pointer events):

- Multi-selected 3 files, dragged over a collapsed folder → overlay showed `Move 3 items`, all 3 source rows dimmed, the folder row highlighted.
- Dragged the same group over root-level rows → the tree picked up the root ring alongside the existing root-row highlight.
- Cancelled the drag → selection and file positions unchanged, all drag styling cleared.
- Single-row drags still show the filename chip.

This is styling-only, so no unit tests were added; the existing sidebar selection/tree tests still pass.

## Checklist

- [x] I discussed this change in a GitHub issue before submitting this PR
- [x] I have run the linter, formatter, and tests to ensure my code is ready for review




https://github.com/user-attachments/assets/2622e235-1a91-468b-8df0-1260dc6b4e00

