### PR TITLE
Prototype: command mode for the global palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 
 ### Added
 
+- Run any Hubble command from the search palette. Press Cmd+P and type `/` to switch from searching notes to running commands by name — including ones with no menu entry at all, like Reveal in File Manager and Chat About This Note. Each row shows its keyboard shortcut, search matches synonyms (`finder` finds Reveal), and the commands you use most stay at the top. [#208](https://github.com/bholmesdev/hubble.md/issues/208)
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 
 ### Added
 
-- Run any Hubble command from the search palette. Press Cmd+P and type `/` to switch from searching notes to running commands by name — including ones with no menu entry at all, like Reveal in File Manager and Chat About This Note. Each row shows its keyboard shortcut, search matches synonyms (`finder` finds Reveal), and the commands you use most stay at the top. [#208](https://github.com/bholmesdev/hubble.md/issues/208)
+- Find and run Hubble commands alongside note results in the search palette. Thanks [@zcuric](https://github.com/zcuric)! [#209](https://github.com/bholmesdev/hubble.md/pull/209)
 
 ### Changed
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1783,6 +1783,16 @@ function registerIpc() {
 		() => mainWindow?.isFullScreen() ?? false,
 	);
 
+	// Same operations the View menu's zoom items run, exposed so the command
+	// palette can dispatch them. The accelerators stay owned by the menu.
+	ipcMain.handle("desktop:zoom-window", (_event, { direction }) => {
+		if (direction === "reset") {
+			resetWindowZoom(mainWindow);
+			return;
+		}
+		stepWindowZoom(mainWindow, direction === "out" ? -zoomStep : zoomStep);
+	});
+
 	ipcMain.handle("desktop:check-for-updates", async () => {
 		await checkForUpdates();
 	});

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1785,7 +1785,14 @@ function registerIpc() {
 
 	// Same operations the View menu's zoom items run, exposed so the command
 	// palette can dispatch them. The accelerators stay owned by the menu.
-	ipcMain.handle("desktop:zoom-window", (_event, { direction }) => {
+	ipcMain.handle("desktop:zoom-window", (_event, input: unknown) => {
+		const direction =
+			typeof input === "object" && input !== null && "direction" in input
+				? input.direction
+				: undefined;
+		if (direction !== "in" && direction !== "out" && direction !== "reset") {
+			throw new Error("Invalid zoom direction");
+		}
 		if (direction === "reset") {
 			resetWindowZoom(mainWindow);
 			return;

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1783,8 +1783,6 @@ function registerIpc() {
 		() => mainWindow?.isFullScreen() ?? false,
 	);
 
-	// Same operations the View menu's zoom items run, exposed so the command
-	// palette can dispatch them. The accelerators stay owned by the menu.
 	ipcMain.handle("desktop:zoom-window", (_event, input: unknown) => {
 		const direction =
 			typeof input === "object" && input !== null && "direction" in input

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -118,6 +118,8 @@ const desktopApi = {
 	recordTelemetryActivity: (input) =>
 		ipcRenderer.invoke("desktop:record-telemetry-activity", input),
 	getFullScreen: () => ipcRenderer.invoke("desktop:get-fullscreen"),
+	zoomWindow: (direction) =>
+		ipcRenderer.invoke("desktop:zoom-window", { direction }),
 	checkForUpdates: () => ipcRenderer.invoke("desktop:check-for-updates"),
 	installUpdate: () => ipcRenderer.invoke("desktop:install-update"),
 	onOpenFile: (callback) =>

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -242,8 +242,6 @@ function App() {
 		}));
 	const lastSeenVersion = useStoreValue(lastSeenVersionStore);
 	const pinnedNotes = useStoreValue(workspaceStore).pinnedNotes;
-	// The root class is the resolved theme, including live OS changes while the
-	// preference is "system".
 	const isDark = useSyncExternalStore(
 		subscribeToResolvedTheme,
 		isResolvedThemeDark,

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -18,7 +18,7 @@ import {
 } from "@hubble.md/ui";
 import { useStoreValue } from "@simplestack/store/react";
 import { keymatch } from "keymatch";
-import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
+import { useEffect, useState, useSyncExternalStore } from "react";
 import { toast } from "sonner";
 import MingcutePencilLine from "~icons/mingcute/pencil-line";
 import {
@@ -221,11 +221,11 @@ function App() {
 		useState<TelemetryConsent | null>(null);
 	const [focusedSidebarItem, setFocusedSidebarItem] =
 		useState<DesktopSidebarFocus>(null);
-	const updateFocusedSidebarItem = useCallback((next: DesktopSidebarFocus) => {
+	const updateFocusedSidebarItem = (next: DesktopSidebarFocus) => {
 		setFocusedSidebarItem((current) =>
 			sameSidebarFocus(current, next) ? current : next,
 		);
-	}, []);
+	};
 	const [dismissedVersion, setDismissedVersion] = useState<string | null>(null);
 	const [searchOpen, setSearchOpen] = useState(false);
 	const [searchFolderParent, setSearchFolderParent] = useState<string | null>(
@@ -254,13 +254,10 @@ function App() {
 		focusedSidebarItem,
 		workspacePath,
 	);
-	const changeSearchOpen = useCallback(
-		(open: boolean) => {
-			if (open) setSearchFolderParent(focusedFolderParent ?? null);
-			setSearchOpen(open);
-		},
-		[focusedFolderParent],
-	);
+	const changeSearchOpen = (open: boolean) => {
+		if (open) setSearchFolderParent(focusedFolderParent ?? null);
+		setSearchOpen(open);
+	};
 	const paletteCommands = buildAppCommands(
 		{
 			openSettings: () => setSettingsOpen(true),
@@ -482,6 +479,7 @@ function App() {
 		};
 		window.addEventListener("keydown", onKeyDown);
 		return () => window.removeEventListener("keydown", onKeyDown);
+		// biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler stabilizes render-local callbacks.
 	}, [changeSearchOpen, focusedSidebarPath]);
 
 	useEffect(() => {
@@ -548,6 +546,7 @@ function App() {
 		return () => {
 			for (const dispose of disposers) dispose();
 		};
+		// biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler stabilizes render-local callbacks.
 	}, [changeSearchOpen]);
 
 	useEffect(() => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -8,8 +8,10 @@ import {
 	classifyHref,
 	EditorView,
 	GlobalSearchPalette,
+	getActiveEditor,
 	Input,
 	MarkdownSourceEditor,
+	OPEN_COMMAND_PALETTE_EVENT,
 	type PaletteFile,
 	PlainTextEditor,
 	type WikiTarget,
@@ -365,6 +367,13 @@ function App() {
 
 	useEffect(() => {
 		const onKeyDown = async (event: KeyboardEvent) => {
+			if (keymatch(event, getCommand("app.format-menu").defaultBinding)) {
+				const editor = getActiveEditor();
+				if (editor?.isFocused && !editor.state.selection.empty) return;
+				event.preventDefault();
+				window.dispatchEvent(new CustomEvent(OPEN_COMMAND_PALETTE_EVENT));
+				return;
+			}
 			const currentPath = focusedSidebarPath ?? viewerStore.get().currentPath;
 			// Chat targets the note open in the viewer, not the sidebar focus.
 			const viewerPath = viewerStore.get().currentPath;

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -382,6 +382,7 @@ function App() {
 
 	useEffect(() => {
 		const onKeyDown = async (event: KeyboardEvent) => {
+			if (event.defaultPrevented) return;
 			if (keymatch(event, getCommand("app.format-menu").defaultBinding)) {
 				const editor = getActiveEditor();
 				if (editor?.isFocused && !editor.state.selection.empty) return;

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -22,7 +22,7 @@ import { useEffect, useState, useSyncExternalStore } from "react";
 import { toast } from "sonner";
 import MingcutePencilLine from "~icons/mingcute/pencil-line";
 import {
-	loadRecentCommands,
+	recentCommandIdsStore,
 	recordRecentCommand,
 } from "./commands/recentCommands";
 import { buildAppCommands } from "./commands/useAppCommands";
@@ -219,7 +219,7 @@ function App() {
 	const [searchFolderParent, setSearchFolderParent] = useState<string | null>(
 		null,
 	);
-	const [recentCommandIds, setRecentCommandIds] = useState(loadRecentCommands);
+	const recentCommandIds = useStoreValue(recentCommandIdsStore);
 	const workspaceFiles = useStoreValue(workspaceStore).files;
 	const paletteFiles: PaletteFile[] = workspaceFiles
 		.filter((file) => (file.kind ?? fileKindForPath(file.path)) === "document")
@@ -746,9 +746,7 @@ function App() {
 				searchContents={searchFileContents}
 				commands={paletteCommands}
 				recentCommandIds={recentCommandIds}
-				onRunCommand={(id) =>
-					setRecentCommandIds((current) => recordRecentCommand(id, current))
-				}
+				onRunCommand={recordRecentCommand}
 			/>
 			<SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen}>
 				<GeneralSettingsSection />

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -19,6 +19,11 @@ import { keymatch } from "keymatch";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import MingcutePencilLine from "~icons/mingcute/pencil-line";
+import {
+	loadRecentCommands,
+	recordRecentCommand,
+} from "./commands/recentCommands";
+import { buildAppCommands } from "./commands/useAppCommands";
 import { HtmlAppEmptyState } from "./components/HtmlAppEmptyState";
 import { SettingsDialog, SettingsSection } from "./components/SettingsDialog";
 import { Sidebar } from "./components/Sidebar";
@@ -186,6 +191,7 @@ function App() {
 	);
 	const [dismissedVersion, setDismissedVersion] = useState<string | null>(null);
 	const [searchOpen, setSearchOpen] = useState(false);
+	const [recentCommandIds, setRecentCommandIds] = useState(loadRecentCommands);
 	const workspaceFiles = useStoreValue(workspaceStore).files;
 	const paletteFiles: PaletteFile[] = workspaceFiles
 		.filter((file) => (file.kind ?? fileKindForPath(file.path)) === "document")
@@ -195,6 +201,30 @@ function App() {
 			modifiedAt: file.modified_at,
 		}));
 	const lastSeenVersion = useStoreValue(lastSeenVersionStore);
+	const pinnedNotes = useStoreValue(workspaceStore).pinnedNotes;
+	// Read the resolved class rather than the preference, so "system" toggles
+	// away from what the user is actually looking at.
+	const isDark =
+		typeof document !== "undefined" &&
+		document.documentElement.classList.contains("dark");
+	const paletteCommands = buildAppCommands(
+		{
+			openSettings: () => setSettingsOpen(true),
+			requestCopyAsMarkdown: () =>
+				setCopyAsMarkdownRequest((request) => request + 1),
+			focusSidebar: focusSidebarNav,
+		},
+		{
+			currentPath: state.currentPath ?? null,
+			workspacePath: workspacePath ?? null,
+			isSourceMode: state.viewMode === "source",
+			sidebarOpen,
+			isDark,
+			isPinned: state.currentPath
+				? pinnedNotes.includes(state.currentPath)
+				: false,
+		},
+	);
 
 	const readyVersion =
 		updateState?.status === "ready"
@@ -666,6 +696,11 @@ function App() {
 				files={paletteFiles}
 				onSelectFile={(path) => void loadPath(path)}
 				searchContents={searchFileContents}
+				commands={paletteCommands}
+				recentCommandIds={recentCommandIds}
+				onRunCommand={(id) =>
+					setRecentCommandIds((current) => recordRecentCommand(id, current))
+				}
 			/>
 			<SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen}>
 				<GeneralSettingsSection />

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -18,7 +18,7 @@ import {
 } from "@hubble.md/ui";
 import { useStoreValue } from "@simplestack/store/react";
 import { keymatch } from "keymatch";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useSyncExternalStore } from "react";
 import { toast } from "sonner";
 import MingcutePencilLine from "~icons/mingcute/pencil-line";
 import {
@@ -119,6 +119,19 @@ const HMR_REV = (() => {
 	return hotData.__editorRev;
 })();
 
+function subscribeToResolvedTheme(onChange: () => void) {
+	const observer = new MutationObserver(onChange);
+	observer.observe(document.documentElement, {
+		attributeFilter: ["class"],
+		attributes: true,
+	});
+	return () => observer.disconnect();
+}
+
+function isResolvedThemeDark() {
+	return document.documentElement.classList.contains("dark");
+}
+
 function focusSidebarNav() {
 	document.querySelector<HTMLElement>(SIDEBAR_NAV_SELECTOR)?.focus();
 }
@@ -204,11 +217,13 @@ function App() {
 		}));
 	const lastSeenVersion = useStoreValue(lastSeenVersionStore);
 	const pinnedNotes = useStoreValue(workspaceStore).pinnedNotes;
-	// Read the resolved class rather than the preference, so "system" toggles
-	// away from what the user is actually looking at.
-	const isDark =
-		typeof document !== "undefined" &&
-		document.documentElement.classList.contains("dark");
+	// The root class is the resolved theme, including live OS changes while the
+	// preference is "system".
+	const isDark = useSyncExternalStore(
+		subscribeToResolvedTheme,
+		isResolvedThemeDark,
+		() => false,
+	);
 	const paletteCommands = buildAppCommands(
 		{
 			openSettings: () => setSettingsOpen(true),

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -111,6 +111,7 @@ import {
 	workspacePathStore,
 	workspaceStore,
 } from "./store/state";
+import { isDarkTheme, subscribeTheme } from "./theme";
 
 // Forces editor refresh when underlying TipTap extensions change
 const HMR_REV = (() => {
@@ -119,19 +120,6 @@ const HMR_REV = (() => {
 	hotData.__editorRev = (hotData.__editorRev ?? 0) + 1;
 	return hotData.__editorRev;
 })();
-
-function subscribeToResolvedTheme(onChange: () => void) {
-	const observer = new MutationObserver(onChange);
-	observer.observe(document.documentElement, {
-		attributeFilter: ["class"],
-		attributes: true,
-	});
-	return () => observer.disconnect();
-}
-
-function isResolvedThemeDark() {
-	return document.documentElement.classList.contains("dark");
-}
 
 function sameSidebarFocus(
 	current: DesktopSidebarFocus,
@@ -242,11 +230,7 @@ function App() {
 		}));
 	const lastSeenVersion = useStoreValue(lastSeenVersionStore);
 	const pinnedNotes = useStoreValue(workspaceStore).pinnedNotes;
-	const isDark = useSyncExternalStore(
-		subscribeToResolvedTheme,
-		isResolvedThemeDark,
-		() => false,
-	);
+	const isDark = useSyncExternalStore(subscribeTheme, isDarkTheme, () => false);
 	const focusedSidebarPath = focusedSidebarItem
 		? focusedSidebarItem.path
 		: null;

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -18,7 +18,7 @@ import {
 } from "@hubble.md/ui";
 import { useStoreValue } from "@simplestack/store/react";
 import { keymatch } from "keymatch";
-import { useEffect, useState, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
 import { toast } from "sonner";
 import MingcutePencilLine from "~icons/mingcute/pencil-line";
 import {
@@ -28,7 +28,7 @@ import {
 import { buildAppCommands } from "./commands/useAppCommands";
 import { HtmlAppEmptyState } from "./components/HtmlAppEmptyState";
 import { SettingsDialog, SettingsSection } from "./components/SettingsDialog";
-import { Sidebar } from "./components/Sidebar";
+import { type DesktopSidebarFocus, Sidebar } from "./components/Sidebar";
 import {
 	TelemetryConsentCallout,
 	TelemetrySettingsSection,
@@ -51,6 +51,7 @@ import { createHtmlFile, createMarkdownFile } from "./fileActions";
 import { isChangelogPath } from "./lib/changelogNote";
 import { copyText } from "./lib/clipboard";
 import {
+	dirname,
 	fileKindForPath,
 	hasHtmlExtension,
 	hasImageExtension,
@@ -132,6 +133,23 @@ function isResolvedThemeDark() {
 	return document.documentElement.classList.contains("dark");
 }
 
+function sameSidebarFocus(
+	current: DesktopSidebarFocus,
+	next: DesktopSidebarFocus,
+) {
+	if (!current || !next) return current === next;
+	return current.kind === next.kind && current.path === next.path;
+}
+
+function folderForSidebarFocus(
+	item: DesktopSidebarFocus,
+	workspacePath: string | null | undefined,
+) {
+	if (!item) return workspacePath ?? null;
+	if (item.kind === "folder") return item.path;
+	return dirname(item.path) ?? workspacePath ?? null;
+}
+
 function focusSidebarNav() {
 	document.querySelector<HTMLElement>(SIDEBAR_NAV_SELECTOR)?.focus();
 }
@@ -201,11 +219,18 @@ function App() {
 	);
 	const [telemetryConsent, setTelemetryConsent] =
 		useState<TelemetryConsent | null>(null);
-	const [focusedSidebarPath, setFocusedSidebarPath] = useState<string | null>(
-		null,
-	);
+	const [focusedSidebarItem, setFocusedSidebarItem] =
+		useState<DesktopSidebarFocus>(null);
+	const updateFocusedSidebarItem = useCallback((next: DesktopSidebarFocus) => {
+		setFocusedSidebarItem((current) =>
+			sameSidebarFocus(current, next) ? current : next,
+		);
+	}, []);
 	const [dismissedVersion, setDismissedVersion] = useState<string | null>(null);
 	const [searchOpen, setSearchOpen] = useState(false);
+	const [searchFolderParent, setSearchFolderParent] = useState<string | null>(
+		null,
+	);
 	const [recentCommandIds, setRecentCommandIds] = useState(loadRecentCommands);
 	const workspaceFiles = useStoreValue(workspaceStore).files;
 	const paletteFiles: PaletteFile[] = workspaceFiles
@@ -224,6 +249,20 @@ function App() {
 		isResolvedThemeDark,
 		() => false,
 	);
+	const focusedSidebarPath = focusedSidebarItem
+		? focusedSidebarItem.path
+		: null;
+	const focusedFolderParent = folderForSidebarFocus(
+		focusedSidebarItem,
+		workspacePath,
+	);
+	const changeSearchOpen = useCallback(
+		(open: boolean) => {
+			if (open) setSearchFolderParent(focusedFolderParent ?? null);
+			setSearchOpen(open);
+		},
+		[focusedFolderParent],
+	);
 	const paletteCommands = buildAppCommands(
 		{
 			openSettings: () => setSettingsOpen(true),
@@ -233,6 +272,9 @@ function App() {
 		},
 		{
 			currentPath: state.currentPath ?? null,
+			newFolderParent: searchOpen
+				? searchFolderParent
+				: (focusedFolderParent ?? null),
 			workspacePath: workspacePath ?? null,
 			isSourceMode: state.viewMode === "source",
 			sidebarOpen,
@@ -377,7 +419,7 @@ function App() {
 	]);
 
 	useEffect(() => {
-		if (!sidebarOpen) setFocusedSidebarPath(null);
+		if (!sidebarOpen) setFocusedSidebarItem(null);
 	}, [sidebarOpen]);
 
 	useEffect(() => {
@@ -413,7 +455,7 @@ function App() {
 				"app.settings": () => setSettingsOpen(true),
 				"app.open-folder": () => setWorkspaceSwitcherOpen(true),
 				// The File menu accelerator fires too, but opening is idempotent.
-				"app.go-to-file": () => setSearchOpen(true),
+				"app.go-to-file": () => changeSearchOpen(true),
 				"app.add-folder": openWorkspaceWithSidebar,
 				"app.open-file": openFilePicker,
 				"app.copy-path": () => copyFilePath(currentPath),
@@ -442,7 +484,7 @@ function App() {
 		};
 		window.addEventListener("keydown", onKeyDown);
 		return () => window.removeEventListener("keydown", onKeyDown);
-	}, [focusedSidebarPath]);
+	}, [changeSearchOpen, focusedSidebarPath]);
 
 	useEffect(() => {
 		let active = true;
@@ -489,7 +531,7 @@ function App() {
 			desktopApi.onMenuShowWorkspaceSwitcher(() =>
 				setWorkspaceSwitcherOpen(true),
 			),
-			desktopApi.onMenuGoToFile(() => setSearchOpen(true)),
+			desktopApi.onMenuGoToFile(() => changeSearchOpen(true)),
 			desktopApi.onMenuSyncWorkspace(() => void refreshFiles()),
 			desktopApi.onMenuToggleTerminal(() => toggleTerminal()),
 			desktopApi.onMenuGoBack(() => void goBack()),
@@ -508,7 +550,7 @@ function App() {
 		return () => {
 			for (const dispose of disposers) dispose();
 		};
-	}, []);
+	}, [changeSearchOpen]);
 
 	useEffect(() => {
 		// Window focus can fire in bursts when switching apps, so debounce the
@@ -624,7 +666,7 @@ function App() {
 			/>
 			<div className="flex min-h-0 flex-1 overflow-hidden">
 				<Sidebar
-					onFocusedPathChange={setFocusedSidebarPath}
+					onFocusedItemChange={updateFocusedSidebarItem}
 					footer={
 						showReadyCallout ? (
 							<SidebarCallout
@@ -717,7 +759,7 @@ function App() {
 			</div>
 			<GlobalSearchPalette
 				open={searchOpen}
-				onOpenChange={setSearchOpen}
+				onOpenChange={changeSearchOpen}
 				files={paletteFiles}
 				onSelectFile={(path) => void loadPath(path)}
 				searchContents={searchFileContents}

--- a/apps/desktop/src/commands/recentCommands.ts
+++ b/apps/desktop/src/commands/recentCommands.ts
@@ -1,7 +1,10 @@
+import { store } from "@simplestack/store";
+import { localStoragePersist } from "../lib/localStoragePersist";
+
 const STORAGE_KEY = "hubble-desktop-recent-commands";
 const MAX_RECENT = 40;
 
-export function loadRecentCommands(): string[] {
+function loadRecentCommands(): string[] {
 	if (typeof localStorage === "undefined") return [];
 	try {
 		const raw = localStorage.getItem(STORAGE_KEY);
@@ -14,19 +17,14 @@ export function loadRecentCommands(): string[] {
 	}
 }
 
-export function recordRecentCommand(id: string, current: string[]): string[] {
-	const next = [id, ...current.filter((existing) => existing !== id)].slice(
-		0,
-		MAX_RECENT,
+export const recentCommandIdsStore = store<string[]>(loadRecentCommands(), {
+	middleware: [localStoragePersist(STORAGE_KEY)],
+});
+
+export function recordRecentCommand(id: string) {
+	recentCommandIdsStore.set((current) =>
+		[id, ...current.filter((existing) => existing !== id)].slice(0, MAX_RECENT),
 	);
-	if (typeof localStorage !== "undefined") {
-		try {
-			localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
-		} catch {
-			// Recency is optional.
-		}
-	}
-	return next;
 }
 
 export { STORAGE_KEY as RECENT_COMMANDS_STORAGE_KEY };

--- a/apps/desktop/src/commands/recentCommands.ts
+++ b/apps/desktop/src/commands/recentCommands.ts
@@ -1,0 +1,46 @@
+const STORAGE_KEY = "hubble-desktop-recent-commands";
+const MAX_RECENT = 40;
+
+/**
+ * Most-recently-run command ids, newest first.
+ *
+ * Kept in its own storage key rather than in the app store: this is palette
+ * ranking state, not app state, and nothing outside the palette reads it. When
+ * the command registry lands it can move alongside the shortcut preferences
+ * (#194) without changing the shape stored here.
+ *
+ * A plain recency list rather than a decayed frequency score. Recency alone
+ * already produces the "the palette learned my habits" feel, and it cannot
+ * develop the stuck-favorite problem where an early burst of use pins a
+ * command to the top long after the user stopped reaching for it.
+ */
+export function loadRecentCommands(): string[] {
+	if (typeof localStorage === "undefined") return [];
+	try {
+		const raw = localStorage.getItem(STORAGE_KEY);
+		if (!raw) return [];
+		const parsed: unknown = JSON.parse(raw);
+		if (!Array.isArray(parsed)) return [];
+		return parsed.filter((id): id is string => typeof id === "string");
+	} catch {
+		return [];
+	}
+}
+
+/** Returns the next list so callers can update React state from the result. */
+export function recordRecentCommand(id: string, current: string[]): string[] {
+	const next = [id, ...current.filter((existing) => existing !== id)].slice(
+		0,
+		MAX_RECENT,
+	);
+	if (typeof localStorage !== "undefined") {
+		try {
+			localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+		} catch {
+			// A full or unavailable localStorage costs ranking quality, nothing more.
+		}
+	}
+	return next;
+}
+
+export { STORAGE_KEY as RECENT_COMMANDS_STORAGE_KEY };

--- a/apps/desktop/src/commands/recentCommands.ts
+++ b/apps/desktop/src/commands/recentCommands.ts
@@ -1,19 +1,6 @@
 const STORAGE_KEY = "hubble-desktop-recent-commands";
 const MAX_RECENT = 40;
 
-/**
- * Most-recently-run command ids, newest first.
- *
- * Kept in its own storage key rather than in the app store: this is palette
- * ranking state, not app state, and nothing outside the palette reads it. When
- * the command registry lands it can move alongside the shortcut preferences
- * (#194) without changing the shape stored here.
- *
- * A plain recency list rather than a decayed frequency score. Recency alone
- * already produces the "the palette learned my habits" feel, and it cannot
- * develop the stuck-favorite problem where an early burst of use pins a
- * command to the top long after the user stopped reaching for it.
- */
 export function loadRecentCommands(): string[] {
 	if (typeof localStorage === "undefined") return [];
 	try {
@@ -27,7 +14,6 @@ export function loadRecentCommands(): string[] {
 	}
 }
 
-/** Returns the next list so callers can update React state from the result. */
 export function recordRecentCommand(id: string, current: string[]): string[] {
 	const next = [id, ...current.filter((existing) => existing !== id)].slice(
 		0,
@@ -37,7 +23,7 @@ export function recordRecentCommand(id: string, current: string[]): string[] {
 		try {
 			localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
 		} catch {
-			// A full or unavailable localStorage costs ranking quality, nothing more.
+			// Recency is optional.
 		}
 	}
 	return next;

--- a/apps/desktop/src/commands/useAppCommands.ts
+++ b/apps/desktop/src/commands/useAppCommands.ts
@@ -113,6 +113,7 @@ function defineCommands(
 		run: () => void | Promise<void>,
 		options?: {
 			destructive?: boolean;
+			globalShortcut?: boolean;
 			label?: string;
 			isEnabled?: () => boolean;
 		},
@@ -125,6 +126,7 @@ function defineCommands(
 			keywords,
 			binding: command.defaultBinding,
 			destructive: options?.destructive,
+			globalShortcut: options?.globalShortcut ?? true,
 			isEnabled: options?.isEnabled ?? (() => command.isEnabled(registry)),
 			run,
 		};
@@ -146,6 +148,7 @@ function defineCommands(
 				runEditorAction(action);
 			},
 			{
+				globalShortcut: false,
 				// Registry editor commands are `always` enabled because the keymap only
 				// fires inside the editor. The palette has no such guard, so it adds one.
 				isEnabled: () => hasRichTextEditor(context),
@@ -209,7 +212,11 @@ function defineCommands(
 				if (!window.confirm(`Delete ${name}?`)) return;
 				await deleteMarkdownFile(path);
 			},
-			{ destructive: true, label: "Delete Note" },
+			{
+				destructive: true,
+				globalShortcut: false,
+				label: "Delete Note",
+			},
 		),
 
 		// ---- Navigate ----
@@ -312,6 +319,7 @@ function defineCommands(
 			group: "View",
 			keywords: ["bigger", "larger", "text size"],
 			binding: "CmdOrCtrl+=",
+			globalShortcut: true,
 			isEnabled: () => true,
 			run: () => desktopApi.zoomWindow("in"),
 		}),
@@ -321,6 +329,7 @@ function defineCommands(
 			group: "View",
 			keywords: ["smaller", "text size"],
 			binding: "CmdOrCtrl+-",
+			globalShortcut: true,
 			isEnabled: () => true,
 			run: () => desktopApi.zoomWindow("out"),
 		}),
@@ -330,6 +339,7 @@ function defineCommands(
 			group: "View",
 			keywords: ["actual size", "default"],
 			binding: "CmdOrCtrl+0",
+			globalShortcut: true,
 			isEnabled: () => true,
 			run: () => desktopApi.zoomWindow("reset"),
 		}),

--- a/apps/desktop/src/commands/useAppCommands.ts
+++ b/apps/desktop/src/commands/useAppCommands.ts
@@ -41,13 +41,6 @@ import { canGoBack, canGoForward } from "../store/history";
 const CONTRIBUTING_URL =
 	"https://github.com/bholmesdev/hubble.md/blob/main/CONTRIBUTING.md";
 
-/**
- * App state the palette needs, beyond what the registry's `CommandContext`
- * already covers.
- *
- * It includes targets for contextual actions and state used to label toggles
- * by what they will do, such as "Hide Sidebar" instead of "Toggle Sidebar".
- */
 export type AppCommandContext = {
 	currentPath: string | null;
 	newFolderParent: string | null;
@@ -58,17 +51,12 @@ export type AppCommandContext = {
 	isPinned: boolean;
 };
 
-/**
- * Side effects the palette cannot reach on its own, because they live in
- * `App`'s React state rather than in the store.
- */
 export type AppCommandActions = {
 	openSettings: () => void;
 	requestCopyAsMarkdown: () => void;
 	focusSidebar: () => void;
 };
 
-/** The subset of app state the registry's own predicates read. */
 function toRegistryContext(context: AppCommandContext): RegistryContext {
 	const path = context.currentPath;
 	const isRealFile = path !== null && !isChangelogPath(path);
@@ -83,7 +71,6 @@ function toRegistryContext(context: AppCommandContext): RegistryContext {
 	};
 }
 
-/** Rich text is being edited, so an editor command has somewhere to land. */
 function hasRichTextEditor(context: AppCommandContext) {
 	const path = context.currentPath;
 	return (
@@ -94,7 +81,7 @@ function hasRichTextEditor(context: AppCommandContext) {
 	);
 }
 
-type Declaration = Omit<PaletteCommand, "binding" | "shortcut"> & {
+type CommandDeclaration = Omit<PaletteCommand, "binding" | "shortcut"> & {
 	binding?: string;
 	isEnabled: () => boolean;
 };
@@ -102,21 +89,10 @@ type Declaration = Omit<PaletteCommand, "binding" | "shortcut"> & {
 function defineCommands(
 	actions: AppCommandActions,
 	context: AppCommandContext,
-): Declaration[] {
+): CommandDeclaration[] {
 	const path = context.currentPath;
 	const registry = toRegistryContext(context);
 
-	/**
-	 * Projects a registry entry into a palette row.
-	 *
-	 * Label, binding, and enablement come from the registry so the palette can
-	 * never disagree with the menu bar or the key handler about what a command
-	 * is called, what it is bound to, or when it applies. Only the palette's own
-	 * concerns — grouping, search synonyms, and the handler — are supplied here.
-	 *
-	 * `label` is overridden only for toggles, which the registry names by the
-	 * toggle rather than by the outcome.
-	 */
 	const fromRegistry = (
 		id: CommandId,
 		group: string,
@@ -128,7 +104,7 @@ function defineCommands(
 			label?: string;
 			isEnabled?: () => boolean;
 		},
-	): Declaration => {
+	): CommandDeclaration => {
 		const command = getCommand(id);
 		return {
 			id,
@@ -143,8 +119,8 @@ function defineCommands(
 		};
 	};
 
-	/** A palette-only action: real behavior, but no registry entry or binding. */
-	const local = (declaration: Declaration): Declaration => declaration;
+	const paletteOnly = (declaration: CommandDeclaration): CommandDeclaration =>
+		declaration;
 
 	const editorCommand = (
 		id: Extract<CommandId, `editor.${string}`>,
@@ -162,18 +138,17 @@ function defineCommands(
 			},
 			{
 				globalShortcut: false,
-				// Registry editor commands are `always` enabled because the keymap only
-				// fires inside the editor. The palette has no such guard, so it adds one.
+				// The registry assumes editor-local use.
 				isEnabled: () => hasRichTextEditor(context),
 			},
 		);
 
 	return [
-		// ---- File ----
+		// File
 		fromRegistry("app.new-file", "File", ["create", "markdown", "note"], () =>
 			createMarkdownFile(),
 		),
-		local({
+		paletteOnly({
 			id: "app.new-folder",
 			label: "New Folder",
 			group: "File",
@@ -220,9 +195,6 @@ function defineCommands(
 			async () => {
 				if (!path) return;
 				const name = basename(path);
-				// Matches the sidebar's confirm rather than introducing a second
-				// deletion flow. A palette is easy to trigger by accident, and the
-				// undo toast that follows is a safety net, not a substitute.
 				if (!window.confirm(`Delete ${name}?`)) return;
 				await deleteMarkdownFile(path);
 			},
@@ -233,7 +205,7 @@ function defineCommands(
 			},
 		),
 
-		// ---- Navigate ----
+		// Navigate
 		fromRegistry("app.go-back", "Navigate", ["history", "previous"], goBack),
 		fromRegistry("app.go-forward", "Navigate", ["history", "next"], goForward),
 		fromRegistry(
@@ -248,7 +220,7 @@ function defineCommands(
 			["workspace", "vault", "switch", "recent"],
 			() => setWorkspaceSwitcherOpen(true),
 		),
-		local({
+		paletteOnly({
 			id: "app.toggle-pinned",
 			label: context.isPinned ? "Unpin Note" : "Pin Note",
 			group: "Navigate",
@@ -259,7 +231,7 @@ function defineCommands(
 				if (path) await togglePinnedNote(path);
 			},
 		}),
-		local({
+		paletteOnly({
 			id: "app.focus-sidebar",
 			label: "Focus Sidebar",
 			group: "Navigate",
@@ -271,9 +243,8 @@ function defineCommands(
 			},
 		}),
 
-		// ---- Editor ----
-		// `editor.link` is omitted: it opens the link popover, which needs the
-		// selection the palette has just taken focus from.
+		// Editor
+		// The link popover needs the selection that the palette takes focus from.
 		editorCommand("editor.bold", "bold", ["strong", "format"]),
 		editorCommand("editor.italic", "italic", ["emphasis", "format"]),
 		editorCommand("editor.code", "code", ["monospace", "format"]),
@@ -296,7 +267,7 @@ function defineCommands(
 		]),
 		editorCommand("editor.blockquote", "blockquote", ["quote", "citation"]),
 
-		// ---- View ----
+		// View
 		fromRegistry(
 			"app.toggle-sidebar",
 			"View",
@@ -317,7 +288,7 @@ function defineCommands(
 			() => setViewerMode(context.isSourceMode ? "rich" : "source"),
 			{ label: context.isSourceMode ? "Edit Rich Text" : "Edit Source" },
 		),
-		local({
+		paletteOnly({
 			id: "view.toggle-theme",
 			label: context.isDark ? "Switch to Light Theme" : "Switch to Dark Theme",
 			group: "View",
@@ -325,9 +296,8 @@ function defineCommands(
 			isEnabled: () => true,
 			run: () => setThemePreference(context.isDark ? "light" : "dark"),
 		}),
-		// Zoom stays out of the registry by design (#193: OS convention, and `=`
-		// vs `+` differs per platform), so these carry their own hint strings.
-		local({
+		// Zoom bindings differ by platform, so they stay outside the registry.
+		paletteOnly({
 			id: "view.zoom-in",
 			label: "Zoom In",
 			group: "View",
@@ -337,7 +307,7 @@ function defineCommands(
 			isEnabled: () => true,
 			run: () => desktopApi.zoomWindow("in"),
 		}),
-		local({
+		paletteOnly({
 			id: "view.zoom-out",
 			label: "Zoom Out",
 			group: "View",
@@ -347,7 +317,7 @@ function defineCommands(
 			isEnabled: () => true,
 			run: () => desktopApi.zoomWindow("out"),
 		}),
-		local({
+		paletteOnly({
 			id: "view.zoom-reset",
 			label: "Reset Zoom",
 			group: "View",
@@ -358,7 +328,7 @@ function defineCommands(
 			run: () => desktopApi.zoomWindow("reset"),
 		}),
 
-		// ---- App ----
+		// App
 		fromRegistry(
 			"app.settings",
 			"App",
@@ -371,7 +341,7 @@ function defineCommands(
 			["agent", "ai", "claude", "codex", "terminal"],
 			requestChatAboutNote,
 		),
-		local({
+		paletteOnly({
 			id: "app.check-for-updates",
 			label: "Check for Updates",
 			group: "App",
@@ -387,7 +357,7 @@ function defineCommands(
 				}
 			},
 		}),
-		local({
+		paletteOnly({
 			id: "app.whats-new",
 			label: "What's New",
 			group: "App",
@@ -397,7 +367,7 @@ function defineCommands(
 				await openChangelog();
 			},
 		}),
-		local({
+		paletteOnly({
 			id: "app.contributing",
 			label: "Open Contributing Guide",
 			group: "App",
@@ -408,14 +378,6 @@ function defineCommands(
 	];
 }
 
-/**
- * Builds the palette's command list for the current context.
- *
- * Disabled commands are dropped rather than greyed out: a palette is a search
- * surface, and a result you can select but not run reads as a bug. The menu bar
- * still shows them disabled, which is where discoverability of *unavailable*
- * actions belongs.
- */
 export function buildAppCommands(
 	actions: AppCommandActions,
 	context: AppCommandContext,

--- a/apps/desktop/src/commands/useAppCommands.ts
+++ b/apps/desktop/src/commands/useAppCommands.ts
@@ -111,7 +111,11 @@ function defineCommands(
 		group: string,
 		keywords: string[],
 		run: () => void | Promise<void>,
-		options?: { label?: string; isEnabled?: () => boolean },
+		options?: {
+			destructive?: boolean;
+			label?: string;
+			isEnabled?: () => boolean;
+		},
 	): Declaration => {
 		const command = getCommand(id);
 		return {
@@ -120,6 +124,7 @@ function defineCommands(
 			group,
 			keywords,
 			binding: command.defaultBinding,
+			destructive: options?.destructive,
 			isEnabled: options?.isEnabled ?? (() => command.isEnabled(registry)),
 			run,
 		};
@@ -204,7 +209,7 @@ function defineCommands(
 				if (!window.confirm(`Delete ${name}?`)) return;
 				await deleteMarkdownFile(path);
 			},
-			{ label: "Delete Note" },
+			{ destructive: true, label: "Delete Note" },
 		),
 
 		// ---- Navigate ----

--- a/apps/desktop/src/commands/useAppCommands.ts
+++ b/apps/desktop/src/commands/useAppCommands.ts
@@ -99,7 +99,6 @@ function defineCommands(
 		keywords: string[],
 		run: () => void | Promise<void>,
 		options?: {
-			destructive?: boolean;
 			globalShortcut?: boolean;
 			label?: string;
 			isEnabled?: () => boolean;
@@ -112,7 +111,6 @@ function defineCommands(
 			group,
 			keywords,
 			binding: command.defaultBinding,
-			destructive: options?.destructive,
 			globalShortcut: options?.globalShortcut ?? true,
 			isEnabled: options?.isEnabled ?? (() => command.isEnabled(registry)),
 			run,
@@ -199,7 +197,6 @@ function defineCommands(
 				await deleteMarkdownFile(path);
 			},
 			{
-				destructive: true,
 				globalShortcut: false,
 				label: "Delete Note",
 			},

--- a/apps/desktop/src/commands/useAppCommands.ts
+++ b/apps/desktop/src/commands/useAppCommands.ts
@@ -1,0 +1,400 @@
+import {
+	type CommandId,
+	getCommand,
+	type CommandContext as RegistryContext,
+} from "@hubble.md/editor";
+import {
+	type EditorActionId,
+	formatShortcut,
+	type PaletteCommand,
+	runEditorAction,
+} from "@hubble.md/ui";
+import { toast } from "sonner";
+import { desktopApi } from "../desktopApi";
+import { createMarkdownFile } from "../fileActions";
+import { isChangelogPath } from "../lib/changelogNote";
+import { copyText } from "../lib/clipboard";
+import { isEditableFile } from "../lib/filePath";
+import {
+	createFolderInFolder,
+	deleteMarkdownFile,
+	goBack,
+	goForward,
+	openChangelog,
+	openWorkspaceWithSidebar,
+	requestChatAboutNote,
+	setSidebarOpen,
+	setThemePreference,
+	setViewerMode,
+	setWorkspaceSwitcherOpen,
+	togglePinnedNote,
+	toggleSidebar,
+	toggleTerminal,
+} from "../store/actions";
+import { canGoBack, canGoForward } from "../store/history";
+
+const CONTRIBUTING_URL =
+	"https://github.com/bholmesdev/hubble.md/blob/main/CONTRIBUTING.md";
+
+/**
+ * App state the palette needs, beyond what the registry's `CommandContext`
+ * already covers.
+ *
+ * The extra fields exist only to label toggles by what they will *do* — "Hide
+ * Sidebar" rather than "Toggle Sidebar" — so a user reading the list does not
+ * have to know the current state to predict the outcome.
+ */
+export type AppCommandContext = {
+	currentPath: string | null;
+	workspacePath: string | null;
+	isSourceMode: boolean;
+	sidebarOpen: boolean;
+	isDark: boolean;
+	isPinned: boolean;
+};
+
+/**
+ * Side effects the palette cannot reach on its own, because they live in
+ * `App`'s React state rather than in the store.
+ */
+export type AppCommandActions = {
+	openSettings: () => void;
+	requestCopyAsMarkdown: () => void;
+	focusSidebar: () => void;
+};
+
+/** The subset of app state the registry's own predicates read. */
+function toRegistryContext(context: AppCommandContext): RegistryContext {
+	const path = context.currentPath;
+	const isRealFile = path !== null && !isChangelogPath(path);
+	return {
+		hasCurrentFile: isRealFile,
+		hasEditableFile: isRealFile && isEditableFile(path),
+		hasWorkspace: context.workspacePath !== null,
+		isSourceMode: context.isSourceMode,
+		canGoBack: canGoBack(),
+		canGoForward: canGoForward(),
+	};
+}
+
+/** Rich text is being edited, so an editor command has somewhere to land. */
+function hasRichTextEditor(context: AppCommandContext) {
+	const registry = toRegistryContext(context);
+	return registry.hasEditableFile === true && !context.isSourceMode;
+}
+
+type Declaration = Omit<PaletteCommand, "shortcut"> & {
+	binding?: string;
+	isEnabled: () => boolean;
+};
+
+function defineCommands(
+	actions: AppCommandActions,
+	context: AppCommandContext,
+): Declaration[] {
+	const path = context.currentPath;
+	const registry = toRegistryContext(context);
+
+	/**
+	 * Projects a registry entry into a palette row.
+	 *
+	 * Label, binding, and enablement come from the registry so the palette can
+	 * never disagree with the menu bar or the key handler about what a command
+	 * is called, what it is bound to, or when it applies. Only the palette's own
+	 * concerns — grouping, search synonyms, and the handler — are supplied here.
+	 *
+	 * `label` is overridden only for toggles, which the registry names by the
+	 * toggle rather than by the outcome.
+	 */
+	const fromRegistry = (
+		id: CommandId,
+		group: string,
+		keywords: string[],
+		run: () => void | Promise<void>,
+		options?: { label?: string; isEnabled?: () => boolean },
+	): Declaration => {
+		const command = getCommand(id);
+		return {
+			id,
+			label: options?.label ?? command.label,
+			group,
+			keywords,
+			binding: command.defaultBinding,
+			isEnabled: options?.isEnabled ?? (() => command.isEnabled(registry)),
+			run,
+		};
+	};
+
+	/** A palette-only action: real behavior, but no registry entry or binding. */
+	const local = (declaration: Declaration): Declaration => declaration;
+
+	const editorCommand = (
+		id: Extract<CommandId, `editor.${string}`>,
+		action: EditorActionId,
+		keywords: string[],
+	) =>
+		fromRegistry(
+			id,
+			"Editor",
+			keywords,
+			() => {
+				runEditorAction(action);
+			},
+			{
+				// Registry editor commands are `always` enabled because the keymap only
+				// fires inside the editor. The palette has no such guard, so it adds one.
+				isEnabled: () => hasRichTextEditor(context),
+			},
+		);
+
+	return [
+		// ---- File ----
+		fromRegistry("app.new-file", "File", ["create", "markdown", "note"], () =>
+			createMarkdownFile(),
+		),
+		local({
+			id: "app.new-folder",
+			label: "New Folder",
+			group: "File",
+			keywords: ["create", "directory"],
+			isEnabled: () => context.workspacePath !== null,
+			run: async () => {
+				if (context.workspacePath) {
+					await createFolderInFolder(context.workspacePath);
+				}
+			},
+		}),
+		fromRegistry(
+			"app.reveal",
+			"File",
+			["finder", "explorer", "show", "folder"],
+			async () => {
+				if (!path) return;
+				try {
+					await desktopApi.revealFile(path);
+				} catch {
+					toast.error("Failed to reveal file");
+				}
+			},
+		),
+		fromRegistry(
+			"app.copy-path",
+			"File",
+			["clipboard", "location"],
+			async () => {
+				if (path) await copyText(path, "File path");
+			},
+		),
+		fromRegistry(
+			"app.copy-as-markdown",
+			"File",
+			["clipboard", "export", "source"],
+			actions.requestCopyAsMarkdown,
+		),
+		fromRegistry(
+			"app.delete",
+			"File",
+			["remove", "trash"],
+			async () => {
+				if (!path) return;
+				const name = path.split("/").pop() ?? path;
+				// Matches the sidebar's confirm rather than introducing a second
+				// deletion flow. A palette is easy to trigger by accident, and the
+				// undo toast that follows is a safety net, not a substitute.
+				if (!window.confirm(`Delete ${name}?`)) return;
+				await deleteMarkdownFile(path);
+			},
+			{ label: "Delete Note" },
+		),
+
+		// ---- Navigate ----
+		fromRegistry("app.go-back", "Navigate", ["history", "previous"], goBack),
+		fromRegistry("app.go-forward", "Navigate", ["history", "next"], goForward),
+		fromRegistry(
+			"app.add-folder",
+			"Navigate",
+			["workspace", "vault", "directory", "open"],
+			openWorkspaceWithSidebar,
+		),
+		fromRegistry(
+			"app.open-folder",
+			"Navigate",
+			["workspace", "vault", "switch", "recent"],
+			() => setWorkspaceSwitcherOpen(true),
+		),
+		local({
+			id: "app.toggle-pinned",
+			label: context.isPinned ? "Unpin Note" : "Pin Note",
+			group: "Navigate",
+			keywords: ["favorite", "bookmark", "star"],
+			isEnabled: () =>
+				registry.hasCurrentFile === true && context.workspacePath !== null,
+			run: async () => {
+				if (path) await togglePinnedNote(path);
+			},
+		}),
+		local({
+			id: "app.focus-sidebar",
+			label: "Focus Sidebar",
+			group: "Navigate",
+			keywords: ["files", "tree", "explorer"],
+			isEnabled: () => true,
+			run: () => {
+				setSidebarOpen(true);
+				requestAnimationFrame(() => actions.focusSidebar());
+			},
+		}),
+
+		// ---- Editor ----
+		// `editor.link` is omitted: it opens the link popover, which needs the
+		// selection the palette has just taken focus from.
+		editorCommand("editor.bold", "bold", ["strong", "format"]),
+		editorCommand("editor.italic", "italic", ["emphasis", "format"]),
+		editorCommand("editor.code", "code", ["monospace", "format"]),
+		editorCommand("editor.strike", "strike", ["strikethrough", "format"]),
+		editorCommand("editor.heading-1", "heading-1", ["title", "h1"]),
+		editorCommand("editor.heading-2", "heading-2", ["subtitle", "h2"]),
+		editorCommand("editor.heading-3", "heading-3", ["h3"]),
+		editorCommand("editor.bullet-list", "bullet-list", [
+			"unordered",
+			"bullets",
+		]),
+		editorCommand("editor.ordered-list", "ordered-list", [
+			"ordered",
+			"numbers",
+		]),
+		editorCommand("editor.task-list", "task-list", [
+			"todo",
+			"checkbox",
+			"checklist",
+		]),
+		editorCommand("editor.blockquote", "blockquote", ["quote", "citation"]),
+
+		// ---- View ----
+		fromRegistry(
+			"app.toggle-sidebar",
+			"View",
+			["files", "panel", "explorer"],
+			toggleSidebar,
+			{ label: context.sidebarOpen ? "Hide Sidebar" : "Show Sidebar" },
+		),
+		fromRegistry(
+			"app.toggle-terminal",
+			"View",
+			["shell", "console", "command line"],
+			toggleTerminal,
+		),
+		fromRegistry(
+			"app.toggle-source-mode",
+			"View",
+			["markdown", "raw", "code"],
+			() => setViewerMode(context.isSourceMode ? "rich" : "source"),
+			{ label: context.isSourceMode ? "Edit Rich Text" : "Edit Source" },
+		),
+		local({
+			id: "view.toggle-theme",
+			label: context.isDark ? "Switch to Light Theme" : "Switch to Dark Theme",
+			group: "View",
+			keywords: ["dark mode", "light mode", "appearance", "color"],
+			isEnabled: () => true,
+			run: () => setThemePreference(context.isDark ? "light" : "dark"),
+		}),
+		// Zoom stays out of the registry by design (#193: OS convention, and `=`
+		// vs `+` differs per platform), so these carry their own hint strings.
+		local({
+			id: "view.zoom-in",
+			label: "Zoom In",
+			group: "View",
+			keywords: ["bigger", "larger", "text size"],
+			binding: "CmdOrCtrl+=",
+			isEnabled: () => true,
+			run: () => desktopApi.zoomWindow("in"),
+		}),
+		local({
+			id: "view.zoom-out",
+			label: "Zoom Out",
+			group: "View",
+			keywords: ["smaller", "text size"],
+			binding: "CmdOrCtrl+-",
+			isEnabled: () => true,
+			run: () => desktopApi.zoomWindow("out"),
+		}),
+		local({
+			id: "view.zoom-reset",
+			label: "Reset Zoom",
+			group: "View",
+			keywords: ["actual size", "default"],
+			binding: "CmdOrCtrl+0",
+			isEnabled: () => true,
+			run: () => desktopApi.zoomWindow("reset"),
+		}),
+
+		// ---- App ----
+		fromRegistry(
+			"app.settings",
+			"App",
+			["preferences", "options", "config"],
+			actions.openSettings,
+		),
+		fromRegistry(
+			"app.chat-about-note",
+			"App",
+			["agent", "ai", "claude", "codex", "terminal"],
+			requestChatAboutNote,
+		),
+		local({
+			id: "app.check-for-updates",
+			label: "Check for Updates",
+			group: "App",
+			keywords: ["upgrade", "version", "release"],
+			isEnabled: () => true,
+			run: async () => {
+				try {
+					await desktopApi.checkForUpdates();
+				} catch (error) {
+					toast.error("Failed to check for updates", {
+						description: error instanceof Error ? error.message : String(error),
+					});
+				}
+			},
+		}),
+		local({
+			id: "app.whats-new",
+			label: "What's New",
+			group: "App",
+			keywords: ["changelog", "release notes", "updates"],
+			isEnabled: () => true,
+			run: async () => {
+				await openChangelog();
+			},
+		}),
+		local({
+			id: "app.contributing",
+			label: "Open Contributing Guide",
+			group: "App",
+			keywords: ["docs", "help", "github", "open source"],
+			isEnabled: () => true,
+			run: () => desktopApi.openExternalUrl(CONTRIBUTING_URL),
+		}),
+	];
+}
+
+/**
+ * Builds the palette's command list for the current context.
+ *
+ * Disabled commands are dropped rather than greyed out: a palette is a search
+ * surface, and a result you can select but not run reads as a bug. The menu bar
+ * still shows them disabled, which is where discoverability of *unavailable*
+ * actions belongs.
+ */
+export function buildAppCommands(
+	actions: AppCommandActions,
+	context: AppCommandContext,
+): PaletteCommand[] {
+	return defineCommands(actions, context)
+		.filter((command) => command.isEnabled())
+		.map(({ isEnabled: _isEnabled, binding, ...command }) => ({
+			...command,
+			shortcut: binding ? formatShortcut(binding) : undefined,
+		}));
+}

--- a/apps/desktop/src/commands/useAppCommands.ts
+++ b/apps/desktop/src/commands/useAppCommands.ts
@@ -44,12 +44,12 @@ const CONTRIBUTING_URL =
  * App state the palette needs, beyond what the registry's `CommandContext`
  * already covers.
  *
- * The extra fields exist only to label toggles by what they will *do* — "Hide
- * Sidebar" rather than "Toggle Sidebar" — so a user reading the list does not
- * have to know the current state to predict the outcome.
+ * It includes targets for contextual actions and state used to label toggles
+ * by what they will do, such as "Hide Sidebar" instead of "Toggle Sidebar".
  */
 export type AppCommandContext = {
 	currentPath: string | null;
+	newFolderParent: string | null;
 	workspacePath: string | null;
 	isSourceMode: boolean;
 	sidebarOpen: boolean;
@@ -175,10 +175,10 @@ function defineCommands(
 			label: "New Folder",
 			group: "File",
 			keywords: ["create", "directory"],
-			isEnabled: () => context.workspacePath !== null,
+			isEnabled: () => context.newFolderParent !== null,
 			run: async () => {
-				if (context.workspacePath) {
-					await createFolderInFolder(context.workspacePath);
+				if (context.newFolderParent) {
+					await createFolderInFolder(context.newFolderParent);
 				}
 			},
 		}),
@@ -208,6 +208,7 @@ function defineCommands(
 			"File",
 			["clipboard", "export", "source"],
 			actions.requestCopyAsMarkdown,
+			{ isEnabled: () => hasRichTextEditor(context) },
 		),
 		fromRegistry(
 			"app.delete",

--- a/apps/desktop/src/commands/useAppCommands.ts
+++ b/apps/desktop/src/commands/useAppCommands.ts
@@ -14,7 +14,11 @@ import { desktopApi } from "../desktopApi";
 import { createMarkdownFile } from "../fileActions";
 import { isChangelogPath } from "../lib/changelogNote";
 import { copyText } from "../lib/clipboard";
-import { isEditableFile } from "../lib/filePath";
+import {
+	hasMarkdownExtension,
+	isEditableFile,
+	supportsSourceToggle,
+} from "../lib/filePath";
 import {
 	createFolderInFolder,
 	deleteMarkdownFile,
@@ -70,6 +74,7 @@ function toRegistryContext(context: AppCommandContext): RegistryContext {
 	return {
 		hasCurrentFile: isRealFile,
 		hasEditableFile: isRealFile && isEditableFile(path),
+		hasSourceViewOpen: isRealFile && supportsSourceToggle(path),
 		hasWorkspace: context.workspacePath !== null,
 		isSourceMode: context.isSourceMode,
 		canGoBack: canGoBack(),
@@ -79,8 +84,13 @@ function toRegistryContext(context: AppCommandContext): RegistryContext {
 
 /** Rich text is being edited, so an editor command has somewhere to land. */
 function hasRichTextEditor(context: AppCommandContext) {
-	const registry = toRegistryContext(context);
-	return registry.hasEditableFile === true && !context.isSourceMode;
+	const path = context.currentPath;
+	return (
+		path !== null &&
+		!isChangelogPath(path) &&
+		hasMarkdownExtension(path) &&
+		!context.isSourceMode
+	);
 }
 
 type Declaration = Omit<PaletteCommand, "binding" | "shortcut"> & {

--- a/apps/desktop/src/commands/useAppCommands.ts
+++ b/apps/desktop/src/commands/useAppCommands.ts
@@ -15,6 +15,7 @@ import { createMarkdownFile } from "../fileActions";
 import { isChangelogPath } from "../lib/changelogNote";
 import { copyText } from "../lib/clipboard";
 import {
+	basename,
 	hasMarkdownExtension,
 	isEditableFile,
 	supportsSourceToggle,
@@ -155,7 +156,9 @@ function defineCommands(
 			"Editor",
 			keywords,
 			() => {
-				runEditorAction(action);
+				if (!runEditorAction(action)) {
+					throw new Error("No active editor");
+				}
 			},
 			{
 				globalShortcut: false,
@@ -216,7 +219,7 @@ function defineCommands(
 			["remove", "trash"],
 			async () => {
 				if (!path) return;
-				const name = path.split("/").pop() ?? path;
+				const name = basename(path);
 				// Matches the sidebar's confirm rather than introducing a second
 				// deletion flow. A palette is easy to trigger by accident, and the
 				// undo toast that follows is a safety net, not a substitute.

--- a/apps/desktop/src/commands/useAppCommands.ts
+++ b/apps/desktop/src/commands/useAppCommands.ts
@@ -83,7 +83,7 @@ function hasRichTextEditor(context: AppCommandContext) {
 	return registry.hasEditableFile === true && !context.isSourceMode;
 }
 
-type Declaration = Omit<PaletteCommand, "shortcut"> & {
+type Declaration = Omit<PaletteCommand, "binding" | "shortcut"> & {
 	binding?: string;
 	isEnabled: () => boolean;
 };
@@ -395,6 +395,7 @@ export function buildAppCommands(
 		.filter((command) => command.isEnabled())
 		.map(({ isEnabled: _isEnabled, binding, ...command }) => ({
 			...command,
+			binding,
 			shortcut: binding ? formatShortcut(binding) : undefined,
 		}));
 }

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -33,12 +33,17 @@ import {
 } from "../store/state";
 import { WorkspaceSwitcher } from "./WorkspaceSwitcher";
 
+export type DesktopSidebarFocus = {
+	kind: "file" | "folder";
+	path: string;
+} | null;
+
 export function Sidebar({
 	footer,
-	onFocusedPathChange,
+	onFocusedItemChange,
 }: {
 	footer?: ReactNode;
-	onFocusedPathChange?: (path: string | null) => void;
+	onFocusedItemChange?: (item: DesktopSidebarFocus) => void;
 }) {
 	const workspace = useStoreValue(workspaceStore);
 	const sidebarOpen = useStoreValue(sidebarOpenStore);
@@ -114,12 +119,13 @@ export function Sidebar({
 			}
 			onFocusedItemChange={(item: SidebarFocusedItem) => {
 				if (!item) {
-					onFocusedPathChange?.(null);
+					onFocusedItemChange?.(null);
 					return;
 				}
-				onFocusedPathChange?.(
-					item.kind === "file" ? item.path : absolutePath(item.folderId),
-				);
+				onFocusedItemChange?.({
+					kind: item.kind,
+					path: item.kind === "file" ? item.path : absolutePath(item.folderId),
+				});
 			}}
 			revealLabel={revealFileLabel(desktopApi.platform)}
 			onRenameFile={(path, nextName) => void renameMarkdownFile(path, nextName)}

--- a/apps/desktop/src/components/TerminalPanel.tsx
+++ b/apps/desktop/src/components/TerminalPanel.tsx
@@ -27,6 +27,7 @@ import {
 	viewerStore,
 	workspacePathStore,
 } from "../store/state";
+import { isDarkTheme, subscribeTheme } from "../theme";
 import "@xterm/xterm/css/xterm.css";
 import MingcuteAddLine from "~icons/mingcute/add-line";
 import MingcuteCheckLine from "~icons/mingcute/check-line";
@@ -614,8 +615,7 @@ function TerminalInstance({
 			}
 			if (!fontFamily) fontFamily = "monospace";
 
-			const isDark = document.documentElement.classList.contains("dark");
-			const palette = isDark ? DARK_THEME : LIGHT_THEME;
+			const palette = isDarkTheme() ? DARK_THEME : LIGHT_THEME;
 
 			term.options.fontFamily = fontFamily;
 			term.options.theme = {
@@ -628,11 +628,7 @@ function TerminalInstance({
 
 		updateTheme();
 
-		const themeObserver = new MutationObserver(() => updateTheme());
-		themeObserver.observe(document.documentElement, {
-			attributes: true,
-			attributeFilter: ["class"],
-		});
+		const unsubscribeTheme = subscribeTheme(updateTheme);
 
 		const fitAddon = new FitAddon();
 		term.loadAddon(fitAddon);
@@ -680,7 +676,7 @@ function TerminalInstance({
 			unsubscribeData();
 			unsubscribeExit();
 			resizeObserver.disconnect();
-			themeObserver.disconnect();
+			unsubscribeTheme();
 			term.dispose();
 		};
 	}, [sessionId]); // Important: only sessionId — anything else here remounts xterm

--- a/apps/desktop/src/desktopApi/types.ts
+++ b/apps/desktop/src/desktopApi/types.ts
@@ -202,10 +202,6 @@ export type DesktopApi = {
 	setTelemetryConsent(consent: TelemetryChoice): Promise<TelemetryConsent>;
 	recordTelemetryActivity(input: { usedHtmlApp: boolean }): Promise<void>;
 	getFullScreen(): Promise<boolean>;
-	/**
-	 * Zoom stays owned by the main process and keeps its OS-convention
-	 * accelerators; this only lets the renderer dispatch the same actions.
-	 */
 	zoomWindow(direction: ZoomDirection): Promise<void>;
 	checkForUpdates(): Promise<void>;
 	installUpdate(): Promise<void>;

--- a/apps/desktop/src/desktopApi/types.ts
+++ b/apps/desktop/src/desktopApi/types.ts
@@ -92,6 +92,8 @@ export type WatchOptions = {
 
 export type Unsubscribe = () => void;
 
+export type ZoomDirection = "in" | "out" | "reset";
+
 export type MenuState = {
 	hasWorkspace: boolean;
 	hasSourceViewOpen: boolean;
@@ -200,6 +202,11 @@ export type DesktopApi = {
 	setTelemetryConsent(consent: TelemetryChoice): Promise<TelemetryConsent>;
 	recordTelemetryActivity(input: { usedHtmlApp: boolean }): Promise<void>;
 	getFullScreen(): Promise<boolean>;
+	/**
+	 * Zoom stays owned by the main process and keeps its OS-convention
+	 * accelerators; this only lets the renderer dispatch the same actions.
+	 */
+	zoomWindow(direction: ZoomDirection): Promise<void>;
 	checkForUpdates(): Promise<void>;
 	installUpdate(): Promise<void>;
 	onOpenFile(callback: (path: string) => void): Unsubscribe;

--- a/apps/desktop/src/theme.test.ts
+++ b/apps/desktop/src/theme.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { initTheme, setThemePreference } from "./theme";
+import { initTheme, setThemePreference, subscribeTheme } from "./theme";
 
 type ChangeListener = (event: { matches: boolean }) => void;
 
@@ -61,6 +61,20 @@ describe("theme", () => {
 
 		emit(false);
 		expect(document.documentElement.classList.contains("dark")).toBe(false);
+	});
+
+	it("notifies subscribers when the resolved appearance changes", () => {
+		const { emit } = mockMatchMedia(false);
+		initTheme("system");
+		const listener = vi.fn();
+		const unsubscribe = subscribeTheme(listener);
+
+		emit(true);
+		expect(listener).toHaveBeenCalledOnce();
+
+		unsubscribe();
+		emit(false);
+		expect(listener).toHaveBeenCalledOnce();
 	});
 
 	it("applies explicit light and dark preferences", () => {

--- a/apps/desktop/src/theme.ts
+++ b/apps/desktop/src/theme.ts
@@ -2,13 +2,26 @@ export type ThemePreference = "light" | "dark" | "system";
 
 let systemQuery: MediaQueryList | null = null;
 let preference: ThemePreference = "system";
+let dark = false;
+const listeners = new Set<() => void>();
+
+export function isDarkTheme(): boolean {
+	return dark;
+}
+
+export function subscribeTheme(listener: () => void): () => void {
+	listeners.add(listener);
+	return () => listeners.delete(listener);
+}
 
 function applyTheme(): void {
-	document.documentElement.classList.toggle(
-		"dark",
+	const isDark =
 		preference === "dark" ||
-			(preference === "system" && systemQuery?.matches === true),
-	);
+		(preference === "system" && systemQuery?.matches === true);
+	document.documentElement.classList.toggle("dark", isDark);
+	if (isDark === dark) return;
+	dark = isDark;
+	for (const listener of listeners) listener();
 }
 
 /**

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -1,6 +1,7 @@
 export { ContextMenuSpellcheckExtension } from "./ContextMenuSpellcheckExtension.js";
 export {
 	type AppCommandId,
+	type CommandContext,
 	type CommandId,
 	getCommand,
 	tiptapBinding,

--- a/packages/ui/src/components/GlobalSearchPalette.tsx
+++ b/packages/ui/src/components/GlobalSearchPalette.tsx
@@ -154,6 +154,16 @@ function useContentResults(
 	return { result, searching };
 }
 
+async function runPaletteCommand(command: PaletteCommand) {
+	try {
+		await command.run();
+		return true;
+	} catch (error) {
+		console.error(`Failed to run command "${command.label}":`, error);
+		return false;
+	}
+}
+
 function GlobalSearchPalette({
 	open,
 	onOpenChange,
@@ -256,11 +266,8 @@ function GlobalSearchPalette({
 	// would otherwise fight the palette's own closing focus restore.
 	const runCommand = async (command: PaletteCommand) => {
 		onOpenChange(false);
-		try {
-			await command.run();
+		if (await runPaletteCommand(command)) {
 			onRunCommand?.(command.id);
-		} catch (error) {
-			console.error(`Failed to run command "${command.label}":`, error);
 		}
 	};
 

--- a/packages/ui/src/components/GlobalSearchPalette.tsx
+++ b/packages/ui/src/components/GlobalSearchPalette.tsx
@@ -4,7 +4,16 @@ import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import MingcuteCornerDownLeftLine from "~icons/mingcute/corner-down-left-line";
 import MingcuteFileLine from "~icons/mingcute/file-line";
 import MingcuteSearch2Line from "~icons/mingcute/search-2-line";
+import MingcuteTerminalLine from "~icons/mingcute/terminal-line";
 import { type MatchRange, matchRanges, scorePath } from "../lib/fuzzy";
+import {
+	COMMAND_PREFIX,
+	groupCommands,
+	isCommandQuery,
+	type PaletteCommand,
+	rankCommands,
+	stripCommandPrefix,
+} from "../lib/paletteCommand";
 
 const SEARCH_DEBOUNCE_MS = 150;
 const MIN_CONTENT_QUERY_LENGTH = 3;
@@ -40,6 +49,11 @@ export type GlobalSearchPaletteProps = {
 	files: PaletteFile[];
 	onSelectFile: (path: string) => void;
 	searchContents: (query: string) => Promise<PaletteContentResult>;
+	/** Runnable commands, already filtered to those enabled in this context. */
+	commands?: PaletteCommand[];
+	/** Most-recently-run command ids first; used only to break ranking ties. */
+	recentCommandIds?: string[];
+	onRunCommand?: (id: string) => void;
 };
 
 function Highlight({ text, ranges }: { text: string; ranges: MatchRange[] }) {
@@ -143,11 +157,25 @@ function GlobalSearchPalette({
 	files,
 	onSelectFile,
 	searchContents,
+	commands = [],
+	recentCommandIds = [],
+	onRunCommand,
 }: GlobalSearchPaletteProps) {
 	const [query, setQuery] = useState("");
 	const inputRef = useRef<HTMLInputElement | null>(null);
-	const nameResults = getNameResults(files, query);
-	const { result, searching } = useContentResults(query, open, searchContents);
+	const commandMode = isCommandQuery(query);
+	// Content search must not run in command mode, and must not see the `/`.
+	const fileQuery = commandMode ? "" : query;
+	const nameResults = getNameResults(files, fileQuery);
+	const { result, searching } = useContentResults(
+		fileQuery,
+		open && !commandMode,
+		searchContents,
+	);
+
+	const commandResults = groupCommands(
+		rankCommands(stripCommandPrefix(query), commands, recentCommandIds),
+	);
 
 	useEffect(() => {
 		if (!open) setQuery("");
@@ -167,8 +195,18 @@ function GlobalSearchPalette({
 		onSelectFile(path);
 	};
 
-	const isEmptyQuery = query.trim() === "";
-	const hasResults = nameResults.length > 0 || contentResults.length > 0;
+	// Close before running: a command that opens another dialog or moves focus
+	// would otherwise fight the palette's own closing focus restore.
+	const runCommand = (command: PaletteCommand) => {
+		onOpenChange(false);
+		onRunCommand?.(command.id);
+		void command.run();
+	};
+
+	const isEmptyQuery = fileQuery.trim() === "";
+	const hasResults = commandMode
+		? commandResults.length > 0
+		: nameResults.length > 0 || contentResults.length > 0;
 	return (
 		<Dialog.Root open={open} onOpenChange={onOpenChange}>
 			<Dialog.Portal>
@@ -189,23 +227,35 @@ function GlobalSearchPalette({
 					initialFocus={inputRef}
 					className="fixed top-[12vh] left-1/2 z-50 flex max-h-[60vh] w-[calc(100%-2rem)] max-w-2xl -translate-x-1/2 scale-100 flex-col overflow-hidden rounded-[var(--radius-popover)] bg-popover text-popover-foreground opacity-100 shadow-overlay ring-1 ring-black/10 outline-hidden transition-[translate,scale,opacity] duration-200 ease-snappy data-[closed]:pointer-events-none data-[ending-style]:scale-[0.98] data-[ending-style]:opacity-0 data-[starting-style]:scale-[0.98] data-[starting-style]:opacity-0 dark:ring-white/15"
 				>
-					<Dialog.Title className="sr-only">Search files</Dialog.Title>
+					<Dialog.Title className="sr-only">
+						{commandMode ? "Run a command" : "Search files"}
+					</Dialog.Title>
 					<Dialog.Description className="sr-only">
-						Find a note by name, path, or content.
+						{commandMode
+							? "Run a Hubble command. Clear the leading slash to search notes instead."
+							: "Find a note by name, path, or content. Type a slash to run a command instead."}
 					</Dialog.Description>
 					<Command
-						label="Search files"
+						label={commandMode ? "Run a command" : "Search files"}
 						shouldFilter={false}
 						loop
 						className="flex min-h-0 flex-1 flex-col"
 					>
 						<div className="flex items-center gap-2.5 border-b border-border px-3.5">
-							<MingcuteSearch2Line className="size-4 shrink-0 text-muted-foreground" />
+							{commandMode ? (
+								<MingcuteTerminalLine className="size-4 shrink-0 text-muted-foreground" />
+							) : (
+								<MingcuteSearch2Line className="size-4 shrink-0 text-muted-foreground" />
+							)}
 							<Command.Input
 								ref={inputRef}
 								value={query}
 								onValueChange={setQuery}
-								placeholder="Search notes by name or content"
+								placeholder={
+									commandMode
+										? "Run a command"
+										: "Search notes, or type / for commands"
+								}
 								className="h-12 w-full border-0 bg-transparent text-[13px] text-foreground outline-hidden placeholder:text-muted-foreground"
 							/>
 							{searching && (
@@ -218,11 +268,34 @@ function GlobalSearchPalette({
 						<Command.List className="min-h-0 flex-1 overflow-y-auto overscroll-contain p-1.5">
 							{!hasResults && !searching && (
 								<div className="px-3 py-8 text-center text-xs text-muted-foreground">
-									{isEmptyQuery ? "No notes yet" : "No matches"}
+									{commandMode
+										? "No commands"
+										: isEmptyQuery
+											? "No notes yet"
+											: "No matches"}
 								</div>
 							)}
 
-							{nameResults.length > 0 && (
+							{commandMode &&
+								commandResults.map(({ group, commands: groupItems }) => (
+									<ResultGroup key={group} heading={group}>
+										{groupItems.map((command) => (
+											<Command.Item
+												key={command.id}
+												value={`command:${command.id}`}
+												onSelect={() => runCommand(command)}
+												className={ROW_CLASS}
+											>
+												<CommandRow
+													command={command}
+													query={stripCommandPrefix(query)}
+												/>
+											</Command.Item>
+										))}
+									</ResultGroup>
+								))}
+
+							{!commandMode && nameResults.length > 0 && (
 								<ResultGroup heading={isEmptyQuery ? "Recent" : "Notes"}>
 									{nameResults.map((file) => (
 										<Command.Item
@@ -240,7 +313,7 @@ function GlobalSearchPalette({
 								</ResultGroup>
 							)}
 
-							{contentResults.length > 0 && (
+							{!commandMode && contentResults.length > 0 && (
 								<ResultGroup heading="Content">
 									{contentResults.map((entry) => {
 										const relativePath =
@@ -285,10 +358,18 @@ function GlobalSearchPalette({
 								<Legend
 									icon={<MingcuteCornerDownLeftLine className="size-3" />}
 								>
-									Open
+									{commandMode ? "Run" : "Open"}
 								</Legend>
 								<Legend keys="esc">Close</Legend>
 							</span>
+							{commands.length > 0 && (
+								<span className="ms-auto flex items-center gap-1.5">
+									<kbd className="flex h-4 min-w-4 items-center justify-center rounded-[var(--radius-inner)] border border-border px-1 font-sans text-[10px] leading-none text-muted-foreground">
+										{COMMAND_PREFIX}
+									</kbd>
+									{commandMode ? "Clear for notes" : "Commands"}
+								</span>
+							)}
 						</div>
 					</Command>
 				</Dialog.Popup>
@@ -346,6 +427,30 @@ function FileRow({
 				<span className="max-w-[45%] shrink-0 truncate text-[11px] text-muted-foreground">
 					<Highlight text={folder} ranges={folderRanges} />
 				</span>
+			)}
+		</span>
+	);
+}
+
+/** Command label with its shortcut trailing, matched characters emphasized. */
+function CommandRow({
+	command,
+	query,
+}: {
+	command: PaletteCommand;
+	query: string;
+}) {
+	const ranges = query ? matchRanges(query, command.label) : [];
+
+	return (
+		<span className="flex min-w-0 items-center gap-2.5">
+			<span className="min-w-0 flex-1 truncate text-[13px] text-foreground">
+				<Highlight text={command.label} ranges={ranges} />
+			</span>
+			{command.shortcut && (
+				<kbd className="shrink-0 rounded-[var(--radius-inner)] border border-border px-1.5 py-0.5 font-sans text-[10px] leading-none text-muted-foreground">
+					{command.shortcut}
+				</kbd>
 			)}
 		</span>
 	);

--- a/packages/ui/src/components/GlobalSearchPalette.tsx
+++ b/packages/ui/src/components/GlobalSearchPalette.tsx
@@ -4,7 +4,6 @@ import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import MingcuteCornerDownLeftLine from "~icons/mingcute/corner-down-left-line";
 import MingcuteFileLine from "~icons/mingcute/file-line";
 import MingcuteSearch2Line from "~icons/mingcute/search-2-line";
-import MingcuteTerminalLine from "~icons/mingcute/terminal-line";
 import { type MatchRange, matchRanges, scorePath } from "../lib/fuzzy";
 import {
 	COMMAND_PREFIX,
@@ -162,9 +161,11 @@ function GlobalSearchPalette({
 	onRunCommand,
 }: GlobalSearchPaletteProps) {
 	const [query, setQuery] = useState("");
+	// Mode is held rather than derived from the query, because the prefix is
+	// promoted to a chip the moment it is typed and never becomes text. `query`
+	// is always the search terms alone, in either mode.
+	const [commandMode, setCommandMode] = useState(false);
 	const inputRef = useRef<HTMLInputElement | null>(null);
-	const commandMode = isCommandQuery(query);
-	// Content search must not run in command mode, and must not see the `/`.
 	const fileQuery = commandMode ? "" : query;
 	const nameResults = getNameResults(files, fileQuery);
 	const { result, searching } = useContentResults(
@@ -174,11 +175,37 @@ function GlobalSearchPalette({
 	);
 
 	const commandResults = groupCommands(
-		rankCommands(stripCommandPrefix(query), commands, recentCommandIds),
+		rankCommands(query, commands, recentCommandIds),
 	);
 
+	/** Typing the prefix into an empty query swaps the chip in, not the text. */
+	const changeQuery = (next: string) => {
+		if (!commandMode && isCommandQuery(next)) {
+			setCommandMode(true);
+			setQuery(stripCommandPrefix(next));
+			return;
+		}
+		setQuery(next);
+	};
+
+	/**
+	 * Backspace on an empty command query removes the chip.
+	 *
+	 * This keeps the chip feeling like the character it replaced: the same
+	 * keystroke that used to delete a leading `/` still leaves command mode,
+	 * so nobody has to discover a different way back to searching notes.
+	 */
+	const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+		if (event.key !== "Backspace" || !commandMode || query !== "") return;
+		event.preventDefault();
+		setCommandMode(false);
+	};
+
 	useEffect(() => {
-		if (!open) setQuery("");
+		if (!open) {
+			setQuery("");
+			setCommandMode(false);
+		}
 	}, [open]);
 
 	const relativeByPath = new Map(
@@ -232,7 +259,7 @@ function GlobalSearchPalette({
 					</Dialog.Title>
 					<Dialog.Description className="sr-only">
 						{commandMode
-							? "Run a Hubble command. Clear the leading slash to search notes instead."
+							? "Run a Hubble command. Press Backspace on an empty query to search notes instead."
 							: "Find a note by name, path, or content. Type a slash to run a command instead."}
 					</Dialog.Description>
 					<Command
@@ -243,14 +270,21 @@ function GlobalSearchPalette({
 					>
 						<div className="flex items-center gap-2.5 border-b border-border px-3.5">
 							{commandMode ? (
-								<MingcuteTerminalLine className="size-4 shrink-0 text-muted-foreground" />
+								/* The prefix itself, promoted out of the text. It reads as a
+								   state the input is in rather than a character to edit
+								   around, and keeps the palette looking like a text editor
+								   rather than a terminal. */
+								<span className="flex h-[22px] shrink-0 items-center rounded-[var(--radius-inner)] bg-accent px-2 font-medium text-[13px] text-foreground leading-none">
+									{COMMAND_PREFIX}
+								</span>
 							) : (
 								<MingcuteSearch2Line className="size-4 shrink-0 text-muted-foreground" />
 							)}
 							<Command.Input
 								ref={inputRef}
 								value={query}
-								onValueChange={setQuery}
+								onValueChange={changeQuery}
+								onKeyDown={handleKeyDown}
 								placeholder={
 									commandMode
 										? "Run a command"
@@ -367,7 +401,7 @@ function GlobalSearchPalette({
 									<kbd className="flex h-4 min-w-4 items-center justify-center rounded-[var(--radius-inner)] border border-border px-1 font-sans text-[10px] leading-none text-muted-foreground">
 										{COMMAND_PREFIX}
 									</kbd>
-									{commandMode ? "Clear for notes" : "Commands"}
+									{commandMode ? "Backspace for notes" : "Commands"}
 								</span>
 							)}
 						</div>

--- a/packages/ui/src/components/GlobalSearchPalette.tsx
+++ b/packages/ui/src/components/GlobalSearchPalette.tsx
@@ -10,6 +10,7 @@ import {
 	COMMAND_PREFIX,
 	groupCommands,
 	isCommandQuery,
+	OPEN_COMMAND_PALETTE_EVENT,
 	type PaletteCommand,
 	rankCommands,
 	rankSearchCommands,
@@ -210,7 +211,9 @@ function GlobalSearchPalette({
 		if (
 			commands.some(
 				(command) =>
-					command.binding && keymatch(event.nativeEvent, command.binding),
+					command.globalShortcut &&
+					command.binding &&
+					keymatch(event.nativeEvent, command.binding),
 			)
 		) {
 			onOpenChange(false);
@@ -223,6 +226,17 @@ function GlobalSearchPalette({
 			setCommandMode(false);
 		}
 	}, [open]);
+
+	useEffect(() => {
+		const openCommands = () => {
+			setQuery("");
+			setCommandMode(true);
+			onOpenChange(true);
+		};
+		window.addEventListener(OPEN_COMMAND_PALETTE_EVENT, openCommands);
+		return () =>
+			window.removeEventListener(OPEN_COMMAND_PALETTE_EVENT, openCommands);
+	}, [onOpenChange]);
 
 	const relativeByPath = new Map(
 		files.map((file) => [file.path, file.relativePath]),
@@ -423,7 +437,7 @@ function GlobalSearchPalette({
 								</Legend>
 								<Legend keys="esc">Close</Legend>
 							</span>
-							{commands.length > 0 && (
+							{commands.length > 0 && (commandMode || query === "") && (
 								<span className="ms-auto flex items-center gap-1.5">
 									<kbd className="flex h-4 min-w-4 items-center justify-center rounded-[var(--radius-inner)] border border-border px-1 font-sans text-[10px] leading-none text-muted-foreground">
 										{commandMode ? formatShortcut("Backspace") : COMMAND_PREFIX}

--- a/packages/ui/src/components/GlobalSearchPalette.tsx
+++ b/packages/ui/src/components/GlobalSearchPalette.tsx
@@ -1,5 +1,6 @@
 import { Dialog } from "@base-ui/react/dialog";
 import { Command } from "cmdk";
+import { keymatch } from "keymatch";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import MingcuteCornerDownLeftLine from "~icons/mingcute/corner-down-left-line";
 import MingcuteFileLine from "~icons/mingcute/file-line";
@@ -13,6 +14,7 @@ import {
 	rankCommands,
 	stripCommandPrefix,
 } from "../lib/paletteCommand";
+import { formatShortcut } from "../lib/shortcut";
 
 const SEARCH_DEBOUNCE_MS = 150;
 const MIN_CONTENT_QUERY_LENGTH = 3;
@@ -196,9 +198,20 @@ function GlobalSearchPalette({
 	 * so nobody has to discover a different way back to searching notes.
 	 */
 	const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-		if (event.key !== "Backspace" || !commandMode || query !== "") return;
-		event.preventDefault();
-		setCommandMode(false);
+		if (event.key === "Backspace" && commandMode && query === "") {
+			event.preventDefault();
+			setCommandMode(false);
+			return;
+		}
+
+		if (
+			commands.some(
+				(command) =>
+					command.binding && keymatch(event.nativeEvent, command.binding),
+			)
+		) {
+			onOpenChange(false);
+		}
 	};
 
 	useEffect(() => {
@@ -270,11 +283,7 @@ function GlobalSearchPalette({
 					>
 						<div className="flex items-center gap-2.5 border-b border-border px-3.5">
 							{commandMode ? (
-								/* The prefix itself, promoted out of the text. It reads as a
-								   state the input is in rather than a character to edit
-								   around, and keeps the palette looking like a text editor
-								   rather than a terminal. */
-								<span className="flex h-[22px] shrink-0 items-center rounded-[var(--radius-inner)] bg-accent px-2 font-medium text-[13px] text-foreground leading-none">
+								<span className="flex size-4 -translate-y-0.5 shrink-0 items-center justify-center text-[13px] text-muted-foreground leading-none">
 									{COMMAND_PREFIX}
 								</span>
 							) : (
@@ -399,9 +408,11 @@ function GlobalSearchPalette({
 							{commands.length > 0 && (
 								<span className="ms-auto flex items-center gap-1.5">
 									<kbd className="flex h-4 min-w-4 items-center justify-center rounded-[var(--radius-inner)] border border-border px-1 font-sans text-[10px] leading-none text-muted-foreground">
-										{COMMAND_PREFIX}
+										{commandMode
+											? formatShortcut("Backspace")
+											: COMMAND_PREFIX}
 									</kbd>
-									{commandMode ? "Backspace for notes" : "Commands"}
+									{commandMode ? "Search notes" : "Commands"}
 								</span>
 							)}
 						</div>

--- a/packages/ui/src/components/GlobalSearchPalette.tsx
+++ b/packages/ui/src/components/GlobalSearchPalette.tsx
@@ -254,10 +254,14 @@ function GlobalSearchPalette({
 
 	// Close before running: a command that opens another dialog or moves focus
 	// would otherwise fight the palette's own closing focus restore.
-	const runCommand = (command: PaletteCommand) => {
+	const runCommand = async (command: PaletteCommand) => {
 		onOpenChange(false);
 		onRunCommand?.(command.id);
-		void command.run();
+		try {
+			await command.run();
+		} catch (error) {
+			console.error(`Failed to run command "${command.label}":`, error);
+		}
 	};
 
 	const isEmptyQuery = fileQuery.trim() === "";
@@ -343,7 +347,7 @@ function GlobalSearchPalette({
 											<Command.Item
 												key={command.id}
 												value={`command:${command.id}`}
-												onSelect={() => runCommand(command)}
+												onSelect={() => void runCommand(command)}
 												className={ROW_CLASS}
 											>
 												<CommandRow
@@ -361,7 +365,7 @@ function GlobalSearchPalette({
 										<Command.Item
 											key={command.id}
 											value={`command:${command.id}`}
-											onSelect={() => runCommand(command)}
+											onSelect={() => void runCommand(command)}
 											className={ROW_CLASS}
 										>
 											<CommandRow command={command} query={query} />

--- a/packages/ui/src/components/GlobalSearchPalette.tsx
+++ b/packages/ui/src/components/GlobalSearchPalette.tsx
@@ -52,9 +52,7 @@ export type GlobalSearchPaletteProps = {
 	files: PaletteFile[];
 	onSelectFile: (path: string) => void;
 	searchContents: (query: string) => Promise<PaletteContentResult>;
-	/** Runnable commands, already filtered to those enabled in this context. */
 	commands?: PaletteCommand[];
-	/** Most-recently-run command ids first; used only to break ranking ties. */
 	recentCommandIds?: string[];
 	onRunCommand?: (id: string) => void;
 };
@@ -175,9 +173,7 @@ function GlobalSearchPalette({
 	onRunCommand,
 }: GlobalSearchPaletteProps) {
 	const [query, setQuery] = useState("");
-	// Mode is held rather than derived from the query, because the prefix is
-	// promoted to a chip the moment it is typed and never becomes text. `query`
-	// is always the search terms alone, in either mode.
+	// The slash renders as a chip, so it is not part of the query.
 	const [commandMode, setCommandMode] = useState(false);
 	const inputRef = useRef<HTMLInputElement | null>(null);
 	const fileQuery = commandMode ? "" : query;
@@ -194,7 +190,6 @@ function GlobalSearchPalette({
 	const commandResults = commandMode ? groupCommands(rankedCommands) : [];
 	const searchCommandResults = commandMode ? [] : rankedCommands;
 
-	/** Typing the prefix into an empty query swaps the chip in, not the text. */
 	const changeQuery = (next: string) => {
 		if (!commandMode && isCommandQuery(next)) {
 			setCommandMode(true);
@@ -204,13 +199,6 @@ function GlobalSearchPalette({
 		setQuery(next);
 	};
 
-	/**
-	 * Backspace on an empty command query removes the chip.
-	 *
-	 * This keeps the chip feeling like the character it replaced: the same
-	 * keystroke that used to delete a leading `/` still leaves command mode,
-	 * so nobody has to discover a different way back to searching notes.
-	 */
 	const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
 		if (event.key === "Backspace" && commandMode && query === "") {
 			event.preventDefault();
@@ -262,8 +250,7 @@ function GlobalSearchPalette({
 		onSelectFile(path);
 	};
 
-	// Close before running: a command that opens another dialog or moves focus
-	// would otherwise fight the palette's own closing focus restore.
+	// Close first so focus restoration cannot fight the command.
 	const runCommand = async (command: PaletteCommand) => {
 		onOpenChange(false);
 		if (await runPaletteCommand(command)) {
@@ -518,7 +505,6 @@ function FileRow({
 	);
 }
 
-/** Command label with its shortcut trailing, matched characters emphasized. */
 function CommandRow({
 	command,
 	query,

--- a/packages/ui/src/components/GlobalSearchPalette.tsx
+++ b/packages/ui/src/components/GlobalSearchPalette.tsx
@@ -12,6 +12,7 @@ import {
 	isCommandQuery,
 	type PaletteCommand,
 	rankCommands,
+	rankSearchCommands,
 	stripCommandPrefix,
 } from "../lib/paletteCommand";
 import { formatShortcut } from "../lib/shortcut";
@@ -169,16 +170,18 @@ function GlobalSearchPalette({
 	const [commandMode, setCommandMode] = useState(false);
 	const inputRef = useRef<HTMLInputElement | null>(null);
 	const fileQuery = commandMode ? "" : query;
-	const nameResults = getNameResults(files, fileQuery);
+	const nameResults = commandMode ? [] : getNameResults(files, fileQuery);
 	const { result, searching } = useContentResults(
 		fileQuery,
 		open && !commandMode,
 		searchContents,
 	);
 
-	const commandResults = groupCommands(
-		rankCommands(query, commands, recentCommandIds),
-	);
+	const rankedCommands = commandMode
+		? rankCommands(query, commands, recentCommandIds)
+		: rankSearchCommands(query, commands, recentCommandIds);
+	const commandResults = commandMode ? groupCommands(rankedCommands) : [];
+	const searchCommandResults = commandMode ? [] : rankedCommands;
 
 	/** Typing the prefix into an empty query swaps the chip in, not the text. */
 	const changeQuery = (next: string) => {
@@ -246,7 +249,9 @@ function GlobalSearchPalette({
 	const isEmptyQuery = fileQuery.trim() === "";
 	const hasResults = commandMode
 		? commandResults.length > 0
-		: nameResults.length > 0 || contentResults.length > 0;
+		: searchCommandResults.length > 0 ||
+			nameResults.length > 0 ||
+			contentResults.length > 0;
 	return (
 		<Dialog.Root open={open} onOpenChange={onOpenChange}>
 			<Dialog.Portal>
@@ -273,7 +278,7 @@ function GlobalSearchPalette({
 					<Dialog.Description className="sr-only">
 						{commandMode
 							? "Run a Hubble command. Press Backspace on an empty query to search notes instead."
-							: "Find a note by name, path, or content. Type a slash to run a command instead."}
+							: "Find notes and commands. Type a slash to browse all commands."}
 					</Dialog.Description>
 					<Command
 						label={commandMode ? "Run a command" : "Search files"}
@@ -295,9 +300,7 @@ function GlobalSearchPalette({
 								onValueChange={changeQuery}
 								onKeyDown={handleKeyDown}
 								placeholder={
-									commandMode
-										? "Run a command"
-										: "Search notes, or type / for commands"
+									commandMode ? "Run a command" : "Search notes and commands"
 								}
 								className="h-12 w-full border-0 bg-transparent text-[13px] text-foreground outline-hidden placeholder:text-muted-foreground"
 							/>
@@ -337,6 +340,21 @@ function GlobalSearchPalette({
 										))}
 									</ResultGroup>
 								))}
+
+							{!commandMode && searchCommandResults.length > 0 && (
+								<ResultGroup heading="Commands">
+									{searchCommandResults.map((command) => (
+										<Command.Item
+											key={command.id}
+											value={`command:${command.id}`}
+											onSelect={() => runCommand(command)}
+											className={ROW_CLASS}
+										>
+											<CommandRow command={command} query={query} />
+										</Command.Item>
+									))}
+								</ResultGroup>
+							)}
 
 							{!commandMode && nameResults.length > 0 && (
 								<ResultGroup heading={isEmptyQuery ? "Recent" : "Notes"}>
@@ -408,11 +426,9 @@ function GlobalSearchPalette({
 							{commands.length > 0 && (
 								<span className="ms-auto flex items-center gap-1.5">
 									<kbd className="flex h-4 min-w-4 items-center justify-center rounded-[var(--radius-inner)] border border-border px-1 font-sans text-[10px] leading-none text-muted-foreground">
-										{commandMode
-											? formatShortcut("Backspace")
-											: COMMAND_PREFIX}
+										{commandMode ? formatShortcut("Backspace") : COMMAND_PREFIX}
 									</kbd>
-									{commandMode ? "Search notes" : "Commands"}
+									{commandMode ? "Search notes" : "All commands"}
 								</span>
 							)}
 						</div>

--- a/packages/ui/src/components/GlobalSearchPalette.tsx
+++ b/packages/ui/src/components/GlobalSearchPalette.tsx
@@ -256,9 +256,9 @@ function GlobalSearchPalette({
 	// would otherwise fight the palette's own closing focus restore.
 	const runCommand = async (command: PaletteCommand) => {
 		onOpenChange(false);
-		onRunCommand?.(command.id);
 		try {
 			await command.run();
+			onRunCommand?.(command.id);
 		} catch (error) {
 			console.error(`Failed to run command "${command.label}":`, error);
 		}

--- a/packages/ui/src/editor/EditorView.tsx
+++ b/packages/ui/src/editor/EditorView.tsx
@@ -28,6 +28,7 @@ import {
 	useEditor,
 } from "@tiptap/react";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { clearActiveEditor, setActiveEditor } from "./activeEditor";
 import { CODE_BLOCK_COPY_EVENT, HubbleCodeBlock } from "./CodeBlockExtension";
 import { copySelectionAsMarkdown } from "./copyAsMarkdown";
 import { LinkClickExtension } from "./LinkClickExtension";
@@ -229,6 +230,8 @@ export function EditorView({
 	});
 	useLayoutEffect(() => {
 		editorRef.current = editor;
+		setActiveEditor(editor);
+		return () => clearActiveEditor(editor);
 	}, [editor]);
 
 	useEffect(() => {

--- a/packages/ui/src/editor/FormatCommandMenu.tsx
+++ b/packages/ui/src/editor/FormatCommandMenu.tsx
@@ -217,6 +217,7 @@ export function FormatCommandMenu({
 				if (!keymatch(event, getCommand("app.format-menu").defaultBinding))
 					return;
 				if (!editor.isFocused && !open) return;
+				if (!open && editor.state.selection.empty) return;
 				event.preventDefault();
 				if (open) {
 					closeMenu();

--- a/packages/ui/src/editor/FormatCommandMenu.tsx
+++ b/packages/ui/src/editor/FormatCommandMenu.tsx
@@ -219,6 +219,7 @@ export function FormatCommandMenu({
 				if (!editor.isFocused && !open) return;
 				if (!open && editor.state.selection.empty) return;
 				event.preventDefault();
+				event.stopImmediatePropagation();
 				if (open) {
 					closeMenu();
 					return;
@@ -226,8 +227,8 @@ export function FormatCommandMenu({
 				openMenu();
 			};
 
-			window.addEventListener("keydown", handleKeyDown);
-			return () => window.removeEventListener("keydown", handleKeyDown);
+			window.addEventListener("keydown", handleKeyDown, true);
+			return () => window.removeEventListener("keydown", handleKeyDown, true);
 		},
 		// biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler stabilizes render-local callbacks.
 		[closeMenu, editor, open, openMenu],

--- a/packages/ui/src/editor/activeEditor.ts
+++ b/packages/ui/src/editor/activeEditor.ts
@@ -1,0 +1,88 @@
+import type { Editor } from "@tiptap/react";
+
+/**
+ * The rich-text editor currently mounted, if any.
+ *
+ * Editor commands are normally reached through the keymap or a menu that
+ * already holds an `Editor`. The command palette has neither: it runs from a
+ * dialog that has taken focus away from the document, so it needs a way to
+ * reach the editor that was active when it opened.
+ *
+ * Hubble mounts at most one rich-text editor at a time, so a single slot is
+ * enough. If split view ever lands this becomes a focused-editor lookup rather
+ * than a lone reference.
+ */
+let active: Editor | null = null;
+
+export function setActiveEditor(editor: Editor | null) {
+	active = editor;
+}
+
+/**
+ * Clears the slot only if `editor` still owns it.
+ *
+ * An unmounting editor must not blank out a newer one: switching notes mounts
+ * the replacement before React runs the old effect's cleanup, so an
+ * unconditional clear would leave no active editor at all.
+ */
+export function clearActiveEditor(editor: Editor | null) {
+	if (active === editor) active = null;
+}
+
+export function getActiveEditor(): Editor | null {
+	// A destroyed editor throws on any command call, and unmount ordering means
+	// we can still be holding one; treat it as absent.
+	if (active?.isDestroyed) return null;
+	return active;
+}
+
+/**
+ * Formatting actions a caller outside the editor can trigger by name.
+ *
+ * Named actions rather than an exposed TipTap chain: the `Commands` interface
+ * is assembled by declaration merging from the extension packages this module
+ * imports, so a caller in another package sees a bare `ChainedCommands` and
+ * cannot type `toggleBold`. Keeping the chain here also means consumers never
+ * depend on which extension provides a given mark.
+ */
+const EDITOR_ACTIONS = {
+	bold: (chain) => chain.toggleBold(),
+	italic: (chain) => chain.toggleItalic(),
+	code: (chain) => chain.toggleCode(),
+	strike: (chain) => chain.toggleStrike(),
+	"heading-1": (chain) => chain.toggleHeading({ level: 1 }),
+	"heading-2": (chain) => chain.toggleHeading({ level: 2 }),
+	"heading-3": (chain) => chain.toggleHeading({ level: 3 }),
+	// Hubble's own list commands, not TipTap's. `ListToggleExtension` retypes
+	// the nearest enclosing list rather than wrapping the block, and its task
+	// list is a bullet list of `task` items rather than TipTap's `taskList`
+	// node — so `toggleTaskList` silently does nothing here. These are the exact
+	// commands `Mod-Shift-7/8/9` already run.
+	"bullet-list": (chain) => chain.toggleParentBulletList(),
+	"ordered-list": (chain) => chain.toggleParentOrderedList(),
+	"task-list": (chain) => chain.toggleParentTaskList(),
+	blockquote: (chain) => chain.toggleBlockquote(),
+} satisfies Record<
+	string,
+	(chain: ReturnType<Editor["chain"]>) => ReturnType<Editor["chain"]>
+>;
+
+export type EditorActionId = keyof typeof EDITOR_ACTIONS;
+
+export const editorActionIds = Object.keys(EDITOR_ACTIONS) as EditorActionId[];
+
+/**
+ * Runs a named formatting action against the active editor.
+ *
+ * Focus is restored first: the palette closes before the command runs, so the
+ * selection is still in the document but focus is not, and without `focus()` a
+ * mark toggle would apply to a collapsed selection the user cannot see.
+ *
+ * Returns false when no editor is mounted, so callers can stay silent rather
+ * than reporting a failure the user cannot act on.
+ */
+export function runEditorAction(action: EditorActionId): boolean {
+	const editor = getActiveEditor();
+	if (!editor) return false;
+	return EDITOR_ACTIONS[action](editor.chain().focus()).run();
+}

--- a/packages/ui/src/editor/activeEditor.ts
+++ b/packages/ui/src/editor/activeEditor.ts
@@ -1,50 +1,21 @@
 import type { Editor } from "@tiptap/react";
 
-/**
- * The rich-text editor currently mounted, if any.
- *
- * Editor commands are normally reached through the keymap or a menu that
- * already holds an `Editor`. The command palette has neither: it runs from a
- * dialog that has taken focus away from the document, so it needs a way to
- * reach the editor that was active when it opened.
- *
- * Hubble mounts at most one rich-text editor at a time, so a single slot is
- * enough. If split view ever lands this becomes a focused-editor lookup rather
- * than a lone reference.
- */
 let active: Editor | null = null;
 
 export function setActiveEditor(editor: Editor | null) {
 	active = editor;
 }
 
-/**
- * Clears the slot only if `editor` still owns it.
- *
- * An unmounting editor must not blank out a newer one: switching notes mounts
- * the replacement before React runs the old effect's cleanup, so an
- * unconditional clear would leave no active editor at all.
- */
 export function clearActiveEditor(editor: Editor | null) {
+	// An old editor may clean up after its replacement mounts.
 	if (active === editor) active = null;
 }
 
 export function getActiveEditor(): Editor | null {
-	// A destroyed editor throws on any command call, and unmount ordering means
-	// we can still be holding one; treat it as absent.
 	if (active?.isDestroyed) return null;
 	return active;
 }
 
-/**
- * Formatting actions a caller outside the editor can trigger by name.
- *
- * Named actions rather than an exposed TipTap chain: the `Commands` interface
- * is assembled by declaration merging from the extension packages this module
- * imports, so a caller in another package sees a bare `ChainedCommands` and
- * cannot type `toggleBold`. Keeping the chain here also means consumers never
- * depend on which extension provides a given mark.
- */
 const EDITOR_ACTIONS = {
 	bold: (chain) => chain.toggleBold(),
 	italic: (chain) => chain.toggleItalic(),
@@ -53,11 +24,7 @@ const EDITOR_ACTIONS = {
 	"heading-1": (chain) => chain.toggleHeading({ level: 1 }),
 	"heading-2": (chain) => chain.toggleHeading({ level: 2 }),
 	"heading-3": (chain) => chain.toggleHeading({ level: 3 }),
-	// Hubble's own list commands, not TipTap's. `ListToggleExtension` retypes
-	// the nearest enclosing list rather than wrapping the block, and its task
-	// list is a bullet list of `task` items rather than TipTap's `taskList`
-	// node — so `toggleTaskList` silently does nothing here. These are the exact
-	// commands `Mod-Shift-7/8/9` already run.
+	// TipTap's task list does not match Hubble's schema.
 	"bullet-list": (chain) => chain.toggleParentBulletList(),
 	"ordered-list": (chain) => chain.toggleParentOrderedList(),
 	"task-list": (chain) => chain.toggleParentTaskList(),
@@ -71,18 +38,9 @@ export type EditorActionId = keyof typeof EDITOR_ACTIONS;
 
 export const editorActionIds = Object.keys(EDITOR_ACTIONS) as EditorActionId[];
 
-/**
- * Runs a named formatting action against the active editor.
- *
- * Focus is restored first: the palette closes before the command runs, so the
- * selection is still in the document but focus is not, and without `focus()` a
- * mark toggle would apply to a collapsed selection the user cannot see.
- *
- * Returns false when no editor is mounted, so callers can stay silent rather
- * than reporting a failure the user cannot act on.
- */
 export function runEditorAction(action: EditorActionId): boolean {
 	const editor = getActiveEditor();
 	if (!editor) return false;
+	// The palette takes focus before running the command.
 	return EDITOR_ACTIONS[action](editor.chain().focus()).run();
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -21,6 +21,14 @@ export {
 export { NewNoteButton, Toolbar } from "./components/Toolbar";
 export { WorkspaceSwitcherMenu } from "./components/WorkspaceSwitcherMenu";
 export {
+	clearActiveEditor,
+	type EditorActionId,
+	editorActionIds,
+	getActiveEditor,
+	runEditorAction,
+	setActiveEditor,
+} from "./editor/activeEditor";
+export {
 	EditorView,
 	type EditorViewProps,
 	type WikiTarget,
@@ -53,6 +61,15 @@ export {
 	type ResizePointerContext,
 	useResizeSeparator,
 } from "./hooks/useResizeSeparator";
+export {
+	COMMAND_PREFIX,
+	groupCommands,
+	isCommandQuery,
+	type PaletteCommand,
+	rankCommands,
+	scoreCommand,
+	stripCommandPrefix,
+} from "./lib/paletteCommand";
 export { formatCommandShortcut, formatShortcut } from "./lib/shortcut";
 export { Button, buttonVariants } from "./primitives/button";
 export { Input } from "./primitives/input";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -65,8 +65,10 @@ export {
 	COMMAND_PREFIX,
 	groupCommands,
 	isCommandQuery,
+	OPEN_COMMAND_PALETTE_EVENT,
 	type PaletteCommand,
 	rankCommands,
+	rankSearchCommands,
 	scoreCommand,
 	stripCommandPrefix,
 } from "./lib/paletteCommand";

--- a/packages/ui/src/lib/paletteCommand.test.ts
+++ b/packages/ui/src/lib/paletteCommand.test.ts
@@ -4,6 +4,7 @@ import {
 	isCommandQuery,
 	type PaletteCommand,
 	rankCommands,
+	rankSearchCommands,
 	scoreCommand,
 	stripCommandPrefix,
 } from "./paletteCommand";
@@ -101,6 +102,41 @@ describe("rankCommands", () => {
 		const tied = [command("a", "Copy Path"), command("b", "Copy Path")];
 		expect(rankCommands("copy path", tied, ["b"])[0].id).toBe("b");
 		expect(rankCommands("copy path", tied)[0].id).toBe("a");
+	});
+});
+
+describe("rankSearchCommands", () => {
+	const commands = [
+		command("a", "Settings"),
+		command("b", "Switch Theme", "View", ["dark mode"]),
+		command("c", "Show Sidebar"),
+		command("d", "Show Source"),
+		command("e", "Show Terminal"),
+		{ ...command("f", "Delete Note"), destructive: true },
+	];
+
+	it("requires a meaningful query", () => {
+		expect(rankSearchCommands("", commands)).toEqual([]);
+		expect(rankSearchCommands("s", commands)).toEqual([]);
+		expect(rankSearchCommands("--", commands)).toEqual([]);
+	});
+
+	it("keeps strong label and synonym matches", () => {
+		expect(rankSearchCommands("set", commands).map(({ id }) => id)).toEqual([
+			"a",
+		]);
+		expect(rankSearchCommands("dark", commands).map(({ id }) => id)).toEqual([
+			"b",
+		]);
+	});
+
+	it("drops loose and destructive matches", () => {
+		expect(rankSearchCommands("ss", commands)).toEqual([]);
+		expect(rankSearchCommands("delete", commands)).toEqual([]);
+	});
+
+	it("shows at most three commands", () => {
+		expect(rankSearchCommands("sh", commands)).toHaveLength(3);
 	});
 });
 

--- a/packages/ui/src/lib/paletteCommand.test.ts
+++ b/packages/ui/src/lib/paletteCommand.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import {
+	groupCommands,
+	isCommandQuery,
+	type PaletteCommand,
+	rankCommands,
+	scoreCommand,
+	stripCommandPrefix,
+} from "./paletteCommand";
+
+function command(
+	id: string,
+	label: string,
+	group = "App",
+	keywords?: string[],
+): PaletteCommand {
+	return { id, label, group, keywords, run: () => {} };
+}
+
+describe("isCommandQuery / stripCommandPrefix", () => {
+	it("treats a leading slash as command mode", () => {
+		expect(isCommandQuery("/")).toBe(true);
+		expect(isCommandQuery("/bold")).toBe(true);
+		expect(isCommandQuery("bold")).toBe(false);
+		expect(isCommandQuery("")).toBe(false);
+	});
+
+	it("only strips a leading prefix", () => {
+		expect(stripCommandPrefix("/bold")).toBe("bold");
+		// A path segment mid-query is content, not a mode switch.
+		expect(stripCommandPrefix("notes/todo")).toBe("notes/todo");
+	});
+
+	it("strips only the first slash, so nested paths survive", () => {
+		expect(stripCommandPrefix("/notes/todo")).toBe("notes/todo");
+	});
+});
+
+describe("scoreCommand", () => {
+	it("ranks a label hit above a keyword hit", () => {
+		const label = command("a", "New Note");
+		const keyword = command("b", "Create Folder", "File", ["new"]);
+		expect(scoreCommand("new", label)).toBeGreaterThan(
+			scoreCommand("new", keyword),
+		);
+	});
+
+	it("ranks a keyword hit above a group-name hit", () => {
+		const keyword = command("a", "Toggle Theme", "View", ["dark mode"]);
+		const group = command("b", "Zoom In", "dark mode");
+		expect(scoreCommand("dark mode", keyword)).toBeGreaterThan(
+			scoreCommand("dark mode", group),
+		);
+	});
+
+	it("finds a command through a synonym its label never uses", () => {
+		const reveal = command("a", "Reveal in File Manager", "File", ["finder"]);
+		expect(scoreCommand("finder", reveal)).toBeGreaterThan(0);
+	});
+
+	it("does not match a subsequence spanning two separate keywords", () => {
+		// "ax" would match if keywords were joined into one searchable string.
+		const spanning = command("a", "Unrelated", "App", ["alpha", "xray"]);
+		expect(scoreCommand("ax", spanning)).toBe(0);
+	});
+});
+
+describe("rankCommands", () => {
+	const commands = [
+		command("a", "Bold"),
+		command("b", "Bulleted List"),
+		command("c", "Zoom In"),
+	];
+
+	it("drops commands that do not match", () => {
+		const ranked = rankCommands("bold", commands);
+		expect(ranked.map((entry) => entry.id)).toEqual(["a"]);
+	});
+
+	it("orders an empty query purely by recency", () => {
+		const ranked = rankCommands("", commands, ["c", "b"]);
+		expect(ranked.map((entry) => entry.id)).toEqual(["c", "b", "a"]);
+	});
+
+	it("never floats a recent command above a stronger text match", () => {
+		// "Bold" is an exact hit; "Bulleted List" only a prefix hit, even though
+		// it was used more recently.
+		const ranked = rankCommands("bold", [...commands], ["b"]);
+		expect(ranked[0].id).toBe("a");
+	});
+
+	it("breaks ties by recency before falling back to alphabetical", () => {
+		const tied = [command("a", "Copy Path"), command("b", "Copy Path")];
+		expect(rankCommands("copy path", tied, ["b"])[0].id).toBe("b");
+		expect(rankCommands("copy path", tied)[0].id).toBe("a");
+	});
+});
+
+describe("groupCommands", () => {
+	it("orders groups by their best-scoring member, not alphabetically", () => {
+		const ranked = [
+			command("a", "Zoom In", "View"),
+			command("b", "New Note", "File"),
+			command("c", "Zoom Out", "View"),
+		];
+		expect(groupCommands(ranked).map((entry) => entry.group)).toEqual([
+			"View",
+			"File",
+		]);
+	});
+
+	it("keeps every command in exactly one group", () => {
+		const ranked = [
+			command("a", "Bold", "Editor"),
+			command("b", "New Note", "File"),
+			command("c", "Italic", "Editor"),
+		];
+		const grouped = groupCommands(ranked);
+		expect(grouped.flatMap((entry) => entry.commands.map((c) => c.id))).toEqual(
+			["a", "c", "b"],
+		);
+	});
+});

--- a/packages/ui/src/lib/paletteCommand.test.ts
+++ b/packages/ui/src/lib/paletteCommand.test.ts
@@ -28,7 +28,6 @@ describe("isCommandQuery / stripCommandPrefix", () => {
 
 	it("only strips a leading prefix", () => {
 		expect(stripCommandPrefix("/bold")).toBe("bold");
-		// A path segment mid-query is content, not a mode switch.
 		expect(stripCommandPrefix("notes/todo")).toBe("notes/todo");
 	});
 
@@ -36,9 +35,6 @@ describe("isCommandQuery / stripCommandPrefix", () => {
 		expect(stripCommandPrefix("/notes/todo")).toBe("notes/todo");
 	});
 
-	// The palette promotes the prefix to a chip on the keystroke that produces
-	// it, so only the empty-query case ever triggers the switch. A slash typed
-	// later is an ordinary character in a filename.
 	it("does not treat a slash after other text as a mode switch", () => {
 		expect(isCommandQuery("notes/")).toBe(false);
 		expect(isCommandQuery("a/b")).toBe(false);
@@ -68,7 +64,6 @@ describe("scoreCommand", () => {
 	});
 
 	it("does not match a subsequence spanning two separate keywords", () => {
-		// "ax" would match if keywords were joined into one searchable string.
 		const spanning = command("a", "Unrelated", "App", ["alpha", "xray"]);
 		expect(scoreCommand("ax", spanning)).toBe(0);
 	});
@@ -92,8 +87,6 @@ describe("rankCommands", () => {
 	});
 
 	it("never floats a recent command above a stronger text match", () => {
-		// "Bold" is an exact hit; "Bulleted List" only a prefix hit, even though
-		// it was used more recently.
 		const ranked = rankCommands("bold", [...commands], ["b"]);
 		expect(ranked[0].id).toBe("a");
 	});

--- a/packages/ui/src/lib/paletteCommand.test.ts
+++ b/packages/ui/src/lib/paletteCommand.test.ts
@@ -34,6 +34,14 @@ describe("isCommandQuery / stripCommandPrefix", () => {
 	it("strips only the first slash, so nested paths survive", () => {
 		expect(stripCommandPrefix("/notes/todo")).toBe("notes/todo");
 	});
+
+	// The palette promotes the prefix to a chip on the keystroke that produces
+	// it, so only the empty-query case ever triggers the switch. A slash typed
+	// later is an ordinary character in a filename.
+	it("does not treat a slash after other text as a mode switch", () => {
+		expect(isCommandQuery("notes/")).toBe(false);
+		expect(isCommandQuery("a/b")).toBe(false);
+	});
 });
 
 describe("scoreCommand", () => {

--- a/packages/ui/src/lib/paletteCommand.test.ts
+++ b/packages/ui/src/lib/paletteCommand.test.ts
@@ -105,7 +105,6 @@ describe("rankSearchCommands", () => {
 		command("c", "Show Sidebar"),
 		command("d", "Show Source"),
 		command("e", "Show Terminal"),
-		{ ...command("f", "Delete Note"), destructive: true },
 	];
 
 	it("requires a meaningful query", () => {
@@ -123,9 +122,8 @@ describe("rankSearchCommands", () => {
 		]);
 	});
 
-	it("drops loose and destructive matches", () => {
+	it("drops loose matches", () => {
 		expect(rankSearchCommands("ss", commands)).toEqual([]);
-		expect(rankSearchCommands("delete", commands)).toEqual([]);
 	});
 
 	it("shows at most three commands", () => {

--- a/packages/ui/src/lib/paletteCommand.ts
+++ b/packages/ui/src/lib/paletteCommand.ts
@@ -5,7 +5,6 @@ export type PaletteCommand = {
 	label: string;
 	group: string;
 	keywords?: string[];
-	destructive?: boolean;
 	globalShortcut?: boolean;
 	binding?: string;
 	shortcut?: string;
@@ -55,11 +54,7 @@ export function rankSearchCommands(
 	const trimmed = query.trim();
 	if (trimmed.replace(/[\s_-]+/g, "").length < 2) return [];
 
-	return rankCommands(
-		trimmed,
-		commands.filter((command) => !command.destructive),
-		recentIds,
-	)
+	return rankCommands(trimmed, commands, recentIds)
 		.filter(
 			(command) => scoreCommand(trimmed, command) >= MIN_SEARCH_COMMAND_SCORE,
 		)

--- a/packages/ui/src/lib/paletteCommand.ts
+++ b/packages/ui/src/lib/paletteCommand.ts
@@ -18,7 +18,9 @@ export type PaletteCommand = {
 	group: string;
 	/** Search synonyms, so "theme" finds "Toggle Dark Mode". */
 	keywords?: string[];
-	/** Already formatted for the platform via `formatShortcut`. */
+	/** Raw shortcut used to dismiss the palette before the host handles it. */
+	binding?: string;
+	/** Shortcut formatted for display via `formatShortcut`. */
 	shortcut?: string;
 	run: () => void | Promise<void>;
 };

--- a/packages/ui/src/lib/paletteCommand.ts
+++ b/packages/ui/src/lib/paletteCommand.ts
@@ -20,6 +20,8 @@ export type PaletteCommand = {
 	keywords?: string[];
 	/** Destructive commands require explicit slash-mode intent. */
 	destructive?: boolean;
+	/** The host handles this shortcut even while the palette input has focus. */
+	globalShortcut?: boolean;
 	/** Raw shortcut used to dismiss the palette before the host handles it. */
 	binding?: string;
 	/** Shortcut formatted for display via `formatShortcut`. */
@@ -120,6 +122,7 @@ export function groupCommands(
 }
 
 const COMMAND_PREFIX = "/";
+const OPEN_COMMAND_PALETTE_EVENT = "hubble:open-command-palette";
 
 /**
  * Command mode is entered by a leading `/`, matching the editor's own slash
@@ -133,4 +136,4 @@ export function stripCommandPrefix(query: string): string {
 	return isCommandQuery(query) ? query.slice(COMMAND_PREFIX.length) : query;
 }
 
-export { COMMAND_PREFIX };
+export { COMMAND_PREFIX, OPEN_COMMAND_PALETTE_EVENT };

--- a/packages/ui/src/lib/paletteCommand.ts
+++ b/packages/ui/src/lib/paletteCommand.ts
@@ -18,6 +18,8 @@ export type PaletteCommand = {
 	group: string;
 	/** Search synonyms, so "theme" finds "Toggle Dark Mode". */
 	keywords?: string[];
+	/** Destructive commands require explicit slash-mode intent. */
+	destructive?: boolean;
 	/** Raw shortcut used to dismiss the palette before the host handles it. */
 	binding?: string;
 	/** Shortcut formatted for display via `formatShortcut`. */
@@ -73,6 +75,29 @@ export function rankCommands(
 				a.command.label.localeCompare(b.command.label),
 		)
 		.map((entry) => entry.command);
+}
+
+const MIN_SEARCH_COMMAND_SCORE = 0.63;
+const MAX_SEARCH_COMMANDS = 3;
+
+/** Strong, safe command matches shown alongside note search results. */
+export function rankSearchCommands(
+	query: string,
+	commands: PaletteCommand[],
+	recentIds: string[] = [],
+): PaletteCommand[] {
+	const trimmed = query.trim();
+	if (trimmed.replace(/[\s_-]+/g, "").length < 2) return [];
+
+	return rankCommands(
+		trimmed,
+		commands.filter((command) => !command.destructive),
+		recentIds,
+	)
+		.filter(
+			(command) => scoreCommand(trimmed, command) >= MIN_SEARCH_COMMAND_SCORE,
+		)
+		.slice(0, MAX_SEARCH_COMMANDS);
 }
 
 /**

--- a/packages/ui/src/lib/paletteCommand.ts
+++ b/packages/ui/src/lib/paletteCommand.ts
@@ -1,0 +1,109 @@
+import { scoreText } from "./fuzzy";
+
+/**
+ * A runnable action shown in the palette's command mode.
+ *
+ * `label`, `group`, and `shortcut` are display-only; `run` is what the palette
+ * invokes. Commands are supplied by the host app rather than defined here so
+ * this package stays free of desktop-specific actions.
+ *
+ * Once the command registry (#193) lands, a `PaletteCommand` becomes a
+ * projection of a registry entry: `id`, `label`, and `shortcut` read straight
+ * from it, `run` comes from the shared handler map, and enablement is applied
+ * by the caller before the list reaches this component.
+ */
+export type PaletteCommand = {
+	id: string;
+	label: string;
+	group: string;
+	/** Search synonyms, so "theme" finds "Toggle Dark Mode". */
+	keywords?: string[];
+	/** Already formatted for the platform via `formatShortcut`. */
+	shortcut?: string;
+	run: () => void | Promise<void>;
+};
+
+/**
+ * Ranks a command against a query.
+ *
+ * The label carries full weight. Keywords and the group name are discounted so
+ * a direct label hit always outranks a synonym: for the query "new", "New
+ * Note" beats a File-group command that merely happens to list "new" as a
+ * keyword. Keywords are scored individually rather than as one joined string,
+ * otherwise a subsequence could span two unrelated synonyms and score a match
+ * that reads as a false positive.
+ */
+export function scoreCommand(query: string, command: PaletteCommand): number {
+	const label = scoreText(query, command.label);
+	const keyword = Math.max(
+		0,
+		...(command.keywords ?? []).map((word) => scoreText(query, word)),
+	);
+	const group = scoreText(query, command.group);
+	return Math.max(label, 0.7 * keyword, 0.5 * group);
+}
+
+/**
+ * Filters and orders commands for a query.
+ *
+ * `recentIds` is most-recently-run first and only breaks ties between equal
+ * scores, so frecency makes the list feel learned without ever floating a
+ * weaker text match above a stronger one. On an empty query every command
+ * scores 1, which collapses the ordering to pure recency — the Raycast
+ * behavior where the palette opens already showing what you last did.
+ */
+export function rankCommands(
+	query: string,
+	commands: PaletteCommand[],
+	recentIds: string[] = [],
+): PaletteCommand[] {
+	const recency = new Map(recentIds.map((id, index) => [id, index]));
+	const rank = (command: PaletteCommand) =>
+		recency.get(command.id) ?? Number.MAX_SAFE_INTEGER;
+
+	return commands
+		.map((command) => ({ command, score: scoreCommand(query, command) }))
+		.filter((entry) => entry.score > 0)
+		.sort(
+			(a, b) =>
+				b.score - a.score ||
+				rank(a.command) - rank(b.command) ||
+				a.command.label.localeCompare(b.command.label),
+		)
+		.map((entry) => entry.command);
+}
+
+/**
+ * Groups ranked commands while preserving rank order.
+ *
+ * A group takes the position of its best-scoring member, so the group holding
+ * the top hit renders first instead of the list snapping back to a fixed
+ * category order and burying what the user actually typed.
+ */
+export function groupCommands(
+	commands: PaletteCommand[],
+): { group: string; commands: PaletteCommand[] }[] {
+	const groups = new Map<string, PaletteCommand[]>();
+	for (const command of commands) {
+		const existing = groups.get(command.group);
+		if (existing) existing.push(command);
+		else groups.set(command.group, [command]);
+	}
+	return [...groups].map(([group, items]) => ({ group, commands: items }));
+}
+
+const COMMAND_PREFIX = "/";
+
+/**
+ * Command mode is entered by a leading `/`, matching the editor's own slash
+ * menu so one key means "give me a list of things to run" everywhere in Hubble.
+ */
+export function isCommandQuery(query: string): boolean {
+	return query.startsWith(COMMAND_PREFIX);
+}
+
+export function stripCommandPrefix(query: string): string {
+	return isCommandQuery(query) ? query.slice(COMMAND_PREFIX.length) : query;
+}
+
+export { COMMAND_PREFIX };

--- a/packages/ui/src/lib/paletteCommand.ts
+++ b/packages/ui/src/lib/paletteCommand.ts
@@ -1,45 +1,19 @@
 import { scoreText } from "./fuzzy";
 
-/**
- * A runnable action shown in the palette's command mode.
- *
- * `label`, `group`, and `shortcut` are display-only; `run` is what the palette
- * invokes. Commands are supplied by the host app rather than defined here so
- * this package stays free of desktop-specific actions.
- *
- * Once the command registry (#193) lands, a `PaletteCommand` becomes a
- * projection of a registry entry: `id`, `label`, and `shortcut` read straight
- * from it, `run` comes from the shared handler map, and enablement is applied
- * by the caller before the list reaches this component.
- */
 export type PaletteCommand = {
 	id: string;
 	label: string;
 	group: string;
-	/** Search synonyms, so "theme" finds "Toggle Dark Mode". */
 	keywords?: string[];
-	/** Destructive commands require explicit slash-mode intent. */
 	destructive?: boolean;
-	/** The host handles this shortcut even while the palette input has focus. */
 	globalShortcut?: boolean;
-	/** Raw shortcut used to dismiss the palette before the host handles it. */
 	binding?: string;
-	/** Shortcut formatted for display via `formatShortcut`. */
 	shortcut?: string;
 	run: () => void | Promise<void>;
 };
 
-/**
- * Ranks a command against a query.
- *
- * The label carries full weight. Keywords and the group name are discounted so
- * a direct label hit always outranks a synonym: for the query "new", "New
- * Note" beats a File-group command that merely happens to list "new" as a
- * keyword. Keywords are scored individually rather than as one joined string,
- * otherwise a subsequence could span two unrelated synonyms and score a match
- * that reads as a false positive.
- */
 export function scoreCommand(query: string, command: PaletteCommand): number {
+	// Prefer labels, then synonyms, then group names.
 	const label = scoreText(query, command.label);
 	const keyword = Math.max(
 		0,
@@ -49,22 +23,13 @@ export function scoreCommand(query: string, command: PaletteCommand): number {
 	return Math.max(label, 0.7 * keyword, 0.5 * group);
 }
 
-/**
- * Filters and orders commands for a query.
- *
- * `recentIds` is most-recently-run first and only breaks ties between equal
- * scores, so frecency makes the list feel learned without ever floating a
- * weaker text match above a stronger one. On an empty query every command
- * scores 1, which collapses the ordering to pure recency — the Raycast
- * behavior where the palette opens already showing what you last did.
- */
 export function rankCommands(
 	query: string,
 	commands: PaletteCommand[],
 	recentIds: string[] = [],
 ): PaletteCommand[] {
 	const recency = new Map(recentIds.map((id, index) => [id, index]));
-	const rank = (command: PaletteCommand) =>
+	const recentRank = (command: PaletteCommand) =>
 		recency.get(command.id) ?? Number.MAX_SAFE_INTEGER;
 
 	return commands
@@ -73,7 +38,7 @@ export function rankCommands(
 		.sort(
 			(a, b) =>
 				b.score - a.score ||
-				rank(a.command) - rank(b.command) ||
+				recentRank(a.command) - recentRank(b.command) ||
 				a.command.label.localeCompare(b.command.label),
 		)
 		.map((entry) => entry.command);
@@ -82,7 +47,6 @@ export function rankCommands(
 const MIN_SEARCH_COMMAND_SCORE = 0.63;
 const MAX_SEARCH_COMMANDS = 3;
 
-/** Strong, safe command matches shown alongside note search results. */
 export function rankSearchCommands(
 	query: string,
 	commands: PaletteCommand[],
@@ -102,13 +66,6 @@ export function rankSearchCommands(
 		.slice(0, MAX_SEARCH_COMMANDS);
 }
 
-/**
- * Groups ranked commands while preserving rank order.
- *
- * A group takes the position of its best-scoring member, so the group holding
- * the top hit renders first instead of the list snapping back to a fixed
- * category order and burying what the user actually typed.
- */
 export function groupCommands(
 	commands: PaletteCommand[],
 ): { group: string; commands: PaletteCommand[] }[] {
@@ -124,10 +81,6 @@ export function groupCommands(
 const COMMAND_PREFIX = "/";
 const OPEN_COMMAND_PALETTE_EVENT = "hubble:open-command-palette";
 
-/**
- * Command mode is entered by a leading `/`, matching the editor's own slash
- * menu so one key means "give me a list of things to run" everywhere in Hubble.
- */
 export function isCommandQuery(query: string): boolean {
 	return query.startsWith(COMMAND_PREFIX);
 }


### PR DESCRIPTION
## Description

Prototype of the command palette proposed in #208, open as a **draft for the UX discussion**.

Refs #208

Updated for @bholmesdev's review: rebased onto latest `main` (with #195 merged), switched the prefix from `>` to `/`, dropped `⌘⇧P`, removed **Go to File** from the list, replaced the terminal icon, and promoted the prefix to a chip.

`⌘P` behaves exactly as it does today. Typing `/` switches from searching notes to running commands — the slash becomes a **chip** in the input's leading slot rather than text you have to read past, and Backspace on an empty query removes it. **One dialog, one keybinding, no mode to remember** — and `/` now means the same thing in the palette as it does in the editor.

**Everything in the palette already works in Hubble today.** This adds no new capability — it's a discoverability layer. Four of the commands (Reveal in File Manager, Copy File Path, Chat About This Note, Toggle Sidebar) currently have *no menu entry at all* and are reachable only if you already know the shortcut.

<!-- VIDEO: drag command-palette-demo.mp4 here -->

The demo shows, in order: `⌘P` file search unchanged → `/` becoming a chip → `/finder` finding **Reveal in File Manager** by synonym → running the theme toggle → reopening to find that command ranked first → Backspace removing the chip to fall back to notes → running **To-do List** on the current paragraph.

## Now built on the merged registry

The earlier revision declared its own labels and bindings because #195 hadn't landed. It now **projects over the registry** instead:

```ts
const command = getCommand(id);
return { id, label: command.label, binding: command.defaultBinding,
         isEnabled: () => command.isEnabled(registryContext), ... }
```

Label, binding, and enablement all come from `getCommand(id)`, so the palette cannot disagree with the menu bar or the key handler about what a command is called, what it's bound to, or when it applies. Only the palette's own concerns — `group`, `keywords`, and the handler — are declared locally, alongside the handful of actions with no registry entry (new folder, theme, zoom, updates, changelog).

**This caught a real bug in my own earlier version.** `app.open-folder` is the *workspace switcher* and `app.add-folder` *opens a folder into the sidebar* — my hand-written labels had those backwards. Reading from the registry fixed it for free, which is a decent argument for the approach.

Two notes on where the registry and the palette legitimately differ:

- **Editor commands.** The registry marks them `always` enabled, correctly, since the keymap only fires inside the editor. The palette has no such guard, so it ANDs in its own "is a rich-text editor actually mounted" check. Otherwise Bold would appear while viewing a PDF.
- **Zoom.** #193 deliberately excludes `⌘=` / `⌘-` / `⌘0` as OS convention. Those three keep their own hint strings and dispatch through a new IPC; the accelerators stay owned by the View menu.

`editor.link` is omitted — it opens the link popover, which needs the selection the palette has just taken focus from.

**Go to File is gone too.** You were right that it's circular: `⌘P` *is* the palette, so an entry that reopens it is meta, and pressing Enter on it did nothing visible because the palette was already open. It dropped out naturally when the list became a registry projection.

## What's in it

- `packages/ui/src/lib/paletteCommand.ts` — command type, scoring, grouping, prefix helpers. Reuses `scoreText` from `fuzzy.ts`.
- `packages/ui/src/components/GlobalSearchPalette.tsx` — command mode and the prefix chip. `query` only ever holds search terms; the prefix is held as mode state instead of living in the text.
- `apps/desktop/src/commands/useAppCommands.ts` — the registry projection.
- `apps/desktop/src/commands/recentCommands.ts` — recency ranking, persisted to its own `localStorage` key.
- `packages/ui/src/editor/activeEditor.ts` — single-slot registry for the mounted editor.
- Zoom IPC.

### Two decisions worth reviewing

**Disabled commands are dropped, not greyed out.** A palette is a search surface; a result you can select but not run reads as a bug. The menu bar still shows unavailable actions disabled, which is where that belongs. With no note open the palette lists 16 commands; with a Markdown note open, 32.

**Recency only breaks ties.** Labels score full weight, keywords and group names are discounted, and recency is applied *after* score — so a learned ordering can never float a weaker text match above a stronger one. On an empty query everything ties at 1, which collapses to pure recency.

## A bug this surfaced in the editor commands

My first pass used TipTap's `toggleTaskList` / `toggleBulletList` / `toggleOrderedList`. **They silently do nothing in Hubble** — `ListToggleExtension` retypes the nearest enclosing list, and a Hubble task list is a bullet list of `task` items rather than TipTap's `taskList` node. Bold worked, so the plumbing looked fine while list commands quietly no-opped.

Fixed to call `toggleParentBulletList` / `toggleParentOrderedList` / `toggleParentTaskList` — the same commands `Mod-Shift-7/8/9` run.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- [x] Existing tests pass
- [x] Added new tests for changes
- [x] Tested manually (describe below)

`pnpm build:desktop` (biome + build + typecheck) passes on the rebase. Test suites: **127 UI** (14 new for scoring, ranking, grouping, and prefix handling), **181 desktop**, **101 editor** — 409 passing.

**Manual Testing Details:**

Driven through CDP against the real Electron renderer on the dev playground:

- `⌘⇧P` is inert — nothing opens.
- `⌘P` opens file search unchanged; placeholder now reads "Search notes, or type / for commands".
- `/` promotes to a chip and switches to command mode in place (32 commands, grouped Editor / View / Navigate / App / File).
- Chip lifecycle: with `/bold` typed, four Backspaces clear the text and **keep** the chip; the fifth removes it and the Recent notes list returns; retyping `/` brings it back. No remount, no flicker.
- **Go to File** no longer appears in the list.
- Registry labels and bindings render correctly (`Add Folder... ⌘⇧N`, `Open Folder... ⌘⇧O`).
- Synonym search: `/finder` → Reveal in File Manager; `/checkbox` → To-do List.
- Enablement is live: 16 commands with no note open, 32 with a Markdown note.
- Commands actually run: theme toggled, To-do List added a checkbox (3 → 4), Numbered List converted `ul` → `ol`, Bulleted List converted back, Quote toggled a blockquote on and off, Heading 2 added an `h2`.
- Recency: after running a command, reopening ranks it first; `localStorage` survives reload.
- Focus returns to the ProseMirror editor after an editor command.

Not verified: Windows and Linux rendering of the shortcut hints, and screen-reader behavior of the mode switch.

## Open questions

- **`/` and absolute paths.** `/` as the first keystroke now always means "commands", so it can't start a path-prefixed file search. A slash *later* in the query is still ordinary text, so `notes/todo` works fine. Nothing searched absolute paths before, so I don't think this costs anything.
- **Discoverability without a keybinding.** With `⌘⇧P` gone, command mode is only reachable by typing `/` inside the palette. The placeholder and footer hint both advertise it, which I think is enough — but it is strictly less discoverable than a shortcut.
- **Ranking on very short queries.** Two characters can rank a label substring above a keyword hit (`/da` puts "Check for Updates" above "Switch to Light Theme", since `Up-da-tes` is a substring while `dark mode` is only a keyword prefix). It resolves by the third character. Tunable if it bothers you.
- **Rename Note** still isn't included. Renaming goes through the toolbar's inline title edit, so it needs a "start rename" signal rather than a callable action. Happy to add if wanted.
- Commands from #208 needing genuinely new behavior — Go to heading (needs #206's outline), Duplicate note, Move to folder, Insert date/time, focus mode, split view, agent activity log — remain **deliberately out of scope**.

## Checklist

- [x] I discussed this change in a GitHub issue before submitting this PR
- [x] I have run the linter, formatter, and tests to ensure my code is ready for review
