### PR TITLE
Undo file deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 ### Added
 
 - Keep the sidebar in sync when files and folders are added, deleted, or renamed outside Hubble. Thanks [@Mamdouh66](https://github.com/Mamdouh66) for the suggestion! [#202](https://github.com/bholmesdev/hubble.md/pull/202)
-- Undo file and folder deletions for eight seconds from the toast or with Cmd+Z. Starting another edit returns Cmd+Z to normal text undo. [#218](https://github.com/bholmesdev/hubble.md/pull/218)
+- Undo accidental file and folder deletions, including multi-select deletes, from the confirmation toast or with Cmd+Z. Thanks [@Siffrico](https://github.com/Siffrico) for the suggestion! [#218](https://github.com/bholmesdev/hubble.md/pull/218)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 ### Added
 
 - Keep the sidebar in sync when files and folders are added, deleted, or renamed outside Hubble. Thanks [@Mamdouh66](https://github.com/Mamdouh66) for the suggestion! [#202](https://github.com/bholmesdev/hubble.md/pull/202)
-- Undo accidental file and folder deletions, including multi-select deletes, from the confirmation toast or with Cmd+Z. Thanks [@Siffrico](https://github.com/Siffrico) for the suggestion! [#218](https://github.com/bholmesdev/hubble.md/pull/218)
+- Undo accidental file and folder deletions from the confirmation toast or with Cmd+Z. Thanks [@Siffrico](https://github.com/Siffrico) for the suggestion! [#218](https://github.com/bholmesdev/hubble.md/pull/218)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 ### Added
 
 - Keep the sidebar in sync when files and folders are added, deleted, or renamed outside Hubble. Thanks [@Mamdouh66](https://github.com/Mamdouh66) for the suggestion! [#202](https://github.com/bholmesdev/hubble.md/pull/202)
+- Undo file and folder deletions for eight seconds from the toast or with Cmd+Z. Starting another edit returns Cmd+Z to normal text undo. [#218](https://github.com/bholmesdev/hubble.md/pull/218)
 
 ### Changed
 

--- a/apps/desktop/electron/deleteUndo.test.ts
+++ b/apps/desktop/electron/deleteUndo.test.ts
@@ -18,28 +18,28 @@ describe("DeleteUndo", () => {
 	it("stages and restores a file", async () => {
 		const source = path.join(workspace, "note.md");
 		await fs.writeFile(source, "original");
-		const trash = new DeleteUndo();
+		const undo = new DeleteUndo();
 
-		const token = await trash.stage(workspace, [source]);
+		const token = await undo.stage(workspace, [source]);
 		await expect(fs.stat(source)).rejects.toMatchObject({ code: "ENOENT" });
 
-		await trash.restore(token);
+		await undo.restore(token);
 		expect(await fs.readFile(source, "utf8")).toBe("original");
 	});
 
 	it("keeps the staged file when its path is recreated", async () => {
 		const source = path.join(workspace, "note.md");
 		await fs.writeFile(source, "original");
-		const trash = new DeleteUndo();
-		const token = await trash.stage(workspace, [source]);
+		const undo = new DeleteUndo();
+		const token = await undo.stage(workspace, [source]);
 		await fs.writeFile(source, "replacement");
 
-		await expect(trash.restore(token)).rejects.toThrow(/Deleted files kept at/);
+		await expect(undo.restore(token)).rejects.toThrow(/Deleted files kept at/);
 
 		expect(await fs.readFile(source, "utf8")).toBe("replacement");
 		expect(
 			await fs.readFile(
-				path.join(workspace, ".hubble", "delete-recovery", token, "0"),
+				path.join(workspace, ".hubble", "recovered", token, "0"),
 				"utf8",
 			),
 		).toBe("original");

--- a/apps/desktop/electron/deleteUndo.test.ts
+++ b/apps/desktop/electron/deleteUndo.test.ts
@@ -1,0 +1,47 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DeleteUndo } from "./deleteUndo";
+
+describe("DeleteUndo", () => {
+	let workspace: string;
+
+	beforeEach(async () => {
+		workspace = await fs.mkdtemp(path.join(os.tmpdir(), "hubble-delete-undo-"));
+	});
+
+	afterEach(async () => {
+		await fs.rm(workspace, { recursive: true, force: true });
+	});
+
+	it("stages and restores a file", async () => {
+		const source = path.join(workspace, "note.md");
+		await fs.writeFile(source, "original");
+		const trash = new DeleteUndo();
+
+		const token = await trash.stage(workspace, [source]);
+		await expect(fs.stat(source)).rejects.toMatchObject({ code: "ENOENT" });
+
+		await trash.restore(token);
+		expect(await fs.readFile(source, "utf8")).toBe("original");
+	});
+
+	it("keeps the staged file when its path is recreated", async () => {
+		const source = path.join(workspace, "note.md");
+		await fs.writeFile(source, "original");
+		const trash = new DeleteUndo();
+		const token = await trash.stage(workspace, [source]);
+		await fs.writeFile(source, "replacement");
+
+		await expect(trash.restore(token)).rejects.toThrow(/Deleted files kept at/);
+
+		expect(await fs.readFile(source, "utf8")).toBe("replacement");
+		expect(
+			await fs.readFile(
+				path.join(workspace, ".hubble", "delete-recovery", token, "0"),
+				"utf8",
+			),
+		).toBe("original");
+	});
+});

--- a/apps/desktop/electron/deleteUndo.ts
+++ b/apps/desktop/electron/deleteUndo.ts
@@ -1,0 +1,185 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { HUBBLE_DIR } from "../src/lib/filePath";
+
+type Entry = { source: string; staged: string };
+type Job = {
+	dir: string;
+	entries: Entry[];
+	state: "staging" | "ready" | "restoring" | "dropping";
+};
+
+function exists(filePath: string) {
+	return fs.stat(filePath).then(
+		() => true,
+		() => false,
+	);
+}
+
+function isInside(root: string, candidate: string) {
+	const relative = path.relative(root, candidate);
+	return (
+		relative !== "" &&
+		relative !== ".." &&
+		!relative.startsWith(`..${path.sep}`) &&
+		!path.isAbsolute(relative)
+	);
+}
+
+/** Short-lived file trash backed by atomic moves within the workspace. */
+export class DeleteUndo {
+	private jobs = new Map<string, Job>();
+
+	async stage(workspace: string, paths: string[]) {
+		if (paths.length === 0) throw new Error("No files selected for deletion");
+		if (new Set(paths).size !== paths.length) {
+			throw new Error("Duplicate delete path");
+		}
+		for (const [index, source] of paths.entries()) {
+			const relative = path.relative(workspace, source);
+			if (
+				!isInside(workspace, source) ||
+				relative === HUBBLE_DIR ||
+				relative.startsWith(`${HUBBLE_DIR}${path.sep}`)
+			) {
+				throw new Error("Delete path is outside the workspace");
+			}
+			if (
+				paths.some(
+					(candidate, candidateIndex) =>
+						candidateIndex !== index && isInside(candidate, source),
+				)
+			) {
+				throw new Error("Delete paths cannot overlap");
+			}
+		}
+
+		const token = randomUUID();
+		const dir = path.join(workspace, HUBBLE_DIR, "trash", token);
+		const entries = paths.map((source, index) => ({
+			source,
+			staged: path.join(dir, String(index)),
+		}));
+		const job: Job = { dir, entries, state: "staging" };
+		this.jobs.set(token, job);
+		const moved: Entry[] = [];
+		try {
+			await fs.mkdir(dir, { recursive: true });
+			for (const entry of entries) {
+				await fs.rename(entry.source, entry.staged);
+				moved.push(entry);
+			}
+			job.state = "ready";
+			return token;
+		} catch (error) {
+			let failed = false;
+			for (const entry of moved.reverse()) {
+				try {
+					await fs.rename(entry.staged, entry.source);
+				} catch {
+					failed = true;
+				}
+			}
+			if (!failed) {
+				await fs.rm(dir, { recursive: true, force: true });
+				this.jobs.delete(token);
+				throw error;
+			}
+			const recovery = path.join(
+				workspace,
+				HUBBLE_DIR,
+				"delete-recovery",
+				token,
+			);
+			await fs.mkdir(path.dirname(recovery), { recursive: true });
+			await fs.rename(dir, recovery);
+			this.jobs.delete(token);
+			throw new Error(`Delete recovery required at ${recovery}`);
+		}
+	}
+
+	async restore(token: string) {
+		const job = this.jobs.get(token);
+		if (!job || job.state !== "ready") {
+			throw new Error("This deletion can no longer be undone");
+		}
+		for (const entry of job.entries) {
+			if (await exists(entry.source)) {
+				throw new Error(
+					`Cannot restore because this path exists: ${entry.source}`,
+				);
+			}
+		}
+		job.state = "restoring";
+		const moved: Entry[] = [];
+		try {
+			for (const entry of job.entries) {
+				await fs.mkdir(path.dirname(entry.source), { recursive: true });
+				await fs.rename(entry.staged, entry.source);
+				moved.push(entry);
+			}
+		} catch (error) {
+			let failed = false;
+			for (const entry of moved.reverse()) {
+				try {
+					if (!(await exists(entry.staged))) {
+						await fs.rename(entry.source, entry.staged);
+					}
+				} catch {
+					failed = true;
+				}
+			}
+			if (failed) {
+				const workspace = path.dirname(path.dirname(path.dirname(job.dir)));
+				const recovery = path.join(
+					workspace,
+					HUBBLE_DIR,
+					"delete-recovery",
+					path.basename(job.dir),
+				);
+				await fs.mkdir(path.dirname(recovery), { recursive: true });
+				await fs.rename(job.dir, recovery);
+				this.jobs.delete(token);
+				throw new Error(`Delete recovery required at ${recovery}`);
+			}
+			job.state = "ready";
+			throw error;
+		}
+		this.jobs.delete(token);
+		await fs.rm(job.dir, { recursive: true, force: true });
+		return job.entries.map((entry) => entry.source);
+	}
+
+	async drop(token: string) {
+		const job = this.jobs.get(token);
+		if (!job || job.state !== "ready") return;
+		job.state = "dropping";
+		await fs.rm(job.dir, { recursive: true, force: true });
+		this.jobs.delete(token);
+	}
+
+	async clean(workspace: string) {
+		const root = path.join(workspace, HUBBLE_DIR, "trash");
+		const active = new Set([...this.jobs.values()].map((job) => job.dir));
+		const entries = await fs
+			.readdir(root, { withFileTypes: true })
+			.catch((error) => {
+				if (
+					error &&
+					typeof error === "object" &&
+					"code" in error &&
+					error.code === "ENOENT"
+				) {
+					return [];
+				}
+				throw error;
+			});
+		for (const entry of entries) {
+			const entryPath = path.join(root, entry.name);
+			if (!active.has(entryPath)) {
+				await fs.rm(entryPath, { recursive: true, force: true });
+			}
+		}
+	}
+}

--- a/apps/desktop/electron/deleteUndo.ts
+++ b/apps/desktop/electron/deleteUndo.ts
@@ -5,6 +5,7 @@ import { HUBBLE_DIR } from "../src/lib/filePath";
 
 type Entry = { source: string; staged: string };
 type Job = {
+	workspace: string;
 	dir: string;
 	entries: Entry[];
 	state: "staging" | "ready" | "restoring" | "dropping";
@@ -32,9 +33,8 @@ export class DeleteUndo {
 	private jobs = new Map<string, Job>();
 
 	private async keepForRecovery(token: string, job: Job) {
-		const workspace = path.dirname(path.dirname(path.dirname(job.dir)));
 		const recovery = path.join(
-			workspace,
+			job.workspace,
 			HUBBLE_DIR,
 			"delete-recovery",
 			path.basename(job.dir),
@@ -75,7 +75,7 @@ export class DeleteUndo {
 			source,
 			staged: path.join(dir, String(index)),
 		}));
-		const job: Job = { dir, entries, state: "staging" };
+		const job: Job = { workspace, dir, entries, state: "staging" };
 		this.jobs.set(token, job);
 		const moved: Entry[] = [];
 		try {
@@ -149,9 +149,12 @@ export class DeleteUndo {
 		try {
 			await fs.rm(job.dir, { recursive: true, force: true });
 			this.jobs.delete(token);
-		} catch (error) {
+		} catch {
 			job.state = "ready";
-			throw error;
+			const recovery = await this.keepForRecovery(token, job);
+			throw new Error(
+				`Could not empty trash. Deleted files kept at ${recovery}`,
+			);
 		}
 	}
 

--- a/apps/desktop/electron/deleteUndo.ts
+++ b/apps/desktop/electron/deleteUndo.ts
@@ -28,7 +28,7 @@ function isInside(root: string, candidate: string) {
 	);
 }
 
-/** Short-lived file trash backed by atomic moves within the workspace. */
+/** Stages deletions for a short undo window using atomic moves within the workspace. */
 export class DeleteUndo {
 	private jobs = new Map<string, Job>();
 
@@ -36,7 +36,7 @@ export class DeleteUndo {
 		const recovery = path.join(
 			job.workspace,
 			HUBBLE_DIR,
-			"delete-recovery",
+			"recovered",
 			path.basename(job.dir),
 		);
 		await fs.mkdir(path.dirname(recovery), { recursive: true });
@@ -70,7 +70,7 @@ export class DeleteUndo {
 		}
 
 		const token = randomUUID();
-		const dir = path.join(workspace, HUBBLE_DIR, "trash", token);
+		const dir = path.join(workspace, HUBBLE_DIR, "deleting", token);
 		const entries = paths.map((source, index) => ({
 			source,
 			staged: path.join(dir, String(index)),
@@ -153,13 +153,13 @@ export class DeleteUndo {
 			job.state = "ready";
 			const recovery = await this.keepForRecovery(token, job);
 			throw new Error(
-				`Could not empty trash. Deleted files kept at ${recovery}`,
+				`Could not finish deleting. Deleted files kept at ${recovery}`,
 			);
 		}
 	}
 
 	async clean(workspace: string) {
-		const root = path.join(workspace, HUBBLE_DIR, "trash");
+		const root = path.join(workspace, HUBBLE_DIR, "deleting");
 		const active = new Set([...this.jobs.values()].map((job) => job.dir));
 		const entries = await fs
 			.readdir(root, { withFileTypes: true })

--- a/apps/desktop/electron/deleteUndo.ts
+++ b/apps/desktop/electron/deleteUndo.ts
@@ -31,6 +31,20 @@ function isInside(root: string, candidate: string) {
 export class DeleteUndo {
 	private jobs = new Map<string, Job>();
 
+	private async keepForRecovery(token: string, job: Job) {
+		const workspace = path.dirname(path.dirname(path.dirname(job.dir)));
+		const recovery = path.join(
+			workspace,
+			HUBBLE_DIR,
+			"delete-recovery",
+			path.basename(job.dir),
+		);
+		await fs.mkdir(path.dirname(recovery), { recursive: true });
+		await fs.rename(job.dir, recovery);
+		this.jobs.delete(token);
+		return recovery;
+	}
+
 	async stage(workspace: string, paths: string[]) {
 		if (paths.length === 0) throw new Error("No files selected for deletion");
 		if (new Set(paths).size !== paths.length) {
@@ -86,15 +100,7 @@ export class DeleteUndo {
 				this.jobs.delete(token);
 				throw error;
 			}
-			const recovery = path.join(
-				workspace,
-				HUBBLE_DIR,
-				"delete-recovery",
-				token,
-			);
-			await fs.mkdir(path.dirname(recovery), { recursive: true });
-			await fs.rename(dir, recovery);
-			this.jobs.delete(token);
+			const recovery = await this.keepForRecovery(token, job);
 			throw new Error(`Delete recovery required at ${recovery}`);
 		}
 	}
@@ -106,8 +112,9 @@ export class DeleteUndo {
 		}
 		for (const entry of job.entries) {
 			if (await exists(entry.source)) {
+				const recovery = await this.keepForRecovery(token, job);
 				throw new Error(
-					`Cannot restore because this path exists: ${entry.source}`,
+					`Cannot restore ${entry.source} because it exists. Deleted files kept at ${recovery}`,
 				);
 			}
 		}
@@ -119,32 +126,16 @@ export class DeleteUndo {
 				await fs.rename(entry.staged, entry.source);
 				moved.push(entry);
 			}
-		} catch (error) {
-			let failed = false;
+		} catch {
 			for (const entry of moved.reverse()) {
 				try {
 					if (!(await exists(entry.staged))) {
 						await fs.rename(entry.source, entry.staged);
 					}
-				} catch {
-					failed = true;
-				}
+				} catch {}
 			}
-			if (failed) {
-				const workspace = path.dirname(path.dirname(path.dirname(job.dir)));
-				const recovery = path.join(
-					workspace,
-					HUBBLE_DIR,
-					"delete-recovery",
-					path.basename(job.dir),
-				);
-				await fs.mkdir(path.dirname(recovery), { recursive: true });
-				await fs.rename(job.dir, recovery);
-				this.jobs.delete(token);
-				throw new Error(`Delete recovery required at ${recovery}`);
-			}
-			job.state = "ready";
-			throw error;
+			const recovery = await this.keepForRecovery(token, job);
+			throw new Error(`Delete recovery required at ${recovery}`);
 		}
 		this.jobs.delete(token);
 		await fs.rm(job.dir, { recursive: true, force: true });
@@ -155,8 +146,13 @@ export class DeleteUndo {
 		const job = this.jobs.get(token);
 		if (!job || job.state !== "ready") return;
 		job.state = "dropping";
-		await fs.rm(job.dir, { recursive: true, force: true });
-		this.jobs.delete(token);
+		try {
+			await fs.rm(job.dir, { recursive: true, force: true });
+			this.jobs.delete(token);
+		} catch (error) {
+			job.state = "ready";
+			throw error;
+		}
 	}
 
 	async clean(workspace: string) {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -277,14 +277,21 @@ async function restorePendingDelete(items: PendingDeleteItem[]) {
 }
 
 async function cleanStaleDeleteUndo(workspace: string) {
-	const undoRoot = path.join(workspace, workspaceConfigDir, "delete-undo");
+	const undoRoot = path.join(workspace, HUBBLE_DIR, "delete-undo");
 	const active = new Set(
 		[...pendingDeletes.values()].map((pending) => pending.operationDir),
 	);
 	const entries = await fs
 		.readdir(undoRoot, { withFileTypes: true })
 		.catch((error: unknown) => {
-			if (isMissingPathError(error)) return [];
+			if (
+				error &&
+				typeof error === "object" &&
+				"code" in error &&
+				error.code === "ENOENT"
+			) {
+				return [];
+			}
 			throw error;
 		});
 	for (const entry of entries) {
@@ -1568,7 +1575,7 @@ function registerIpc() {
 			const token = randomUUID();
 			const operationDir = path.join(
 				workspace,
-				workspaceConfigDir,
+				HUBBLE_DIR,
 				"delete-undo",
 				token,
 			);
@@ -1586,8 +1593,8 @@ function registerIpc() {
 				const relative = path.relative(workspace, item.originalPath);
 				if (
 					!relative ||
-					relative === workspaceConfigDir ||
-					relative.startsWith(`${workspaceConfigDir}${path.sep}`) ||
+					relative === HUBBLE_DIR ||
+					relative.startsWith(`${HUBBLE_DIR}${path.sep}`) ||
 					relative.startsWith(`..${path.sep}`) ||
 					path.isAbsolute(relative)
 				) {
@@ -1636,7 +1643,7 @@ function registerIpc() {
 				} else {
 					const recoveryDir = path.join(
 						workspace,
-						workspaceConfigDir,
+						HUBBLE_DIR,
 						"delete-recovery",
 						token,
 					);

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from "node:crypto";
+import { createHash } from "node:crypto";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -46,6 +46,7 @@ import {
 	SEARCH_MIN_QUERY_LENGTH,
 } from "../src/lib/searchContent";
 import type { ThemePreference } from "../src/theme";
+import { DeleteUndo } from "./deleteUndo";
 import { TelemetryManager } from "./telemetry";
 import { setupTerminalIpc } from "./terminal";
 import {
@@ -181,13 +182,7 @@ const grantedFiles = new Set<string>();
 const grantedRoots = new Set<string>();
 let grantsLoaded = false;
 let deleteUndoAvailable = false;
-type PendingDeleteItem = { originalPath: string; backupPath: string };
-type PendingDelete = {
-	operationDir: string;
-	items: PendingDeleteItem[];
-	state: "staging" | "pending" | "restoring" | "finalizing";
-};
-const pendingDeletes = new Map<string, PendingDelete>();
+const deleteUndo = new DeleteUndo();
 // An AbortSignal cannot cross IPC, so a superseded search is abandoned by
 // comparing its id against the newest one between files.
 let latestSearchRequestId = 0;
@@ -245,61 +240,6 @@ function windowStatePath(): string {
 
 function themeSourcePath(): string {
 	return path.join(app.getPath("userData"), "theme.json");
-}
-
-async function restorePendingDelete(items: PendingDeleteItem[]) {
-	for (const item of items) {
-		if (await pathExists(item.originalPath)) {
-			throw new Error(
-				`Cannot restore because this path exists: ${item.originalPath}`,
-			);
-		}
-	}
-	const restoredPaths: string[] = [];
-	try {
-		for (const item of items) {
-			await fs.mkdir(path.dirname(item.originalPath), { recursive: true });
-			await fs.rename(item.backupPath, item.originalPath);
-			restoredPaths.push(item.originalPath);
-			grantFileWithParent(item.originalPath);
-		}
-	} catch (error) {
-		for (const restoredPath of restoredPaths.reverse()) {
-			const item = items.find(
-				(candidate) => candidate.originalPath === restoredPath,
-			);
-			if (item && !(await pathExists(item.backupPath))) {
-				await fs.rename(restoredPath, item.backupPath);
-			}
-		}
-		throw error;
-	}
-}
-
-async function cleanStaleDeleteUndo(workspace: string) {
-	const undoRoot = path.join(workspace, HUBBLE_DIR, "delete-undo");
-	const active = new Set(
-		[...pendingDeletes.values()].map((pending) => pending.operationDir),
-	);
-	const entries = await fs
-		.readdir(undoRoot, { withFileTypes: true })
-		.catch((error: unknown) => {
-			if (
-				error &&
-				typeof error === "object" &&
-				"code" in error &&
-				error.code === "ENOENT"
-			) {
-				return [];
-			}
-			throw error;
-		});
-	for (const entry of entries) {
-		const entryPath = path.join(undoRoot, entry.name);
-		if (!active.has(entryPath)) {
-			await fs.rm(entryPath, { recursive: true, force: true });
-		}
-	}
 }
 
 function isThemePreference(value: unknown): value is ThemePreference {
@@ -1339,7 +1279,7 @@ function registerIpc() {
 			if (!stat.isDirectory()) {
 				throw new Error(`Not a directory: ${dirPath}`);
 			}
-			await cleanStaleDeleteUndo(root);
+			await deleteUndo.clean(root);
 			return listSidebarFiles(root);
 		},
 	);
@@ -1563,128 +1503,23 @@ function registerIpc() {
 		"desktop:stage-delete",
 		async (
 			_event,
-			{
-				workspacePath,
-				items,
-			}: { workspacePath: string; items: Array<{ path: string }> },
-		) => {
-			if (!Array.isArray(items) || items.length === 0) {
-				throw new Error("No files selected for deletion");
-			}
-			const workspace = assertGranted(workspacePath);
-			const token = randomUUID();
-			const operationDir = path.join(
-				workspace,
-				HUBBLE_DIR,
-				"delete-undo",
-				token,
-			);
-			const pendingItems = items.map((item, index) => ({
-				originalPath: assertGranted(item.path),
-				backupPath: path.join(operationDir, String(index)),
-			}));
-			const uniquePaths = new Set(
-				pendingItems.map((item) => item.originalPath),
-			);
-			if (uniquePaths.size !== pendingItems.length) {
-				throw new Error("Duplicate delete path");
-			}
-			for (const item of pendingItems) {
-				const relative = path.relative(workspace, item.originalPath);
-				if (
-					!relative ||
-					relative === HUBBLE_DIR ||
-					relative.startsWith(`${HUBBLE_DIR}${path.sep}`) ||
-					relative.startsWith(`..${path.sep}`) ||
-					path.isAbsolute(relative)
-				) {
-					throw new Error("Delete path is outside the workspace");
-				}
-			}
-			for (const [index, item] of pendingItems.entries()) {
-				if (
-					pendingItems.some(
-						(candidate, candidateIndex) =>
-							candidateIndex !== index &&
-							isWithin(candidate.originalPath, item.originalPath),
-					)
-				) {
-					throw new Error("Delete paths cannot overlap");
-				}
-			}
-
-			const moved: PendingDeleteItem[] = [];
-			const pending: PendingDelete = {
-				operationDir,
-				items: pendingItems,
-				state: "staging",
-			};
-			pendingDeletes.set(token, pending);
-			try {
-				await fs.mkdir(operationDir, { recursive: true });
-				for (const item of pendingItems) {
-					await fs.rename(item.originalPath, item.backupPath);
-					moved.push(item);
-				}
-				pending.state = "pending";
-				return token;
-			} catch (error) {
-				let rollbackFailed = false;
-				for (const item of moved.reverse()) {
-					try {
-						await fs.rename(item.backupPath, item.originalPath);
-					} catch {
-						rollbackFailed = true;
-					}
-				}
-				if (!rollbackFailed) {
-					pendingDeletes.delete(token);
-					await fs.rm(operationDir, { recursive: true, force: true });
-				} else {
-					const recoveryDir = path.join(
-						workspace,
-						HUBBLE_DIR,
-						"delete-recovery",
-						token,
-					);
-					await fs.mkdir(path.dirname(recoveryDir), { recursive: true });
-					await fs.rename(operationDir, recoveryDir);
-					pendingDeletes.delete(token);
-					throw new Error(`Delete recovery required at ${recoveryDir}`);
-				}
-				throw error;
-			}
-		},
+			{ workspacePath, paths }: { workspacePath: string; paths: string[] },
+		) =>
+			deleteUndo.stage(assertGranted(workspacePath), paths.map(assertGranted)),
 	);
 
 	ipcMain.handle(
 		"desktop:restore-delete",
 		async (_event, { token }: { token: string }) => {
-			const pending = pendingDeletes.get(token);
-			if (!pending || pending.state !== "pending") {
-				throw new Error("This deletion can no longer be undone");
-			}
-			pending.state = "restoring";
-			try {
-				await restorePendingDelete(pending.items);
-				pendingDeletes.delete(token);
-				await fs.rm(pending.operationDir, { recursive: true, force: true });
-			} catch (error) {
-				pending.state = "pending";
-				throw error;
+			for (const restoredPath of await deleteUndo.restore(token)) {
+				grantFileWithParent(restoredPath);
 			}
 		},
 	);
 
 	ipcMain.handle(
 		"desktop:finalize-delete",
-		async (_event, { token }: { token: string }) => {
-			const pending = pendingDeletes.get(token);
-			if (!pending || pending.state !== "pending") return;
-			pending.state = "finalizing";
-			await fs.rm(pending.operationDir, { recursive: true, force: true });
-			pendingDeletes.delete(token);
-		},
+		(_event, { token }: { token: string }) => deleteUndo.drop(token),
 	);
 
 	ipcMain.handle(

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -180,6 +180,14 @@ let workspaceWatcherStart = Promise.resolve();
 const grantedFiles = new Set<string>();
 const grantedRoots = new Set<string>();
 let grantsLoaded = false;
+let deleteUndoAvailable = false;
+type PendingDeleteItem = { originalPath: string; backupPath: string };
+type PendingDelete = {
+	operationDir: string;
+	items: PendingDeleteItem[];
+	state: "staging" | "pending" | "restoring" | "finalizing";
+};
+const pendingDeletes = new Map<string, PendingDelete>();
 // An AbortSignal cannot cross IPC, so a superseded search is abandoned by
 // comparing its id against the newest one between files.
 let latestSearchRequestId = 0;
@@ -237,6 +245,54 @@ function windowStatePath(): string {
 
 function themeSourcePath(): string {
 	return path.join(app.getPath("userData"), "theme.json");
+}
+
+async function restorePendingDelete(items: PendingDeleteItem[]) {
+	for (const item of items) {
+		if (await pathExists(item.originalPath)) {
+			throw new Error(
+				`Cannot restore because this path exists: ${item.originalPath}`,
+			);
+		}
+	}
+	const restoredPaths: string[] = [];
+	try {
+		for (const item of items) {
+			await fs.mkdir(path.dirname(item.originalPath), { recursive: true });
+			await fs.rename(item.backupPath, item.originalPath);
+			restoredPaths.push(item.originalPath);
+			grantFileWithParent(item.originalPath);
+		}
+	} catch (error) {
+		for (const restoredPath of restoredPaths.reverse()) {
+			const item = items.find(
+				(candidate) => candidate.originalPath === restoredPath,
+			);
+			if (item && !(await pathExists(item.backupPath))) {
+				await fs.rename(restoredPath, item.backupPath);
+			}
+		}
+		throw error;
+	}
+}
+
+async function cleanStaleDeleteUndo(workspace: string) {
+	const undoRoot = path.join(workspace, workspaceConfigDir, "delete-undo");
+	const active = new Set(
+		[...pendingDeletes.values()].map((pending) => pending.operationDir),
+	);
+	const entries = await fs
+		.readdir(undoRoot, { withFileTypes: true })
+		.catch((error: unknown) => {
+			if (isMissingPathError(error)) return [];
+			throw error;
+		});
+	for (const entry of entries) {
+		const entryPath = path.join(undoRoot, entry.name);
+		if (!active.has(entryPath)) {
+			await fs.rm(entryPath, { recursive: true, force: true });
+		}
+	}
 }
 
 function isThemePreference(value: unknown): value is ThemePreference {
@@ -849,7 +905,13 @@ function buildMenu() {
 		{
 			label: "Edit",
 			submenu: [
-				{ role: "undo" },
+				deleteUndoAvailable
+					? {
+							label: "Undo Delete",
+							accelerator: "CmdOrCtrl+Z",
+							click: () => sendToRenderer("desktop:undo-delete"),
+						}
+					: { role: "undo" },
 				{ role: "redo" },
 				{ type: "separator" },
 				{ role: "cut" },
@@ -1270,6 +1332,7 @@ function registerIpc() {
 			if (!stat.isDirectory()) {
 				throw new Error(`Not a directory: ${dirPath}`);
 			}
+			await cleanStaleDeleteUndo(root);
 			return listSidebarFiles(root);
 		},
 	);
@@ -1488,6 +1551,143 @@ function registerIpc() {
 			};
 		},
 	);
+
+	ipcMain.handle(
+		"desktop:stage-delete",
+		async (
+			_event,
+			{
+				workspacePath,
+				items,
+			}: { workspacePath: string; items: Array<{ path: string }> },
+		) => {
+			if (!Array.isArray(items) || items.length === 0) {
+				throw new Error("No files selected for deletion");
+			}
+			const workspace = assertGranted(workspacePath);
+			const token = randomUUID();
+			const operationDir = path.join(
+				workspace,
+				workspaceConfigDir,
+				"delete-undo",
+				token,
+			);
+			const pendingItems = items.map((item, index) => ({
+				originalPath: assertGranted(item.path),
+				backupPath: path.join(operationDir, String(index)),
+			}));
+			const uniquePaths = new Set(
+				pendingItems.map((item) => item.originalPath),
+			);
+			if (uniquePaths.size !== pendingItems.length) {
+				throw new Error("Duplicate delete path");
+			}
+			for (const item of pendingItems) {
+				const relative = path.relative(workspace, item.originalPath);
+				if (
+					!relative ||
+					relative === workspaceConfigDir ||
+					relative.startsWith(`${workspaceConfigDir}${path.sep}`) ||
+					relative.startsWith(`..${path.sep}`) ||
+					path.isAbsolute(relative)
+				) {
+					throw new Error("Delete path is outside the workspace");
+				}
+			}
+			for (const [index, item] of pendingItems.entries()) {
+				if (
+					pendingItems.some(
+						(candidate, candidateIndex) =>
+							candidateIndex !== index &&
+							isWithin(candidate.originalPath, item.originalPath),
+					)
+				) {
+					throw new Error("Delete paths cannot overlap");
+				}
+			}
+
+			const moved: PendingDeleteItem[] = [];
+			const pending: PendingDelete = {
+				operationDir,
+				items: pendingItems,
+				state: "staging",
+			};
+			pendingDeletes.set(token, pending);
+			try {
+				await fs.mkdir(operationDir, { recursive: true });
+				for (const item of pendingItems) {
+					await fs.rename(item.originalPath, item.backupPath);
+					moved.push(item);
+				}
+				pending.state = "pending";
+				return token;
+			} catch (error) {
+				let rollbackFailed = false;
+				for (const item of moved.reverse()) {
+					try {
+						await fs.rename(item.backupPath, item.originalPath);
+					} catch {
+						rollbackFailed = true;
+					}
+				}
+				if (!rollbackFailed) {
+					pendingDeletes.delete(token);
+					await fs.rm(operationDir, { recursive: true, force: true });
+				} else {
+					const recoveryDir = path.join(
+						workspace,
+						workspaceConfigDir,
+						"delete-recovery",
+						token,
+					);
+					await fs.mkdir(path.dirname(recoveryDir), { recursive: true });
+					await fs.rename(operationDir, recoveryDir);
+					pendingDeletes.delete(token);
+					throw new Error(`Delete recovery required at ${recoveryDir}`);
+				}
+				throw error;
+			}
+		},
+	);
+
+	ipcMain.handle(
+		"desktop:restore-delete",
+		async (_event, { token }: { token: string }) => {
+			const pending = pendingDeletes.get(token);
+			if (!pending || pending.state !== "pending") {
+				throw new Error("This deletion can no longer be undone");
+			}
+			pending.state = "restoring";
+			try {
+				await restorePendingDelete(pending.items);
+				pendingDeletes.delete(token);
+				await fs.rm(pending.operationDir, { recursive: true, force: true });
+			} catch (error) {
+				pending.state = "pending";
+				throw error;
+			}
+		},
+	);
+
+	ipcMain.handle(
+		"desktop:finalize-delete",
+		async (_event, { token }: { token: string }) => {
+			const pending = pendingDeletes.get(token);
+			if (!pending || pending.state !== "pending") return;
+			pending.state = "finalizing";
+			await fs.rm(pending.operationDir, { recursive: true, force: true });
+			pendingDeletes.delete(token);
+		},
+	);
+
+	ipcMain.handle(
+		"desktop:set-delete-undo-available",
+		(_event, { available }: { available: boolean }) => {
+			deleteUndoAvailable = available === true;
+			buildMenu();
+		},
+	);
+	ipcMain.handle("desktop:undo-text", (event) => event.sender.undo());
 
 	ipcMain.handle(
 		"desktop:delete-file",

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -51,6 +51,15 @@ const desktopApi = {
 		ipcRenderer.invoke("desktop:persist-pasted-image", input),
 	deleteFile: (path, options) =>
 		ipcRenderer.invoke("desktop:delete-file", { path, options }),
+	stageDelete: (workspacePath, items) =>
+		ipcRenderer.invoke("desktop:stage-delete", { workspacePath, items }),
+	undoText: () => ipcRenderer.invoke("desktop:undo-text"),
+	restoreDelete: (token) =>
+		ipcRenderer.invoke("desktop:restore-delete", { token }),
+	finalizeDelete: (token) =>
+		ipcRenderer.invoke("desktop:finalize-delete", { token }),
+	setDeleteUndoAvailable: (available) =>
+		ipcRenderer.invoke("desktop:set-delete-undo-available", { available }),
 	readBinaryFile: (path) =>
 		ipcRenderer.invoke("desktop:read-binary-file", { path }),
 	writeBinaryFile: (path, bytes) =>
@@ -141,6 +150,7 @@ const desktopApi = {
 	onMenuGoForward: (callback) => subscribe("desktop:menu-go-forward", callback),
 	onMenuToggleSourceMode: (callback) =>
 		subscribe("desktop:menu-toggle-source-mode", callback),
+	onUndoDelete: (callback) => subscribe("desktop:undo-delete", callback),
 	onWindowFocus: (callback) => subscribe("desktop:window-focus", callback),
 	onFullScreenChange: (callback) =>
 		subscribe("desktop:fullscreen-change", (isFullScreen: boolean) =>

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -51,8 +51,8 @@ const desktopApi = {
 		ipcRenderer.invoke("desktop:persist-pasted-image", input),
 	deleteFile: (path, options) =>
 		ipcRenderer.invoke("desktop:delete-file", { path, options }),
-	stageDelete: (workspacePath, items) =>
-		ipcRenderer.invoke("desktop:stage-delete", { workspacePath, items }),
+	stageDelete: (workspacePath, paths) =>
+		ipcRenderer.invoke("desktop:stage-delete", { workspacePath, paths }),
 	undoText: () => ipcRenderer.invoke("desktop:undo-text"),
 	restoreDelete: (token) =>
 		ipcRenderer.invoke("desktop:restore-delete", { token }),

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -85,7 +85,7 @@ import {
 	setViewerMode,
 	setWorkspaceSwitcherOpen,
 	toggleTerminal,
-	undoPendingDelete,
+	undoDelete,
 	updateEditorContent,
 } from "./store/actions";
 import { canGoBack, canGoForward } from "./store/history";
@@ -415,7 +415,7 @@ function App() {
 	useEffect(() => {
 		const disposers = [
 			desktopApi.onUndoDelete(() => {
-				void undoPendingDelete().then((undone) => {
+				void undoDelete().then((undone) => {
 					if (!undone) void desktopApi.undoText();
 				});
 			}),

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -85,6 +85,7 @@ import {
 	setViewerMode,
 	setWorkspaceSwitcherOpen,
 	toggleTerminal,
+	undoPendingDelete,
 	updateEditorContent,
 } from "./store/actions";
 import { canGoBack, canGoForward } from "./store/history";
@@ -413,6 +414,11 @@ function App() {
 
 	useEffect(() => {
 		const disposers = [
+			desktopApi.onUndoDelete(() => {
+				void undoPendingDelete().then((undone) => {
+					if (!undone) void desktopApi.undoText();
+				});
+			}),
 			desktopApi.onMenuCreateMarkdownFile(() => void createMarkdownFile()),
 			desktopApi.onMenuCreateHtmlFile(() => void createHtmlFile()),
 			desktopApi.onMenuOpenFile(() => void openFilePicker()),

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -15,6 +15,7 @@ import {
 	createMarkdownFileInFolder,
 	deleteFolder,
 	deleteMarkdownFile,
+	deleteSidebarItems,
 	loadPath,
 	moveSidebarItems,
 	openPathInDefaultApp,
@@ -130,6 +131,15 @@ export function Sidebar({
 				)
 			}
 			onDeleteFile={(path) => void deleteMarkdownFile(path)}
+			onDeleteItems={(items) =>
+				void deleteSidebarItems(
+					items.map((item) =>
+						item.kind === "file"
+							? item
+							: { ...item, folderId: absolutePath(item.folderId) },
+					),
+				)
+			}
 			onTogglePinnedFile={(path) => void togglePinnedNote(path)}
 			onCreateFile={(folderId) =>
 				createMarkdownFileInFolder(absolutePath(folderId))

--- a/apps/desktop/src/components/toast.css
+++ b/apps/desktop/src/components/toast.css
@@ -6,8 +6,6 @@
 	--toast-shadow: var(--shadow-overlay);
 	--toast-control-radius: 0.375rem;
 	--toast-font-size: 0.75rem;
-	--toast-action-bg: var(--primary);
-	--toast-action-fg: var(--primary-foreground);
 	--toast-cancel-bg: var(--secondary);
 	--toast-muted-fg: var(--muted-foreground);
 }
@@ -31,14 +29,19 @@
 }
 
 .hubble-toast-action {
-	background: var(--toast-action-bg) !important;
-	color: var(--toast-action-fg) !important;
+	background: transparent !important;
+	color: var(--toast-muted-fg) !important;
 	border: 1px solid transparent !important;
 	border-radius: var(--toast-control-radius);
 	box-shadow: none !important;
 	padding-inline: 0.7rem;
 	padding-block: 0.35rem;
 	font-weight: 500;
+}
+
+.hubble-toast-action:hover {
+	background: var(--muted) !important;
+	color: var(--toast-fg) !important;
 }
 
 .hubble-toast-cancel {

--- a/apps/desktop/src/components/toast.css
+++ b/apps/desktop/src/components/toast.css
@@ -34,9 +34,21 @@
 	border: 1px solid transparent !important;
 	border-radius: var(--toast-control-radius);
 	box-shadow: none !important;
+	/* Sonner pins action buttons to height: 24px, which swallows the
+	   vertical padding; let content and padding set the height. */
+	height: auto !important;
 	padding-inline: 0.7rem;
 	padding-block: 0.35rem;
 	font-weight: 500;
+}
+
+.hubble-toast-action kbd {
+	margin-left: 0.45em;
+	padding: 0.05rem 0.3rem;
+	border: 1px solid var(--toast-border);
+	border-radius: calc(var(--toast-control-radius) - 2px);
+	font-family: inherit;
+	font-size: 0.95em;
 }
 
 .hubble-toast-action:hover {

--- a/apps/desktop/src/components/undoToastLabel.tsx
+++ b/apps/desktop/src/components/undoToastLabel.tsx
@@ -1,0 +1,11 @@
+import { formatShortcut } from "@hubble.md/ui";
+
+/** Label for the delete toast's undo action: "Undo" plus a keycap shortcut. */
+export function undoToastLabel() {
+	return (
+		<>
+			Undo
+			<kbd>{formatShortcut("CmdOrCtrl+Z")}</kbd>
+		</>
+	);
+}

--- a/apps/desktop/src/desktopApi/types.ts
+++ b/apps/desktop/src/desktopApi/types.ts
@@ -74,10 +74,6 @@ export type PersistPastedImageOutput = {
 	deduped: boolean;
 };
 
-export type StagedDeleteItem = {
-	path: string;
-};
-
 export type OpenPathFromLinkResult =
 	| { kind: "file"; path: string }
 	| { kind: "opened" };
@@ -163,10 +159,7 @@ export type DesktopApi = {
 		input: PersistPastedImageInput,
 	): Promise<PersistPastedImageOutput>;
 	deleteFile(path: string, options?: { recursive?: boolean }): Promise<void>;
-	stageDelete(
-		workspacePath: string,
-		items: StagedDeleteItem[],
-	): Promise<string>;
+	stageDelete(workspacePath: string, paths: string[]): Promise<string>;
 	undoText(): Promise<void>;
 	restoreDelete(token: string): Promise<void>;
 	finalizeDelete(token: string): Promise<void>;

--- a/apps/desktop/src/desktopApi/types.ts
+++ b/apps/desktop/src/desktopApi/types.ts
@@ -74,6 +74,10 @@ export type PersistPastedImageOutput = {
 	deduped: boolean;
 };
 
+export type StagedDeleteItem = {
+	path: string;
+};
+
 export type OpenPathFromLinkResult =
 	| { kind: "file"; path: string }
 	| { kind: "opened" };
@@ -159,6 +163,14 @@ export type DesktopApi = {
 		input: PersistPastedImageInput,
 	): Promise<PersistPastedImageOutput>;
 	deleteFile(path: string, options?: { recursive?: boolean }): Promise<void>;
+	stageDelete(
+		workspacePath: string,
+		items: StagedDeleteItem[],
+	): Promise<string>;
+	undoText(): Promise<void>;
+	restoreDelete(token: string): Promise<void>;
+	finalizeDelete(token: string): Promise<void>;
+	setDeleteUndoAvailable(available: boolean): Promise<void>;
 	readBinaryFile(path: string): Promise<number[]>;
 	writeBinaryFile(path: string, bytes: number[]): Promise<void>;
 	openFilePicker(options: { defaultPath?: string }): Promise<string | null>;
@@ -218,6 +230,7 @@ export type DesktopApi = {
 	onMenuGoBack(callback: () => void): Unsubscribe;
 	onMenuGoForward(callback: () => void): Unsubscribe;
 	onMenuToggleSourceMode(callback: () => void): Unsubscribe;
+	onUndoDelete(callback: () => void): Unsubscribe;
 	onWindowFocus(callback: () => void): Unsubscribe;
 	onFullScreenChange(callback: (isFullScreen: boolean) => void): Unsubscribe;
 

--- a/apps/desktop/src/lib/concurrency.test.ts
+++ b/apps/desktop/src/lib/concurrency.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { dedupeRuns, sequential, takeLatest } from "./concurrency";
+import { dedupeRuns, keyedQueue, sequential, takeLatest } from "./concurrency";
 
 describe("takeLatest", () => {
 	it("marks earlier in-flight calls stale", async () => {
@@ -71,5 +71,51 @@ describe("sequential", () => {
 		await expect(first).rejects.toThrow("disk full");
 		await second;
 		expect(order).toEqual(["first", "second"]);
+	});
+});
+
+describe("keyedQueue", () => {
+	it("runs each key in order while other keys run", async () => {
+		const queue = keyedQueue<string>();
+		const order: string[] = [];
+		let finishFirst: () => void = () => {};
+		const first = queue.run(
+			"a",
+			() =>
+				new Promise<void>((resolve) => {
+					order.push("a1");
+					finishFirst = resolve;
+				}),
+		);
+		const second = queue.run("a", async () => {
+			order.push("a2");
+		});
+		await queue.run("b", async () => {
+			order.push("b");
+		});
+
+		expect(order).toEqual(["a1", "b"]);
+		finishFirst();
+		await Promise.all([first, second]);
+		expect(order).toEqual(["a1", "b", "a2"]);
+	});
+
+	it("waits for matching work even when it fails", async () => {
+		const queue = keyedQueue<string>();
+		let finish: () => void = () => {};
+		void queue.run(
+			"note.md",
+			() =>
+				new Promise<void>((_resolve, reject) => {
+					finish = () => reject(new Error("disk full"));
+				}),
+		);
+		const waited = vi.fn();
+		const wait = queue.waitFor((key) => key.endsWith(".md")).then(waited);
+
+		expect(waited).not.toHaveBeenCalled();
+		finish();
+		await wait;
+		expect(waited).toHaveBeenCalledOnce();
 	});
 });

--- a/apps/desktop/src/lib/concurrency.ts
+++ b/apps/desktop/src/lib/concurrency.ts
@@ -6,6 +6,7 @@
  * - `takeLatest`: everything runs; only the newest call may apply its result.
  * - `dedupeRuns`: one run at a time; overlapping calls share one follow-up.
  * - `sequential`: every call runs, one at a time, in call order.
+ * - `keyedQueue`: `sequential`, scoped by key, with a way to await matching work.
  */
 
 /**
@@ -93,4 +94,30 @@ export function sequential<Args extends unknown[]>(
 		tail = tail.catch(() => {}).then(() => fn(...args));
 		return tail;
 	};
+}
+
+/** Runs tasks in order per key and waits for any matching work on demand. */
+export function keyedQueue<Key>() {
+	const tails = new Map<Key, Promise<void>>();
+
+	const run = (key: Key, task: () => Promise<void>) => {
+		const previous = tails.get(key);
+		const next = previous ? previous.catch(() => {}).then(task) : task();
+		tails.set(key, next);
+		const clear = () => {
+			if (tails.get(key) === next) tails.delete(key);
+		};
+		void next.then(clear, clear);
+		return next;
+	};
+
+	const waitFor = async (matches: (key: Key) => boolean) => {
+		await Promise.all(
+			[...tails]
+				.filter(([key]) => matches(key))
+				.map(([, tail]) => tail.catch(() => {})),
+		);
+	};
+
+	return { run, waitFor };
 }

--- a/apps/desktop/src/store/actions.test.ts
+++ b/apps/desktop/src/store/actions.test.ts
@@ -9,6 +9,11 @@ type MockDesktopApi = {
 	createFolder: ReturnType<typeof vi.fn>;
 	renameFile: ReturnType<typeof vi.fn>;
 	deleteFile: ReturnType<typeof vi.fn>;
+	stageDelete: ReturnType<typeof vi.fn>;
+	restoreDelete: ReturnType<typeof vi.fn>;
+	finalizeDelete: ReturnType<typeof vi.fn>;
+	setDeleteUndoAvailable: ReturnType<typeof vi.fn>;
+	undoText: ReturnType<typeof vi.fn>;
 	pathExists: ReturnType<typeof vi.fn>;
 	openPathFromLink: ReturnType<typeof vi.fn>;
 	openPathInDefaultApp: ReturnType<typeof vi.fn>;
@@ -26,6 +31,11 @@ function createDesktopApi(): MockDesktopApi {
 		createFolder: vi.fn(async () => {}),
 		renameFile: vi.fn(async () => {}),
 		deleteFile: vi.fn(async () => {}),
+		stageDelete: vi.fn(async () => "delete-token"),
+		restoreDelete: vi.fn(async () => {}),
+		finalizeDelete: vi.fn(async () => {}),
+		setDeleteUndoAvailable: vi.fn(async () => {}),
+		undoText: vi.fn(async () => {}),
 		pathExists: vi.fn(async () => false),
 		openPathFromLink: vi.fn(async () => ({ kind: "opened" })),
 		openPathInDefaultApp: vi.fn(async () => {}),
@@ -1107,6 +1117,113 @@ describe("desktop folder actions", () => {
 			recursive: true,
 		});
 		expect(workspaceStore.get().folders).toEqual([]);
+	});
+
+	it("stages a sidebar group as one deletion and restores it", async () => {
+		const api = createDesktopApi();
+		const toast = Object.assign(
+			vi.fn(() => "delete-undo"),
+			{
+				dismiss: vi.fn(),
+				success: vi.fn(),
+				error: vi.fn(),
+			},
+		);
+		vi.doMock("sonner", () => ({ toast }));
+		const {
+			appStore,
+			canUndoPendingDelete,
+			deleteSidebarItems,
+			undoPendingDelete,
+			workspaceStore,
+		} = await loadStoreActions(api);
+		appStore.set((current) => ({
+			...current,
+			workspace: {
+				...current.workspace,
+				workspacePath: "/workspace",
+				files: [
+					{ path: "/workspace/a.md", modified_at: 1 },
+					{ path: "/workspace/folder/b.md", modified_at: 1 },
+				],
+				folders: [{ path: "/workspace/folder", modified_at: 1 }],
+			},
+		}));
+
+		await deleteSidebarItems([
+			{ kind: "file", path: "/workspace/a.md" },
+			{ kind: "folder", folderId: "/workspace/folder" },
+		]);
+
+		expect(api.stageDelete).toHaveBeenCalledOnce();
+		expect(api.stageDelete).toHaveBeenCalledWith("/workspace", [
+			{ path: "/workspace/a.md" },
+			{ path: "/workspace/folder" },
+		]);
+		expect(workspaceStore.get().files).toEqual([]);
+		expect(canUndoPendingDelete()).toBe(true);
+
+		api.listDirectory.mockResolvedValue({
+			files: [
+				{ path: "/workspace/a.md", modified_at: 2 },
+				{ path: "/workspace/folder/b.md", modified_at: 2 },
+			],
+			folders: [{ path: "/workspace/folder", modified_at: 2 }],
+		});
+		expect(await undoPendingDelete()).toBe(true);
+
+		expect(api.restoreDelete).toHaveBeenCalledWith("delete-token");
+		expect(workspaceStore.get().files).toHaveLength(2);
+		expect(canUndoPendingDelete()).toBe(false);
+		vi.doUnmock("sonner");
+	});
+
+	it("expires sidebar delete undo when document editing resumes", async () => {
+		const api = createDesktopApi();
+		const toast = Object.assign(
+			vi.fn(() => "delete-undo"),
+			{
+				dismiss: vi.fn(),
+				success: vi.fn(),
+				error: vi.fn(),
+			},
+		);
+		vi.doMock("sonner", () => ({ toast }));
+		const {
+			appStore,
+			canUndoPendingDelete,
+			deleteSidebarItems,
+			updateEditorContent,
+		} = await loadStoreActions(api);
+		appStore.set((current) => ({
+			...current,
+			workspace: {
+				...current.workspace,
+				workspacePath: "/workspace",
+				files: [
+					{ path: "/workspace/keep.md", modified_at: 1 },
+					{ path: "/workspace/delete.md", modified_at: 1 },
+				],
+			},
+			document: {
+				...current.document,
+				currentPath: "/workspace/keep.md",
+				content: "before",
+				diskContent: "before",
+			},
+		}));
+
+		await deleteSidebarItems([{ kind: "file", path: "/workspace/delete.md" }]);
+		updateEditorContent("/workspace/stale.md", "late update");
+		expect(canUndoPendingDelete()).toBe(true);
+		updateEditorContent("/workspace/keep.md", "after");
+		await vi.waitFor(() =>
+			expect(api.finalizeDelete).toHaveBeenCalledWith("delete-token"),
+		);
+
+		expect(canUndoPendingDelete()).toBe(false);
+		expect(api.setDeleteUndoAvailable).toHaveBeenLastCalledWith(false);
+		vi.doUnmock("sonner");
 	});
 });
 

--- a/apps/desktop/src/store/actions.test.ts
+++ b/apps/desktop/src/store/actions.test.ts
@@ -1156,6 +1156,7 @@ describe("desktop folder actions", () => {
 			"/workspace/folder",
 		]);
 		expect(workspaceStore.get().files).toEqual([]);
+		expect(workspaceStore.get().folders).toEqual([]);
 		expect(api.setDeleteUndoAvailable).toHaveBeenCalledWith(true);
 
 		api.listDirectory.mockResolvedValue({
@@ -1170,6 +1171,43 @@ describe("desktop folder actions", () => {
 		expect(api.restoreDelete).toHaveBeenCalledWith("delete-token");
 		expect(workspaceStore.get().files).toHaveLength(2);
 		expect(api.setDeleteUndoAvailable).toHaveBeenLastCalledWith(false);
+		vi.doUnmock("sonner");
+	});
+
+	it("keeps an open file when its pre-delete save fails", async () => {
+		const api = createDesktopApi();
+		api.writeFileText.mockRejectedValue(new Error("disk full"));
+		const toast = Object.assign(
+			vi.fn(() => "delete-undo"),
+			{
+				dismiss: vi.fn(),
+				success: vi.fn(),
+				error: vi.fn(),
+			},
+		);
+		vi.doMock("sonner", () => ({ toast }));
+		const { appStore, deleteSidebarItems, viewerStore } =
+			await loadStoreActions(api);
+		appStore.set((current) => ({
+			...current,
+			workspace: {
+				...current.workspace,
+				workspacePath: "/workspace",
+				files: [{ path: "/workspace/delete.md", modified_at: 1 }],
+			},
+			document: {
+				...current.document,
+				currentPath: "/workspace/delete.md",
+				content: "unsaved",
+				diskContent: "saved",
+			},
+		}));
+
+		await deleteSidebarItems([{ kind: "file", path: "/workspace/delete.md" }]);
+
+		expect(api.stageDelete).not.toHaveBeenCalled();
+		expect(viewerStore.get().currentPath).toBe("/workspace/delete.md");
+		expect(viewerStore.get().content).toBe("unsaved");
 		vi.doUnmock("sonner");
 	});
 

--- a/apps/desktop/src/store/actions.test.ts
+++ b/apps/desktop/src/store/actions.test.ts
@@ -1130,13 +1130,8 @@ describe("desktop folder actions", () => {
 			},
 		);
 		vi.doMock("sonner", () => ({ toast }));
-		const {
-			appStore,
-			canUndoPendingDelete,
-			deleteSidebarItems,
-			undoPendingDelete,
-			workspaceStore,
-		} = await loadStoreActions(api);
+		const { appStore, deleteSidebarItems, undoPendingDelete, workspaceStore } =
+			await loadStoreActions(api);
 		appStore.set((current) => ({
 			...current,
 			workspace: {
@@ -1157,11 +1152,11 @@ describe("desktop folder actions", () => {
 
 		expect(api.stageDelete).toHaveBeenCalledOnce();
 		expect(api.stageDelete).toHaveBeenCalledWith("/workspace", [
-			{ path: "/workspace/a.md" },
-			{ path: "/workspace/folder" },
+			"/workspace/a.md",
+			"/workspace/folder",
 		]);
 		expect(workspaceStore.get().files).toEqual([]);
-		expect(canUndoPendingDelete()).toBe(true);
+		expect(api.setDeleteUndoAvailable).toHaveBeenCalledWith(true);
 
 		api.listDirectory.mockResolvedValue({
 			files: [
@@ -1174,7 +1169,7 @@ describe("desktop folder actions", () => {
 
 		expect(api.restoreDelete).toHaveBeenCalledWith("delete-token");
 		expect(workspaceStore.get().files).toHaveLength(2);
-		expect(canUndoPendingDelete()).toBe(false);
+		expect(api.setDeleteUndoAvailable).toHaveBeenLastCalledWith(false);
 		vi.doUnmock("sonner");
 	});
 
@@ -1189,12 +1184,8 @@ describe("desktop folder actions", () => {
 			},
 		);
 		vi.doMock("sonner", () => ({ toast }));
-		const {
-			appStore,
-			canUndoPendingDelete,
-			deleteSidebarItems,
-			updateEditorContent,
-		} = await loadStoreActions(api);
+		const { appStore, deleteSidebarItems, updateEditorContent } =
+			await loadStoreActions(api);
 		appStore.set((current) => ({
 			...current,
 			workspace: {
@@ -1215,13 +1206,12 @@ describe("desktop folder actions", () => {
 
 		await deleteSidebarItems([{ kind: "file", path: "/workspace/delete.md" }]);
 		updateEditorContent("/workspace/stale.md", "late update");
-		expect(canUndoPendingDelete()).toBe(true);
+		expect(api.finalizeDelete).not.toHaveBeenCalled();
 		updateEditorContent("/workspace/keep.md", "after");
 		await vi.waitFor(() =>
 			expect(api.finalizeDelete).toHaveBeenCalledWith("delete-token"),
 		);
 
-		expect(canUndoPendingDelete()).toBe(false);
 		expect(api.setDeleteUndoAvailable).toHaveBeenLastCalledWith(false);
 		vi.doUnmock("sonner");
 	});

--- a/apps/desktop/src/store/actions.test.ts
+++ b/apps/desktop/src/store/actions.test.ts
@@ -1211,6 +1211,37 @@ describe("desktop folder actions", () => {
 		vi.doUnmock("sonner");
 	});
 
+	it("does not finalize files after restore fails", async () => {
+		const api = createDesktopApi();
+		api.restoreDelete.mockRejectedValue(new Error("path exists"));
+		const toast = Object.assign(
+			vi.fn(() => "delete-undo"),
+			{
+				dismiss: vi.fn(),
+				success: vi.fn(),
+				error: vi.fn(),
+			},
+		);
+		vi.doMock("sonner", () => ({ toast }));
+		const { appStore, deleteSidebarItems, undoPendingDelete } =
+			await loadStoreActions(api);
+		appStore.set((current) => ({
+			...current,
+			workspace: {
+				...current.workspace,
+				workspacePath: "/workspace",
+				files: [{ path: "/workspace/delete.md", modified_at: 1 }],
+			},
+		}));
+
+		await deleteSidebarItems([{ kind: "file", path: "/workspace/delete.md" }]);
+
+		expect(await undoPendingDelete()).toBe(false);
+		expect(api.finalizeDelete).not.toHaveBeenCalled();
+		expect(api.setDeleteUndoAvailable).toHaveBeenLastCalledWith(false);
+		vi.doUnmock("sonner");
+	});
+
 	it("expires sidebar delete undo when document editing resumes", async () => {
 		const api = createDesktopApi();
 		const toast = Object.assign(

--- a/apps/desktop/src/store/actions.test.ts
+++ b/apps/desktop/src/store/actions.test.ts
@@ -1285,6 +1285,114 @@ describe("desktop folder actions", () => {
 		vi.doUnmock("sonner");
 	});
 
+	it("releases Cmd+Z as soon as document editing resumes", async () => {
+		const api = createDesktopApi();
+		let finishDrop: () => void = () => {};
+		api.finalizeDelete.mockImplementation(
+			() =>
+				new Promise<void>((resolve) => {
+					finishDrop = resolve;
+				}),
+		);
+		const toast = Object.assign(
+			vi.fn(() => "delete-undo"),
+			{
+				dismiss: vi.fn(),
+				success: vi.fn(),
+				error: vi.fn(),
+			},
+		);
+		vi.doMock("sonner", () => ({ toast }));
+		const {
+			appStore,
+			deleteSidebarItems,
+			undoPendingDelete,
+			updateEditorContent,
+		} = await loadStoreActions(api);
+		appStore.set((current) => ({
+			...current,
+			workspace: {
+				...current.workspace,
+				workspacePath: "/workspace",
+				files: [
+					{ path: "/workspace/keep.md", modified_at: 1 },
+					{ path: "/workspace/delete.md", modified_at: 1 },
+				],
+			},
+			document: {
+				...current.document,
+				currentPath: "/workspace/keep.md",
+				content: "before",
+				diskContent: "before",
+			},
+		}));
+
+		await deleteSidebarItems([{ kind: "file", path: "/workspace/delete.md" }]);
+		updateEditorContent("/workspace/keep.md", "after");
+
+		expect(await undoPendingDelete()).toBe(false);
+		expect(api.setDeleteUndoAvailable).toHaveBeenLastCalledWith(false);
+		finishDrop();
+		await vi.waitFor(() => expect(api.finalizeDelete).toHaveBeenCalled());
+		vi.doUnmock("sonner");
+	});
+
+	it("waits for an in-flight save before staging a deletion", async () => {
+		const api = createDesktopApi();
+		let finishFirstWrite: () => void = () => {};
+		api.writeFileText
+			.mockImplementationOnce(
+				() =>
+					new Promise<void>((resolve) => {
+						finishFirstWrite = resolve;
+					}),
+			)
+			.mockResolvedValue(undefined);
+		const toast = Object.assign(
+			vi.fn(() => "delete-undo"),
+			{
+				dismiss: vi.fn(),
+				success: vi.fn(),
+				error: vi.fn(),
+			},
+		);
+		vi.doMock("sonner", () => ({ toast }));
+		const { appStore, deleteSidebarItems, savePathContent } =
+			await loadStoreActions(api);
+		const path = "/workspace/delete.md";
+		appStore.set((current) => ({
+			...current,
+			workspace: {
+				...current.workspace,
+				workspacePath: "/workspace",
+				files: [{ path, modified_at: 1 }],
+			},
+			document: {
+				...current.document,
+				currentPath: path,
+				content: "latest",
+				diskContent: "before",
+			},
+		}));
+
+		const firstSave = savePathContent(path, "older", { force: true });
+		await vi.waitFor(() =>
+			expect(api.writeFileText).toHaveBeenCalledWith(path, "older"),
+		);
+		const deletion = deleteSidebarItems([{ kind: "file", path }]);
+
+		expect(api.stageDelete).not.toHaveBeenCalled();
+		finishFirstWrite();
+		await firstSave;
+		await deletion;
+
+		expect(api.writeFileText).toHaveBeenLastCalledWith(path, "latest");
+		expect(api.writeFileText.mock.invocationCallOrder[1]).toBeLessThan(
+			api.stageDelete.mock.invocationCallOrder[0],
+		);
+		vi.doUnmock("sonner");
+	});
+
 	it("expires sidebar delete undo before switching workspaces", async () => {
 		const api = createDesktopApi();
 		const toast = Object.assign(

--- a/apps/desktop/src/store/actions.test.ts
+++ b/apps/desktop/src/store/actions.test.ts
@@ -1130,7 +1130,7 @@ describe("desktop folder actions", () => {
 			},
 		);
 		vi.doMock("sonner", () => ({ toast }));
-		const { appStore, deleteSidebarItems, undoPendingDelete, workspaceStore } =
+		const { appStore, deleteSidebarItems, undoDelete, workspaceStore } =
 			await loadStoreActions(api);
 		appStore.set((current) => ({
 			...current,
@@ -1166,7 +1166,7 @@ describe("desktop folder actions", () => {
 			],
 			folders: [{ path: "/workspace/folder", modified_at: 2 }],
 		});
-		expect(await undoPendingDelete()).toBe(true);
+		expect(await undoDelete()).toBe(true);
 
 		expect(api.restoreDelete).toHaveBeenCalledWith("delete-token");
 		expect(workspaceStore.get().files).toHaveLength(2);
@@ -1223,7 +1223,7 @@ describe("desktop folder actions", () => {
 			},
 		);
 		vi.doMock("sonner", () => ({ toast }));
-		const { appStore, deleteSidebarItems, undoPendingDelete } =
+		const { appStore, deleteSidebarItems, undoDelete } =
 			await loadStoreActions(api);
 		appStore.set((current) => ({
 			...current,
@@ -1236,51 +1236,8 @@ describe("desktop folder actions", () => {
 
 		await deleteSidebarItems([{ kind: "file", path: "/workspace/delete.md" }]);
 
-		expect(await undoPendingDelete()).toBe(false);
+		expect(await undoDelete()).toBe(false);
 		expect(api.finalizeDelete).not.toHaveBeenCalled();
-		expect(api.setDeleteUndoAvailable).toHaveBeenLastCalledWith(false);
-		vi.doUnmock("sonner");
-	});
-
-	it("expires sidebar delete undo when document editing resumes", async () => {
-		const api = createDesktopApi();
-		const toast = Object.assign(
-			vi.fn(() => "delete-undo"),
-			{
-				dismiss: vi.fn(),
-				success: vi.fn(),
-				error: vi.fn(),
-			},
-		);
-		vi.doMock("sonner", () => ({ toast }));
-		const { appStore, deleteSidebarItems, updateEditorContent } =
-			await loadStoreActions(api);
-		appStore.set((current) => ({
-			...current,
-			workspace: {
-				...current.workspace,
-				workspacePath: "/workspace",
-				files: [
-					{ path: "/workspace/keep.md", modified_at: 1 },
-					{ path: "/workspace/delete.md", modified_at: 1 },
-				],
-			},
-			document: {
-				...current.document,
-				currentPath: "/workspace/keep.md",
-				content: "before",
-				diskContent: "before",
-			},
-		}));
-
-		await deleteSidebarItems([{ kind: "file", path: "/workspace/delete.md" }]);
-		updateEditorContent("/workspace/stale.md", "late update");
-		expect(api.finalizeDelete).not.toHaveBeenCalled();
-		updateEditorContent("/workspace/keep.md", "after");
-		await vi.waitFor(() =>
-			expect(api.finalizeDelete).toHaveBeenCalledWith("delete-token"),
-		);
-
 		expect(api.setDeleteUndoAvailable).toHaveBeenLastCalledWith(false);
 		vi.doUnmock("sonner");
 	});
@@ -1303,12 +1260,8 @@ describe("desktop folder actions", () => {
 			},
 		);
 		vi.doMock("sonner", () => ({ toast }));
-		const {
-			appStore,
-			deleteSidebarItems,
-			undoPendingDelete,
-			updateEditorContent,
-		} = await loadStoreActions(api);
+		const { appStore, deleteSidebarItems, undoDelete, updateEditorContent } =
+			await loadStoreActions(api);
 		appStore.set((current) => ({
 			...current,
 			workspace: {
@@ -1330,7 +1283,7 @@ describe("desktop folder actions", () => {
 		await deleteSidebarItems([{ kind: "file", path: "/workspace/delete.md" }]);
 		updateEditorContent("/workspace/keep.md", "after");
 
-		expect(await undoPendingDelete()).toBe(false);
+		expect(await undoDelete()).toBe(false);
 		expect(api.setDeleteUndoAvailable).toHaveBeenLastCalledWith(false);
 		finishDrop();
 		await vi.waitFor(() => expect(api.finalizeDelete).toHaveBeenCalled());

--- a/apps/desktop/src/store/actions.test.ts
+++ b/apps/desktop/src/store/actions.test.ts
@@ -1284,6 +1284,36 @@ describe("desktop folder actions", () => {
 		expect(api.setDeleteUndoAvailable).toHaveBeenLastCalledWith(false);
 		vi.doUnmock("sonner");
 	});
+
+	it("expires sidebar delete undo before switching workspaces", async () => {
+		const api = createDesktopApi();
+		const toast = Object.assign(
+			vi.fn(() => "delete-undo"),
+			{
+				dismiss: vi.fn(),
+				success: vi.fn(),
+				error: vi.fn(),
+			},
+		);
+		vi.doMock("sonner", () => ({ toast }));
+		const { appStore, deleteSidebarItems, openWorkspace } =
+			await loadStoreActions(api);
+		appStore.set((current) => ({
+			...current,
+			workspace: {
+				...current.workspace,
+				workspacePath: "/workspace",
+				files: [{ path: "/workspace/delete.md", modified_at: 1 }],
+			},
+		}));
+
+		await deleteSidebarItems([{ kind: "file", path: "/workspace/delete.md" }]);
+		await openWorkspace("/other-workspace");
+
+		expect(api.finalizeDelete).toHaveBeenCalledWith("delete-token");
+		expect(api.setDeleteUndoAvailable).toHaveBeenLastCalledWith(false);
+		vi.doUnmock("sonner");
+	});
 });
 
 describe("desktop moveSidebarItem", () => {

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -130,7 +130,7 @@ function pathCoveredByDeleteItems(path: string, items: SidebarDeleteItem[]) {
 	return items.some((item) =>
 		item.kind === "file"
 			? item.path === path
-			: pathInFolder(path, item.folderId),
+			: item.folderId === path || pathInFolder(path, item.folderId),
 	);
 }
 
@@ -738,7 +738,7 @@ export function setViewerMode(viewMode: ViewMode) {
 export async function savePathContent(
 	path: string,
 	content: string,
-	options?: { force?: boolean },
+	options?: { force?: boolean; throwOnError?: boolean },
 ) {
 	// Binary viewers, external files, and the virtual changelog never enter text saves.
 	if (isChangelogPath(path) || !isEditableFile(path)) return;
@@ -819,6 +819,7 @@ export async function savePathContent(
 				error: message,
 			};
 		});
+		if (options?.throwOnError) throw err;
 	}
 }
 
@@ -1378,7 +1379,14 @@ async function performSidebarDelete(items: SidebarDeleteItem[]) {
 		viewerBefore.currentPath &&
 		pathCoveredByDeleteItems(viewerBefore.currentPath, items)
 	) {
-		await savePathContent(viewerBefore.currentPath, viewerBefore.content);
+		try {
+			await savePathContent(viewerBefore.currentPath, viewerBefore.content, {
+				force: true,
+				throwOnError: true,
+			});
+		} catch {
+			return;
+		}
 	}
 	blockedSaveItems = items;
 

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -1332,8 +1332,7 @@ export async function undoPendingDelete(token?: string) {
 		await pending.pinRemovalSaved;
 		await desktopApi.restoreDelete(pending.token);
 	} catch (error) {
-		pending.isRestoring = false;
-		await finalizePendingDeleteUndo(pending.token);
+		clearPendingDelete(pending);
 		toast.error("Failed to undo deletion", {
 			description: handleFileError(error),
 		});

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -1,8 +1,4 @@
-import {
-	formatShortcut,
-	type ReviewThread,
-	type SidebarDeleteItem,
-} from "@hubble.md/ui";
+import type { ReviewThread } from "@hubble.md/ui";
 import { toast } from "sonner";
 import changelogRaw from "../../../../CHANGELOG.md?raw";
 import { desktopApi } from "../desktopApi";
@@ -13,7 +9,7 @@ import {
 	isChangelogPath,
 	prepareChangelogMarkdown,
 } from "../lib/changelogNote";
-import { takeLatest } from "../lib/concurrency";
+import { keyedQueue, takeLatest } from "../lib/concurrency";
 import {
 	absoluteWorkspacePath,
 	basename,
@@ -43,13 +39,12 @@ import {
 	initTheme,
 	type ThemePreference,
 } from "../theme";
+import { createDeleteActions } from "./deleteActions";
 import {
 	activeHistory,
 	canGoBack,
 	canGoForward,
-	clearHistory,
 	normalizeStack,
-	pruneHistory,
 	pushHistory,
 	rewriteHistory,
 	setHistory,
@@ -99,47 +94,11 @@ const workspaceSidebarQueues = new Map<string, Promise<void>>();
 // after the editor already has draft B, that watcher event is not an external
 // conflict; it is just the disk baseline catching up to a save we started.
 const selfSaves = new Map<string, Map<string, number>>();
-const saveQueues = new Map<string, Promise<void>>();
-const DELETE_UNDO_DURATION_MS = 8000;
-let blockedSaveItems: SidebarDeleteItem[] | null = null;
-
-type PendingDeleteUndo = {
-	token: string;
-	workspacePath: string;
-	reopenPath: string | null;
-	removedPins: string[];
-	removedLastOpened: Record<string, string>;
-	historyBefore: ReturnType<typeof historyStore.get>;
-	historyAfter: ReturnType<typeof historyStore.get>;
-	pinRemovalSaved: Promise<void>;
-	toastId: string | number | null;
-	state: "active" | "finalizing" | "restoring";
-};
-
-let pendingDeleteUndo: PendingDeleteUndo | null = null;
-let deleteInFlight = false;
+const saves = keyedQueue<string>();
 
 type SidebarMoveItem =
 	| { kind: "file"; path: string }
 	| { kind: "folder"; folderId: string };
-
-function deleteItemPath(item: SidebarDeleteItem) {
-	return item.kind === "file" ? item.path : item.folderId;
-}
-
-function pathCoveredByDeleteItems(path: string, items: SidebarDeleteItem[]) {
-	return items.some((item) =>
-		item.kind === "file"
-			? item.path === path
-			: item.folderId === path || pathInFolder(path, item.folderId),
-	);
-}
-
-function isStagedForDelete(path: string) {
-	return blockedSaveItems
-		? pathCoveredByDeleteItems(path, blockedSaveItems)
-		: false;
-}
 
 function enqueueWorkspaceSidebarUpdate(
 	workspacePath: string,
@@ -682,7 +641,7 @@ export async function openWorkspace(path?: string) {
 		nextPath = selected;
 	}
 	if (workspaceStore.get().workspacePath !== nextPath) {
-		await finalizePendingDeleteUndo();
+		await expireDeleteUndo();
 	}
 
 	workspaceStore.set((state) => {
@@ -710,7 +669,7 @@ export async function openWorkspace(path?: string) {
 export function updateEditorContent(path: string, content: string) {
 	const current = viewerStore.get();
 	if (current.currentPath !== path || current.content === content) return;
-	void finalizePendingDeleteUndo();
+	void expireDeleteUndo();
 
 	viewerStore.set((state) => {
 		if (state.currentPath !== path) return state;
@@ -739,17 +698,6 @@ export function setViewerMode(viewMode: ViewMode) {
 	});
 }
 
-function queueSave(path: string, save: () => Promise<void>) {
-	const previous = saveQueues.get(path);
-	const next = previous ? previous.catch(() => {}).then(save) : save();
-	saveQueues.set(path, next);
-	const clear = () => {
-		if (saveQueues.get(path) === next) saveQueues.delete(path);
-	};
-	void next.then(clear, clear);
-	return next;
-}
-
 async function savePathContentNow(
 	path: string,
 	content: string,
@@ -758,7 +706,7 @@ async function savePathContentNow(
 	// Binary viewers, external files, and the virtual changelog never enter text saves.
 	if (isChangelogPath(path) || !isEditableFile(path)) return;
 	// A save already queued by the editor must not recreate a staged deletion.
-	if (!options?.allowBlocked && isStagedForDelete(path)) return;
+	if (!options?.allowBlocked && deletionActions.isSaveBlocked(path)) return;
 	const current = viewerStore.get();
 	const force = options?.force === true;
 	if (current.currentPath !== path) return;
@@ -843,8 +791,33 @@ export function savePathContent(
 	content: string,
 	options?: { force?: boolean; throwOnError?: boolean },
 ) {
-	return queueSave(path, () => savePathContentNow(path, content, options));
+	return saves.run(path, () => savePathContentNow(path, content, options));
 }
+
+const deletionActions = createDeleteActions({
+	saveBeforeDelete: (path, content) =>
+		saves.run(path, () =>
+			savePathContentNow(path, content, {
+				force: true,
+				throwOnError: true,
+				allowBlocked: true,
+			}),
+		),
+	waitForSaves: saves.waitFor,
+	refreshFiles,
+	refreshFileList,
+	loadPath,
+	syncPins: syncPinnedNotes,
+	handleError: handleFileError,
+});
+
+export const {
+	deleteFolder,
+	deleteMarkdownFile,
+	deleteSidebarItems,
+	expireDeleteUndo,
+	undoDelete,
+} = deletionActions;
 
 export async function renameMarkdownFile(path: string, nextName: string) {
 	const current = viewerStore.get();
@@ -1216,329 +1189,6 @@ export async function createFolderInFolder(parentPath: string) {
 		const message = handleFileError(err);
 		toast.error("Failed to create folder", { description: message });
 		return null;
-	}
-}
-
-export async function deleteMarkdownFile(
-	path: string,
-	options?: { throwOnError?: boolean },
-) {
-	try {
-		await desktopApi.deleteFile(path);
-		const wasCurrentFile = viewerStore.get().currentPath === path;
-		if (wasCurrentFile) {
-			clearHistory();
-		} else {
-			pruneHistory(path);
-		}
-		appStore.set((state) => ({
-			...state,
-			workspace: {
-				...state.workspace,
-				files: state.workspace.files.filter((file) => file.path !== path),
-				pinnedNotes: state.workspace.pinnedNotes.filter(
-					(pinnedPath) => pinnedPath !== path,
-				),
-				lastOpenedPaths: Object.fromEntries(
-					Object.entries(state.workspace.lastOpenedPaths).filter(
-						([, openedPath]) => openedPath !== path,
-					),
-				),
-			},
-			document:
-				state.document.currentPath === path
-					? emptyDoc(
-							state.document.lastOpenedPath === path
-								? null
-								: state.document.lastOpenedPath,
-						)
-					: {
-							...state.document,
-							lastOpenedPath:
-								state.document.lastOpenedPath === path
-									? null
-									: state.document.lastOpenedPath,
-						},
-		}));
-		await syncPinnedNotes();
-		await refreshFileList();
-	} catch (err) {
-		const message = handleFileError(err);
-		toast.error("Failed to delete file", { description: message });
-		if (options?.throwOnError) throw err;
-	}
-}
-
-export async function deleteFolder(path: string) {
-	try {
-		await desktopApi.deleteFile(path, { recursive: true });
-		const currentPath = viewerStore.get().currentPath;
-		if (currentPath && pathInFolder(currentPath, path)) {
-			clearHistory();
-		} else {
-			pruneHistory(path, true);
-		}
-		appStore.set((state) => ({
-			...state,
-			workspace: {
-				...state.workspace,
-				files: state.workspace.files.filter(
-					(file) => !pathInFolder(file.path, path),
-				),
-				pinnedNotes: state.workspace.pinnedNotes.filter(
-					(pinnedPath) => !pathInFolder(pinnedPath, path),
-				),
-				lastOpenedPaths: Object.fromEntries(
-					Object.entries(state.workspace.lastOpenedPaths).filter(
-						([, openedPath]) => !pathInFolder(openedPath, path),
-					),
-				),
-			},
-			document:
-				state.document.currentPath &&
-				pathInFolder(state.document.currentPath, path)
-					? emptyDoc(
-							state.document.lastOpenedPath &&
-								pathInFolder(state.document.lastOpenedPath, path)
-								? null
-								: state.document.lastOpenedPath,
-						)
-					: {
-							...state.document,
-							lastOpenedPath:
-								state.document.lastOpenedPath &&
-								pathInFolder(state.document.lastOpenedPath, path)
-									? null
-									: state.document.lastOpenedPath,
-						},
-		}));
-		await syncPinnedNotes();
-		await refreshFileList();
-	} catch (err) {
-		const message = handleFileError(err);
-		toast.error("Failed to delete folder", { description: message });
-	}
-}
-
-function claimPendingDelete(state: "finalizing" | "restoring", token?: string) {
-	const pending = pendingDeleteUndo;
-	if (
-		!pending ||
-		pending.state !== "active" ||
-		(token && pending.token !== token)
-	) {
-		return null;
-	}
-	pending.state = state;
-	if (pending.toastId !== null) toast.dismiss(pending.toastId);
-	void desktopApi.setDeleteUndoAvailable(false);
-	return pending;
-}
-
-function finishPendingDelete(pending: PendingDeleteUndo) {
-	if (pendingDeleteUndo !== pending) return;
-	pendingDeleteUndo = null;
-	blockedSaveItems = null;
-}
-
-export async function finalizePendingDeleteUndo(token?: string) {
-	const pending = claimPendingDelete("finalizing", token);
-	if (!pending) return false;
-	try {
-		await pending.pinRemovalSaved;
-		await desktopApi.finalizeDelete(pending.token);
-	} catch (error) {
-		toast.error("Failed to finish deleting items", {
-			description: handleFileError(error),
-		});
-	}
-	finishPendingDelete(pending);
-	return true;
-}
-
-export async function undoPendingDelete(token?: string) {
-	const pending = claimPendingDelete("restoring", token);
-	if (!pending) return false;
-	try {
-		// Finish the removal write so it cannot overwrite the restored pins.
-		await pending.pinRemovalSaved;
-		await desktopApi.restoreDelete(pending.token);
-	} catch (error) {
-		toast.error("Failed to undo deletion", {
-			description: handleFileError(error),
-		});
-		finishPendingDelete(pending);
-		return false;
-	}
-
-	finishPendingDelete(pending);
-	const currentWorkspace = workspaceStore.get().workspacePath;
-	if (currentWorkspace === pending.workspacePath) {
-		workspaceStore.set((state) => ({
-			...state,
-			pinnedNotes: [...new Set([...state.pinnedNotes, ...pending.removedPins])],
-			lastOpenedPaths: {
-				...state.lastOpenedPaths,
-				...pending.removedLastOpened,
-			},
-		}));
-		if (historyStore.get() === pending.historyAfter) {
-			historyStore.set(pending.historyBefore);
-		}
-		await refreshFiles(pending.workspacePath);
-		if (pending.reopenPath && viewerStore.get().currentPath === null) {
-			await loadPath(pending.reopenPath, {
-				history: "none",
-				launchExternal: false,
-			});
-		}
-		await syncPinnedNotes();
-	}
-	return true;
-}
-
-async function performSidebarDelete(items: SidebarDeleteItem[]) {
-	if (items.length === 0) return;
-	await finalizePendingDeleteUndo();
-	if (pendingDeleteUndo) return;
-
-	const workspaceBefore = workspaceStore.get();
-	if (!workspaceBefore.workspacePath) return;
-	const viewerBefore = viewerStore.get();
-	const historyBefore = historyStore.get();
-	blockedSaveItems = items;
-	await Promise.all(
-		[...saveQueues]
-			.filter(([path]) => pathCoveredByDeleteItems(path, items))
-			.map(([, save]) => save.catch(() => {})),
-	);
-	const currentPath = viewerBefore.currentPath;
-	if (currentPath && pathCoveredByDeleteItems(currentPath, items)) {
-		try {
-			await queueSave(currentPath, () =>
-				savePathContentNow(currentPath, viewerBefore.content, {
-					force: true,
-					throwOnError: true,
-					allowBlocked: true,
-				}),
-			);
-		} catch {
-			blockedSaveItems = null;
-			return;
-		}
-	}
-
-	let token: string;
-	try {
-		token = await desktopApi.stageDelete(
-			workspaceBefore.workspacePath,
-			items.map(deleteItemPath),
-		);
-	} catch (error) {
-		blockedSaveItems = null;
-		toast.error("Failed to delete items", {
-			description: handleFileError(error),
-		});
-		return;
-	}
-	if (workspaceStore.get().workspacePath !== workspaceBefore.workspacePath) {
-		blockedSaveItems = null;
-		await desktopApi.finalizeDelete(token);
-		return;
-	}
-
-	const deletedPath = (candidate: string) =>
-		pathCoveredByDeleteItems(candidate, items);
-	const deletedCurrent =
-		viewerBefore.currentPath !== null && deletedPath(viewerBefore.currentPath);
-	const removedPins = workspaceBefore.pinnedNotes.filter(deletedPath);
-	const removedLastOpened = Object.fromEntries(
-		Object.entries(workspaceBefore.lastOpenedPaths).filter(([, path]) =>
-			deletedPath(path),
-		),
-	);
-	if (deletedCurrent) {
-		clearHistory();
-	} else {
-		for (const item of items) {
-			if (item.kind === "file") pruneHistory(item.path);
-			else pruneHistory(item.folderId, true);
-		}
-	}
-	appStore.set((state) => ({
-		...state,
-		workspace: {
-			...state.workspace,
-			files: state.workspace.files.filter((file) => !deletedPath(file.path)),
-			folders: state.workspace.folders.filter(
-				(folder) => !deletedPath(folder.path),
-			),
-			pinnedNotes: state.workspace.pinnedNotes.filter(
-				(pin) => !deletedPath(pin),
-			),
-			lastOpenedPaths: Object.fromEntries(
-				Object.entries(state.workspace.lastOpenedPaths).filter(
-					([, openedPath]) => !deletedPath(openedPath),
-				),
-			),
-		},
-		document: deletedCurrent
-			? emptyDoc(
-					state.document.lastOpenedPath &&
-						deletedPath(state.document.lastOpenedPath)
-						? null
-						: state.document.lastOpenedPath,
-				)
-			: {
-					...state.document,
-					lastOpenedPath:
-						state.document.lastOpenedPath &&
-						deletedPath(state.document.lastOpenedPath)
-							? null
-							: state.document.lastOpenedPath,
-				},
-	}));
-	const pinRemovalSaved = syncPinnedNotes();
-	pendingDeleteUndo = {
-		token,
-		workspacePath: workspaceBefore.workspacePath,
-		reopenPath: deletedCurrent ? viewerBefore.currentPath : null,
-		removedPins,
-		removedLastOpened,
-		historyBefore,
-		historyAfter: historyStore.get(),
-		pinRemovalSaved,
-		toastId: null,
-		state: "active",
-	};
-	const count = items.length;
-	const toastId = toast(
-		`Deleted ${count === 1 ? "1 item" : `${count} items`}`,
-		{
-			duration: DELETE_UNDO_DURATION_MS,
-			action: {
-				label: `Undo ${formatShortcut("CmdOrCtrl+Z")}`,
-				onClick: (event) => {
-					event.preventDefault();
-					void undoPendingDelete(token);
-				},
-			},
-			onAutoClose: () => void finalizePendingDeleteUndo(token),
-			onDismiss: () => void finalizePendingDeleteUndo(token),
-		},
-	);
-	if (pendingDeleteUndo?.token === token) pendingDeleteUndo.toastId = toastId;
-	await desktopApi.setDeleteUndoAvailable(true);
-	await pinRemovalSaved;
-}
-
-export async function deleteSidebarItems(items: SidebarDeleteItem[]) {
-	if (deleteInFlight) return;
-	deleteInFlight = true;
-	try {
-		await performSidebarDelete(items);
-	} finally {
-		deleteInFlight = false;
 	}
 }
 

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -680,6 +680,9 @@ export async function openWorkspace(path?: string) {
 		if (typeof selected !== "string") return;
 		nextPath = selected;
 	}
+	if (workspaceStore.get().workspacePath !== nextPath) {
+		await finalizePendingDeleteUndo();
+	}
 
 	workspaceStore.set((state) => {
 		const filtered = state.recentWorkspaces.filter((p) => p !== nextPath);
@@ -1309,7 +1312,6 @@ export async function finalizePendingDeleteUndo(token?: string) {
 	if (!pending || pending.isRestoring || (token && pending.token !== token)) {
 		return false;
 	}
-	clearPendingDelete(pending);
 	try {
 		await pending.pinRemovalSaved;
 		await desktopApi.finalizeDelete(pending.token);
@@ -1318,6 +1320,7 @@ export async function finalizePendingDeleteUndo(token?: string) {
 			description: handleFileError(error),
 		});
 	}
+	clearPendingDelete(pending);
 	return true;
 }
 

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -1,4 +1,4 @@
-import type { ReviewThread } from "@hubble.md/ui";
+import type { ReviewThread, SidebarDeleteItem } from "@hubble.md/ui";
 import { toast } from "sonner";
 import changelogRaw from "../../../../CHANGELOG.md?raw";
 import { desktopApi } from "../desktopApi";
@@ -95,10 +95,51 @@ const workspaceSidebarQueues = new Map<string, Promise<void>>();
 // after the editor already has draft B, that watcher event is not an external
 // conflict; it is just the disk baseline catching up to a save we started.
 const selfSaves = new Map<string, Map<string, number>>();
+const DELETE_UNDO_DURATION_MS = 8000;
+const stagedDeletePaths = new Set<string>();
+
+type PendingDeleteUndo = {
+	token: string;
+	items: SidebarDeleteItem[];
+	workspacePath: string | null;
+	currentPath: string | null;
+	pinnedNotes: string[];
+	lastOpenedPaths: Record<string, string>;
+	historyBefore: ReturnType<typeof historyStore.get>;
+	historyAfter: string;
+	deleteStateSettled: Promise<void>;
+	toastId: string | number | null;
+	isRestoring: boolean;
+};
+
+let pendingDeleteUndo: PendingDeleteUndo | null = null;
+let deleteInFlight = false;
 
 type SidebarMoveItem =
 	| { kind: "file"; path: string }
 	| { kind: "folder"; folderId: string };
+
+function deleteItemPath(item: SidebarDeleteItem) {
+	return item.kind === "file" ? item.path : item.folderId;
+}
+
+function pathCoveredByDeleteItems(path: string, items: SidebarDeleteItem[]) {
+	return items.some((item) =>
+		item.kind === "file"
+			? item.path === path
+			: pathInFolder(path, item.folderId),
+	);
+}
+
+function isStagedForDelete(path: string) {
+	return [...stagedDeletePaths].some(
+		(stagedPath) => path === stagedPath || pathInFolder(path, stagedPath),
+	);
+}
+
+function clearStagedDeletePaths(items: SidebarDeleteItem[]) {
+	for (const item of items) stagedDeletePaths.delete(deleteItemPath(item));
+}
 
 function enqueueWorkspaceSidebarUpdate(
 	workspacePath: string,
@@ -665,7 +706,8 @@ export async function openWorkspace(path?: string) {
 
 export function updateEditorContent(path: string, content: string) {
 	const current = viewerStore.get();
-	if (current.currentPath === path && current.content === content) return;
+	if (current.currentPath !== path || current.content === content) return;
+	void finalizePendingDeleteUndo();
 
 	viewerStore.set((state) => {
 		if (state.currentPath !== path) return state;
@@ -701,6 +743,8 @@ export async function savePathContent(
 ) {
 	// Binary viewers, external files, and the virtual changelog never enter text saves.
 	if (isChangelogPath(path) || !isEditableFile(path)) return;
+	// A save already queued by the editor must not recreate a staged deletion.
+	if (isStagedForDelete(path)) return;
 	const current = viewerStore.get();
 	const force = options?.force === true;
 	if (current.currentPath !== path) return;
@@ -1250,6 +1294,226 @@ export async function deleteFolder(path: string) {
 	} catch (err) {
 		const message = handleFileError(err);
 		toast.error("Failed to delete folder", { description: message });
+	}
+}
+
+function cloneHistoryState() {
+	const history = historyStore.get();
+	return {
+		...history,
+		byWorkspace: Object.fromEntries(
+			Object.entries(history.byWorkspace).map(([key, stack]) => [
+				key,
+				{ ...stack, entries: [...stack.entries] },
+			]),
+		),
+	};
+}
+
+export function canUndoPendingDelete() {
+	return pendingDeleteUndo !== null;
+}
+
+export async function finalizePendingDeleteUndo(token?: string) {
+	const pending = pendingDeleteUndo;
+	if (!pending || pending.isRestoring || (token && pending.token !== token)) {
+		return false;
+	}
+	pendingDeleteUndo = null;
+	if (pending.toastId !== null) toast.dismiss(pending.toastId);
+	void desktopApi.setDeleteUndoAvailable(false);
+	clearStagedDeletePaths(pending.items);
+	try {
+		await pending.deleteStateSettled;
+		await desktopApi.finalizeDelete(pending.token);
+	} catch (error) {
+		toast.error("Failed to finish deleting items", {
+			description: handleFileError(error),
+		});
+	}
+	return true;
+}
+
+export async function undoPendingDelete(token?: string) {
+	const pending = pendingDeleteUndo;
+	if (!pending || pending.isRestoring || (token && pending.token !== token)) {
+		return false;
+	}
+	pending.isRestoring = true;
+	try {
+		await pending.deleteStateSettled;
+		await desktopApi.restoreDelete(pending.token);
+	} catch (error) {
+		pending.isRestoring = false;
+		await finalizePendingDeleteUndo(pending.token);
+		toast.error("Failed to undo deletion", {
+			description: handleFileError(error),
+		});
+		return false;
+	}
+
+	pendingDeleteUndo = null;
+	clearStagedDeletePaths(pending.items);
+	if (pending.toastId !== null) toast.dismiss(pending.toastId);
+	void desktopApi.setDeleteUndoAvailable(false);
+	const currentWorkspace = workspaceStore.get().workspacePath;
+	if (currentWorkspace === pending.workspacePath) {
+		const restoredPins = pending.pinnedNotes.filter((pin) =>
+			pathCoveredByDeleteItems(pin, pending.items),
+		);
+		const restoredLastOpened = Object.fromEntries(
+			Object.entries(pending.lastOpenedPaths).filter(([, openedPath]) =>
+				pathCoveredByDeleteItems(openedPath, pending.items),
+			),
+		);
+		workspaceStore.set((state) => ({
+			...state,
+			pinnedNotes: [...new Set([...state.pinnedNotes, ...restoredPins])],
+			lastOpenedPaths: { ...state.lastOpenedPaths, ...restoredLastOpened },
+		}));
+		if (JSON.stringify(historyStore.get()) === pending.historyAfter) {
+			historyStore.set(pending.historyBefore);
+		}
+		await refreshFiles(pending.workspacePath);
+		if (
+			pending.currentPath &&
+			viewerStore.get().currentPath === null &&
+			pathCoveredByDeleteItems(pending.currentPath, pending.items)
+		) {
+			await loadPath(pending.currentPath, {
+				history: "none",
+				launchExternal: false,
+			});
+		}
+		await syncPinnedNotes();
+	}
+	toast.success("Deletion undone");
+	return true;
+}
+
+async function performSidebarDelete(items: SidebarDeleteItem[]) {
+	if (items.length === 0) return;
+	await finalizePendingDeleteUndo();
+	if (pendingDeleteUndo) return;
+
+	const workspaceBefore = workspaceStore.get();
+	if (!workspaceBefore.workspacePath) return;
+	const viewerBefore = viewerStore.get();
+	const historyBefore = cloneHistoryState();
+	if (
+		viewerBefore.currentPath &&
+		pathCoveredByDeleteItems(viewerBefore.currentPath, items)
+	) {
+		await savePathContent(viewerBefore.currentPath, viewerBefore.content);
+	}
+	for (const item of items) stagedDeletePaths.add(deleteItemPath(item));
+
+	let token: string;
+	try {
+		token = await desktopApi.stageDelete(
+			workspaceBefore.workspacePath,
+			items.map((item) => ({ path: deleteItemPath(item) })),
+		);
+	} catch (error) {
+		clearStagedDeletePaths(items);
+		toast.error("Failed to delete items", {
+			description: handleFileError(error),
+		});
+		return;
+	}
+	if (workspaceStore.get().workspacePath !== workspaceBefore.workspacePath) {
+		clearStagedDeletePaths(items);
+		await desktopApi.finalizeDelete(token);
+		return;
+	}
+
+	const deletedPath = (candidate: string) =>
+		pathCoveredByDeleteItems(candidate, items);
+	const deletedCurrent =
+		viewerBefore.currentPath !== null && deletedPath(viewerBefore.currentPath);
+	if (deletedCurrent) {
+		clearHistory();
+	} else {
+		for (const item of items) {
+			if (item.kind === "file") pruneHistory(item.path);
+			else pruneHistory(item.folderId, true);
+		}
+	}
+	appStore.set((state) => ({
+		...state,
+		workspace: {
+			...state.workspace,
+			files: state.workspace.files.filter((file) => !deletedPath(file.path)),
+			folders: state.workspace.folders.filter(
+				(folder) => !deletedPath(folder.path),
+			),
+			pinnedNotes: state.workspace.pinnedNotes.filter(
+				(pin) => !deletedPath(pin),
+			),
+			lastOpenedPaths: Object.fromEntries(
+				Object.entries(state.workspace.lastOpenedPaths).filter(
+					([, openedPath]) => !deletedPath(openedPath),
+				),
+			),
+		},
+		document: deletedCurrent
+			? emptyDoc(
+					state.document.lastOpenedPath &&
+						deletedPath(state.document.lastOpenedPath)
+						? null
+						: state.document.lastOpenedPath,
+				)
+			: {
+					...state.document,
+					lastOpenedPath:
+						state.document.lastOpenedPath &&
+						deletedPath(state.document.lastOpenedPath)
+							? null
+							: state.document.lastOpenedPath,
+				},
+	}));
+	const deleteStateSettled = syncPinnedNotes();
+	pendingDeleteUndo = {
+		token,
+		items,
+		workspacePath: workspaceBefore.workspacePath,
+		currentPath: viewerBefore.currentPath,
+		pinnedNotes: workspaceBefore.pinnedNotes,
+		lastOpenedPaths: workspaceBefore.lastOpenedPaths,
+		historyBefore,
+		historyAfter: JSON.stringify(historyStore.get()),
+		deleteStateSettled,
+		toastId: null,
+		isRestoring: false,
+	};
+	const count = items.length;
+	const toastId = toast(
+		`Deleted ${count === 1 ? "1 item" : `${count} items`}`,
+		{
+			duration: DELETE_UNDO_DURATION_MS,
+			action: {
+				label: "Undo",
+				onClick: (event) => {
+					event.preventDefault();
+					void undoPendingDelete(token);
+				},
+			},
+			onAutoClose: () => void finalizePendingDeleteUndo(token),
+			onDismiss: () => void finalizePendingDeleteUndo(token),
+		},
+	);
+	if (pendingDeleteUndo?.token === token) pendingDeleteUndo.toastId = toastId;
+	await desktopApi.setDeleteUndoAvailable(true);
+	await deleteStateSettled;
+}
+
+export async function deleteSidebarItems(items: SidebarDeleteItem[]) {
+	if (deleteInFlight) return;
+	deleteInFlight = true;
+	try {
+		await performSidebarDelete(items);
+	} finally {
+		deleteInFlight = false;
 	}
 }
 

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -96,18 +96,17 @@ const workspaceSidebarQueues = new Map<string, Promise<void>>();
 // conflict; it is just the disk baseline catching up to a save we started.
 const selfSaves = new Map<string, Map<string, number>>();
 const DELETE_UNDO_DURATION_MS = 8000;
-const stagedDeletePaths = new Set<string>();
+let blockedSaveItems: SidebarDeleteItem[] | null = null;
 
 type PendingDeleteUndo = {
 	token: string;
-	items: SidebarDeleteItem[];
-	workspacePath: string | null;
-	currentPath: string | null;
-	pinnedNotes: string[];
-	lastOpenedPaths: Record<string, string>;
+	workspacePath: string;
+	reopenPath: string | null;
+	removedPins: string[];
+	removedLastOpened: Record<string, string>;
 	historyBefore: ReturnType<typeof historyStore.get>;
-	historyAfter: string;
-	deleteStateSettled: Promise<void>;
+	historyAfter: ReturnType<typeof historyStore.get>;
+	pinRemovalSaved: Promise<void>;
 	toastId: string | number | null;
 	isRestoring: boolean;
 };
@@ -132,13 +131,9 @@ function pathCoveredByDeleteItems(path: string, items: SidebarDeleteItem[]) {
 }
 
 function isStagedForDelete(path: string) {
-	return [...stagedDeletePaths].some(
-		(stagedPath) => path === stagedPath || pathInFolder(path, stagedPath),
-	);
-}
-
-function clearStagedDeletePaths(items: SidebarDeleteItem[]) {
-	for (const item of items) stagedDeletePaths.delete(deleteItemPath(item));
+	return blockedSaveItems
+		? pathCoveredByDeleteItems(path, blockedSaveItems)
+		: false;
 }
 
 function enqueueWorkspaceSidebarUpdate(
@@ -1297,21 +1292,11 @@ export async function deleteFolder(path: string) {
 	}
 }
 
-function cloneHistoryState() {
-	const history = historyStore.get();
-	return {
-		...history,
-		byWorkspace: Object.fromEntries(
-			Object.entries(history.byWorkspace).map(([key, stack]) => [
-				key,
-				{ ...stack, entries: [...stack.entries] },
-			]),
-		),
-	};
-}
-
-export function canUndoPendingDelete() {
-	return pendingDeleteUndo !== null;
+function clearPendingDelete(pending: PendingDeleteUndo) {
+	pendingDeleteUndo = null;
+	blockedSaveItems = null;
+	if (pending.toastId !== null) toast.dismiss(pending.toastId);
+	void desktopApi.setDeleteUndoAvailable(false);
 }
 
 export async function finalizePendingDeleteUndo(token?: string) {
@@ -1319,12 +1304,9 @@ export async function finalizePendingDeleteUndo(token?: string) {
 	if (!pending || pending.isRestoring || (token && pending.token !== token)) {
 		return false;
 	}
-	pendingDeleteUndo = null;
-	if (pending.toastId !== null) toast.dismiss(pending.toastId);
-	void desktopApi.setDeleteUndoAvailable(false);
-	clearStagedDeletePaths(pending.items);
+	clearPendingDelete(pending);
 	try {
-		await pending.deleteStateSettled;
+		await pending.pinRemovalSaved;
 		await desktopApi.finalizeDelete(pending.token);
 	} catch (error) {
 		toast.error("Failed to finish deleting items", {
@@ -1341,7 +1323,8 @@ export async function undoPendingDelete(token?: string) {
 	}
 	pending.isRestoring = true;
 	try {
-		await pending.deleteStateSettled;
+		// Finish the removal write so it cannot overwrite the restored pins.
+		await pending.pinRemovalSaved;
 		await desktopApi.restoreDelete(pending.token);
 	} catch (error) {
 		pending.isRestoring = false;
@@ -1352,35 +1335,23 @@ export async function undoPendingDelete(token?: string) {
 		return false;
 	}
 
-	pendingDeleteUndo = null;
-	clearStagedDeletePaths(pending.items);
-	if (pending.toastId !== null) toast.dismiss(pending.toastId);
-	void desktopApi.setDeleteUndoAvailable(false);
+	clearPendingDelete(pending);
 	const currentWorkspace = workspaceStore.get().workspacePath;
 	if (currentWorkspace === pending.workspacePath) {
-		const restoredPins = pending.pinnedNotes.filter((pin) =>
-			pathCoveredByDeleteItems(pin, pending.items),
-		);
-		const restoredLastOpened = Object.fromEntries(
-			Object.entries(pending.lastOpenedPaths).filter(([, openedPath]) =>
-				pathCoveredByDeleteItems(openedPath, pending.items),
-			),
-		);
 		workspaceStore.set((state) => ({
 			...state,
-			pinnedNotes: [...new Set([...state.pinnedNotes, ...restoredPins])],
-			lastOpenedPaths: { ...state.lastOpenedPaths, ...restoredLastOpened },
+			pinnedNotes: [...new Set([...state.pinnedNotes, ...pending.removedPins])],
+			lastOpenedPaths: {
+				...state.lastOpenedPaths,
+				...pending.removedLastOpened,
+			},
 		}));
-		if (JSON.stringify(historyStore.get()) === pending.historyAfter) {
+		if (historyStore.get() === pending.historyAfter) {
 			historyStore.set(pending.historyBefore);
 		}
 		await refreshFiles(pending.workspacePath);
-		if (
-			pending.currentPath &&
-			viewerStore.get().currentPath === null &&
-			pathCoveredByDeleteItems(pending.currentPath, pending.items)
-		) {
-			await loadPath(pending.currentPath, {
+		if (pending.reopenPath && viewerStore.get().currentPath === null) {
+			await loadPath(pending.reopenPath, {
 				history: "none",
 				launchExternal: false,
 			});
@@ -1399,30 +1370,30 @@ async function performSidebarDelete(items: SidebarDeleteItem[]) {
 	const workspaceBefore = workspaceStore.get();
 	if (!workspaceBefore.workspacePath) return;
 	const viewerBefore = viewerStore.get();
-	const historyBefore = cloneHistoryState();
+	const historyBefore = historyStore.get();
 	if (
 		viewerBefore.currentPath &&
 		pathCoveredByDeleteItems(viewerBefore.currentPath, items)
 	) {
 		await savePathContent(viewerBefore.currentPath, viewerBefore.content);
 	}
-	for (const item of items) stagedDeletePaths.add(deleteItemPath(item));
+	blockedSaveItems = items;
 
 	let token: string;
 	try {
 		token = await desktopApi.stageDelete(
 			workspaceBefore.workspacePath,
-			items.map((item) => ({ path: deleteItemPath(item) })),
+			items.map(deleteItemPath),
 		);
 	} catch (error) {
-		clearStagedDeletePaths(items);
+		blockedSaveItems = null;
 		toast.error("Failed to delete items", {
 			description: handleFileError(error),
 		});
 		return;
 	}
 	if (workspaceStore.get().workspacePath !== workspaceBefore.workspacePath) {
-		clearStagedDeletePaths(items);
+		blockedSaveItems = null;
 		await desktopApi.finalizeDelete(token);
 		return;
 	}
@@ -1431,6 +1402,12 @@ async function performSidebarDelete(items: SidebarDeleteItem[]) {
 		pathCoveredByDeleteItems(candidate, items);
 	const deletedCurrent =
 		viewerBefore.currentPath !== null && deletedPath(viewerBefore.currentPath);
+	const removedPins = workspaceBefore.pinnedNotes.filter(deletedPath);
+	const removedLastOpened = Object.fromEntries(
+		Object.entries(workspaceBefore.lastOpenedPaths).filter(([, path]) =>
+			deletedPath(path),
+		),
+	);
 	if (deletedCurrent) {
 		clearHistory();
 	} else {
@@ -1472,17 +1449,16 @@ async function performSidebarDelete(items: SidebarDeleteItem[]) {
 							: state.document.lastOpenedPath,
 				},
 	}));
-	const deleteStateSettled = syncPinnedNotes();
+	const pinRemovalSaved = syncPinnedNotes();
 	pendingDeleteUndo = {
 		token,
-		items,
 		workspacePath: workspaceBefore.workspacePath,
-		currentPath: viewerBefore.currentPath,
-		pinnedNotes: workspaceBefore.pinnedNotes,
-		lastOpenedPaths: workspaceBefore.lastOpenedPaths,
+		reopenPath: deletedCurrent ? viewerBefore.currentPath : null,
+		removedPins,
+		removedLastOpened,
 		historyBefore,
-		historyAfter: JSON.stringify(historyStore.get()),
-		deleteStateSettled,
+		historyAfter: historyStore.get(),
+		pinRemovalSaved,
 		toastId: null,
 		isRestoring: false,
 	};
@@ -1504,7 +1480,7 @@ async function performSidebarDelete(items: SidebarDeleteItem[]) {
 	);
 	if (pendingDeleteUndo?.token === token) pendingDeleteUndo.toastId = toastId;
 	await desktopApi.setDeleteUndoAvailable(true);
-	await deleteStateSettled;
+	await pinRemovalSaved;
 }
 
 export async function deleteSidebarItems(items: SidebarDeleteItem[]) {

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -99,6 +99,7 @@ const workspaceSidebarQueues = new Map<string, Promise<void>>();
 // after the editor already has draft B, that watcher event is not an external
 // conflict; it is just the disk baseline catching up to a save we started.
 const selfSaves = new Map<string, Map<string, number>>();
+const saveQueues = new Map<string, Promise<void>>();
 const DELETE_UNDO_DURATION_MS = 8000;
 let blockedSaveItems: SidebarDeleteItem[] | null = null;
 
@@ -112,7 +113,7 @@ type PendingDeleteUndo = {
 	historyAfter: ReturnType<typeof historyStore.get>;
 	pinRemovalSaved: Promise<void>;
 	toastId: string | number | null;
-	isRestoring: boolean;
+	state: "active" | "finalizing" | "restoring";
 };
 
 let pendingDeleteUndo: PendingDeleteUndo | null = null;
@@ -738,15 +739,26 @@ export function setViewerMode(viewMode: ViewMode) {
 	});
 }
 
-export async function savePathContent(
+function queueSave(path: string, save: () => Promise<void>) {
+	const previous = saveQueues.get(path);
+	const next = previous ? previous.catch(() => {}).then(save) : save();
+	saveQueues.set(path, next);
+	const clear = () => {
+		if (saveQueues.get(path) === next) saveQueues.delete(path);
+	};
+	void next.then(clear, clear);
+	return next;
+}
+
+async function savePathContentNow(
 	path: string,
 	content: string,
-	options?: { force?: boolean; throwOnError?: boolean },
+	options?: { force?: boolean; throwOnError?: boolean; allowBlocked?: boolean },
 ) {
 	// Binary viewers, external files, and the virtual changelog never enter text saves.
 	if (isChangelogPath(path) || !isEditableFile(path)) return;
 	// A save already queued by the editor must not recreate a staged deletion.
-	if (isStagedForDelete(path)) return;
+	if (!options?.allowBlocked && isStagedForDelete(path)) return;
 	const current = viewerStore.get();
 	const force = options?.force === true;
 	if (current.currentPath !== path) return;
@@ -824,6 +836,14 @@ export async function savePathContent(
 		});
 		if (options?.throwOnError) throw err;
 	}
+}
+
+export function savePathContent(
+	path: string,
+	content: string,
+	options?: { force?: boolean; throwOnError?: boolean },
+) {
+	return queueSave(path, () => savePathContentNow(path, content, options));
 }
 
 export async function renameMarkdownFile(path: string, nextName: string) {
@@ -1300,18 +1320,30 @@ export async function deleteFolder(path: string) {
 	}
 }
 
-function clearPendingDelete(pending: PendingDeleteUndo) {
-	pendingDeleteUndo = null;
-	blockedSaveItems = null;
+function claimPendingDelete(state: "finalizing" | "restoring", token?: string) {
+	const pending = pendingDeleteUndo;
+	if (
+		!pending ||
+		pending.state !== "active" ||
+		(token && pending.token !== token)
+	) {
+		return null;
+	}
+	pending.state = state;
 	if (pending.toastId !== null) toast.dismiss(pending.toastId);
 	void desktopApi.setDeleteUndoAvailable(false);
+	return pending;
+}
+
+function finishPendingDelete(pending: PendingDeleteUndo) {
+	if (pendingDeleteUndo !== pending) return;
+	pendingDeleteUndo = null;
+	blockedSaveItems = null;
 }
 
 export async function finalizePendingDeleteUndo(token?: string) {
-	const pending = pendingDeleteUndo;
-	if (!pending || pending.isRestoring || (token && pending.token !== token)) {
-		return false;
-	}
+	const pending = claimPendingDelete("finalizing", token);
+	if (!pending) return false;
 	try {
 		await pending.pinRemovalSaved;
 		await desktopApi.finalizeDelete(pending.token);
@@ -1320,29 +1352,26 @@ export async function finalizePendingDeleteUndo(token?: string) {
 			description: handleFileError(error),
 		});
 	}
-	clearPendingDelete(pending);
+	finishPendingDelete(pending);
 	return true;
 }
 
 export async function undoPendingDelete(token?: string) {
-	const pending = pendingDeleteUndo;
-	if (!pending || pending.isRestoring || (token && pending.token !== token)) {
-		return false;
-	}
-	pending.isRestoring = true;
+	const pending = claimPendingDelete("restoring", token);
+	if (!pending) return false;
 	try {
 		// Finish the removal write so it cannot overwrite the restored pins.
 		await pending.pinRemovalSaved;
 		await desktopApi.restoreDelete(pending.token);
 	} catch (error) {
-		clearPendingDelete(pending);
 		toast.error("Failed to undo deletion", {
 			description: handleFileError(error),
 		});
+		finishPendingDelete(pending);
 		return false;
 	}
 
-	clearPendingDelete(pending);
+	finishPendingDelete(pending);
 	const currentWorkspace = workspaceStore.get().workspacePath;
 	if (currentWorkspace === pending.workspacePath) {
 		workspaceStore.set((state) => ({
@@ -1377,20 +1406,27 @@ async function performSidebarDelete(items: SidebarDeleteItem[]) {
 	if (!workspaceBefore.workspacePath) return;
 	const viewerBefore = viewerStore.get();
 	const historyBefore = historyStore.get();
-	if (
-		viewerBefore.currentPath &&
-		pathCoveredByDeleteItems(viewerBefore.currentPath, items)
-	) {
+	blockedSaveItems = items;
+	await Promise.all(
+		[...saveQueues]
+			.filter(([path]) => pathCoveredByDeleteItems(path, items))
+			.map(([, save]) => save.catch(() => {})),
+	);
+	const currentPath = viewerBefore.currentPath;
+	if (currentPath && pathCoveredByDeleteItems(currentPath, items)) {
 		try {
-			await savePathContent(viewerBefore.currentPath, viewerBefore.content, {
-				force: true,
-				throwOnError: true,
-			});
+			await queueSave(currentPath, () =>
+				savePathContentNow(currentPath, viewerBefore.content, {
+					force: true,
+					throwOnError: true,
+					allowBlocked: true,
+				}),
+			);
 		} catch {
+			blockedSaveItems = null;
 			return;
 		}
 	}
-	blockedSaveItems = items;
 
 	let token: string;
 	try {
@@ -1473,7 +1509,7 @@ async function performSidebarDelete(items: SidebarDeleteItem[]) {
 		historyAfter: historyStore.get(),
 		pinRemovalSaved,
 		toastId: null,
-		isRestoring: false,
+		state: "active",
 	};
 	const count = items.length;
 	const toastId = toast(

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -1,4 +1,8 @@
-import type { ReviewThread, SidebarDeleteItem } from "@hubble.md/ui";
+import {
+	formatShortcut,
+	type ReviewThread,
+	type SidebarDeleteItem,
+} from "@hubble.md/ui";
 import { toast } from "sonner";
 import changelogRaw from "../../../../CHANGELOG.md?raw";
 import { desktopApi } from "../desktopApi";
@@ -1358,7 +1362,6 @@ export async function undoPendingDelete(token?: string) {
 		}
 		await syncPinnedNotes();
 	}
-	toast.success("Deletion undone");
 	return true;
 }
 
@@ -1468,7 +1471,7 @@ async function performSidebarDelete(items: SidebarDeleteItem[]) {
 		{
 			duration: DELETE_UNDO_DURATION_MS,
 			action: {
-				label: "Undo",
+				label: `Undo ${formatShortcut("CmdOrCtrl+Z")}`,
 				onClick: (event) => {
 					event.preventDefault();
 					void undoPendingDelete(token);

--- a/apps/desktop/src/store/deleteActions.ts
+++ b/apps/desktop/src/store/deleteActions.ts
@@ -12,7 +12,7 @@ import {
 	workspaceStore,
 } from "./state";
 
-const UNDO_MS = 8000;
+const UNDO_MS = 5000;
 
 type PendingDelete = {
 	token: string;

--- a/apps/desktop/src/store/deleteActions.ts
+++ b/apps/desktop/src/store/deleteActions.ts
@@ -1,0 +1,378 @@
+import { formatShortcut, type SidebarDeleteItem } from "@hubble.md/ui";
+import { toast } from "sonner";
+import { desktopApi } from "../desktopApi";
+import { pathInFolder } from "../lib/filePath";
+import { clearHistory, pruneHistory } from "./history";
+import {
+	appStore,
+	emptyDoc,
+	historyStore,
+	viewerStore,
+	workspaceStore,
+} from "./state";
+
+const UNDO_MS = 8000;
+
+type PendingDelete = {
+	token: string;
+	workspacePath: string;
+	reopenPath: string | null;
+	removedPins: string[];
+	removedLastOpened: Record<string, string>;
+	historyBefore: ReturnType<typeof historyStore.get>;
+	historyAfter: ReturnType<typeof historyStore.get>;
+	pinRemovalSaved: Promise<void>;
+	toastId: string | number | null;
+	state: "active" | "expiring" | "restoring";
+};
+
+type DeleteDeps = {
+	saveBeforeDelete: (path: string, content: string) => Promise<void>;
+	waitForSaves: (matches: (path: string) => boolean) => Promise<void>;
+	refreshFiles: (workspacePath: string) => Promise<void>;
+	refreshFileList: () => Promise<void>;
+	loadPath: (
+		path: string,
+		options: { history: "none"; launchExternal: false },
+	) => Promise<void>;
+	syncPins: () => Promise<void>;
+	handleError: (error: unknown) => string;
+};
+
+function itemPath(item: SidebarDeleteItem) {
+	return item.kind === "file" ? item.path : item.folderId;
+}
+
+function covers(path: string, items: SidebarDeleteItem[]) {
+	return items.some((item) =>
+		item.kind === "file"
+			? item.path === path
+			: item.folderId === path || pathInFolder(path, item.folderId),
+	);
+}
+
+export function createDeleteActions(deps: DeleteDeps) {
+	let blockedItems: SidebarDeleteItem[] | null = null;
+	let pending: PendingDelete | null = null;
+	let deleting = false;
+
+	const isSaveBlocked = (path: string) =>
+		blockedItems ? covers(path, blockedItems) : false;
+
+	const claim = (state: "expiring" | "restoring", token?: string) => {
+		if (
+			!pending ||
+			pending.state !== "active" ||
+			(token && pending.token !== token)
+		) {
+			return null;
+		}
+		pending.state = state;
+		if (pending.toastId !== null) toast.dismiss(pending.toastId);
+		void desktopApi.setDeleteUndoAvailable(false);
+		return pending;
+	};
+
+	const finish = (finished: PendingDelete) => {
+		if (pending !== finished) return;
+		pending = null;
+		blockedItems = null;
+	};
+
+	const expireDeleteUndo = async (token?: string) => {
+		const deletion = claim("expiring", token);
+		if (!deletion) return false;
+		try {
+			await deletion.pinRemovalSaved;
+			await desktopApi.finalizeDelete(deletion.token);
+		} catch (error) {
+			toast.error("Failed to finish deleting items", {
+				description: deps.handleError(error),
+			});
+		}
+		finish(deletion);
+		return true;
+	};
+
+	const undoDelete = async (token?: string) => {
+		const deletion = claim("restoring", token);
+		if (!deletion) return false;
+		try {
+			// The removal write must finish before restored pins are written back.
+			await deletion.pinRemovalSaved;
+			await desktopApi.restoreDelete(deletion.token);
+		} catch (error) {
+			toast.error("Failed to undo deletion", {
+				description: deps.handleError(error),
+			});
+			finish(deletion);
+			return false;
+		}
+
+		finish(deletion);
+		if (workspaceStore.get().workspacePath === deletion.workspacePath) {
+			workspaceStore.set((state) => ({
+				...state,
+				pinnedNotes: [
+					...new Set([...state.pinnedNotes, ...deletion.removedPins]),
+				],
+				lastOpenedPaths: {
+					...state.lastOpenedPaths,
+					...deletion.removedLastOpened,
+				},
+			}));
+			if (historyStore.get() === deletion.historyAfter) {
+				historyStore.set(deletion.historyBefore);
+			}
+			await deps.refreshFiles(deletion.workspacePath);
+			if (deletion.reopenPath && viewerStore.get().currentPath === null) {
+				await deps.loadPath(deletion.reopenPath, {
+					history: "none",
+					launchExternal: false,
+				});
+			}
+			await deps.syncPins();
+		}
+		return true;
+	};
+
+	const runDelete = async (items: SidebarDeleteItem[]) => {
+		if (items.length === 0) return;
+		await expireDeleteUndo();
+		if (pending) return;
+
+		const workspaceBefore = workspaceStore.get();
+		if (!workspaceBefore.workspacePath) return;
+		const viewerBefore = viewerStore.get();
+		const historyBefore = historyStore.get();
+		blockedItems = items;
+		await deps.waitForSaves((path) => covers(path, items));
+		const currentPath = viewerBefore.currentPath;
+		if (currentPath && covers(currentPath, items)) {
+			try {
+				await deps.saveBeforeDelete(currentPath, viewerBefore.content);
+			} catch {
+				blockedItems = null;
+				return;
+			}
+		}
+
+		let token: string;
+		try {
+			token = await desktopApi.stageDelete(
+				workspaceBefore.workspacePath,
+				items.map(itemPath),
+			);
+		} catch (error) {
+			blockedItems = null;
+			toast.error("Failed to delete items", {
+				description: deps.handleError(error),
+			});
+			return;
+		}
+		if (workspaceStore.get().workspacePath !== workspaceBefore.workspacePath) {
+			blockedItems = null;
+			await desktopApi.finalizeDelete(token);
+			return;
+		}
+
+		const deletedPath = (path: string) => covers(path, items);
+		const deletedCurrent =
+			viewerBefore.currentPath !== null &&
+			deletedPath(viewerBefore.currentPath);
+		const removedPins = workspaceBefore.pinnedNotes.filter(deletedPath);
+		const removedLastOpened = Object.fromEntries(
+			Object.entries(workspaceBefore.lastOpenedPaths).filter(([, path]) =>
+				deletedPath(path),
+			),
+		);
+		if (deletedCurrent) {
+			clearHistory();
+		} else {
+			for (const item of items) {
+				if (item.kind === "file") pruneHistory(item.path);
+				else pruneHistory(item.folderId, true);
+			}
+		}
+		appStore.set((state) => ({
+			...state,
+			workspace: {
+				...state.workspace,
+				files: state.workspace.files.filter((file) => !deletedPath(file.path)),
+				folders: state.workspace.folders.filter(
+					(folder) => !deletedPath(folder.path),
+				),
+				pinnedNotes: state.workspace.pinnedNotes.filter(
+					(pin) => !deletedPath(pin),
+				),
+				lastOpenedPaths: Object.fromEntries(
+					Object.entries(state.workspace.lastOpenedPaths).filter(
+						([, openedPath]) => !deletedPath(openedPath),
+					),
+				),
+			},
+			document: deletedCurrent
+				? emptyDoc(
+						state.document.lastOpenedPath &&
+							deletedPath(state.document.lastOpenedPath)
+							? null
+							: state.document.lastOpenedPath,
+					)
+				: {
+						...state.document,
+						lastOpenedPath:
+							state.document.lastOpenedPath &&
+							deletedPath(state.document.lastOpenedPath)
+								? null
+								: state.document.lastOpenedPath,
+					},
+		}));
+		const pinRemovalSaved = deps.syncPins();
+		pending = {
+			token,
+			workspacePath: workspaceBefore.workspacePath,
+			reopenPath: deletedCurrent ? viewerBefore.currentPath : null,
+			removedPins,
+			removedLastOpened,
+			historyBefore,
+			historyAfter: historyStore.get(),
+			pinRemovalSaved,
+			toastId: null,
+			state: "active",
+		};
+		const count = items.length;
+		const toastId = toast(
+			`Deleted ${count === 1 ? "1 item" : `${count} items`}`,
+			{
+				duration: UNDO_MS,
+				action: {
+					label: `Undo ${formatShortcut("CmdOrCtrl+Z")}`,
+					onClick: (event) => {
+						event.preventDefault();
+						void undoDelete(token);
+					},
+				},
+				onAutoClose: () => void expireDeleteUndo(token),
+				onDismiss: () => void expireDeleteUndo(token),
+			},
+		);
+		if (pending?.token === token) pending.toastId = toastId;
+		await desktopApi.setDeleteUndoAvailable(true);
+		await pinRemovalSaved;
+	};
+
+	const deleteSidebarItems = async (items: SidebarDeleteItem[]) => {
+		if (deleting) return;
+		deleting = true;
+		try {
+			await runDelete(items);
+		} finally {
+			deleting = false;
+		}
+	};
+
+	const deleteMarkdownFile = async (
+		path: string,
+		options?: { throwOnError?: boolean },
+	) => {
+		try {
+			await desktopApi.deleteFile(path);
+			if (viewerStore.get().currentPath === path) clearHistory();
+			else pruneHistory(path);
+			appStore.set((state) => ({
+				...state,
+				workspace: {
+					...state.workspace,
+					files: state.workspace.files.filter((file) => file.path !== path),
+					pinnedNotes: state.workspace.pinnedNotes.filter(
+						(pinnedPath) => pinnedPath !== path,
+					),
+					lastOpenedPaths: Object.fromEntries(
+						Object.entries(state.workspace.lastOpenedPaths).filter(
+							([, openedPath]) => openedPath !== path,
+						),
+					),
+				},
+				document:
+					state.document.currentPath === path
+						? emptyDoc(
+								state.document.lastOpenedPath === path
+									? null
+									: state.document.lastOpenedPath,
+							)
+						: {
+								...state.document,
+								lastOpenedPath:
+									state.document.lastOpenedPath === path
+										? null
+										: state.document.lastOpenedPath,
+							},
+			}));
+			await deps.syncPins();
+			await deps.refreshFileList();
+		} catch (error) {
+			toast.error("Failed to delete file", {
+				description: deps.handleError(error),
+			});
+			if (options?.throwOnError) throw error;
+		}
+	};
+
+	const deleteFolder = async (path: string) => {
+		try {
+			await desktopApi.deleteFile(path, { recursive: true });
+			const currentPath = viewerStore.get().currentPath;
+			if (currentPath && pathInFolder(currentPath, path)) clearHistory();
+			else pruneHistory(path, true);
+			appStore.set((state) => ({
+				...state,
+				workspace: {
+					...state.workspace,
+					files: state.workspace.files.filter(
+						(file) => !pathInFolder(file.path, path),
+					),
+					pinnedNotes: state.workspace.pinnedNotes.filter(
+						(pinnedPath) => !pathInFolder(pinnedPath, path),
+					),
+					lastOpenedPaths: Object.fromEntries(
+						Object.entries(state.workspace.lastOpenedPaths).filter(
+							([, openedPath]) => !pathInFolder(openedPath, path),
+						),
+					),
+				},
+				document:
+					state.document.currentPath &&
+					pathInFolder(state.document.currentPath, path)
+						? emptyDoc(
+								state.document.lastOpenedPath &&
+									pathInFolder(state.document.lastOpenedPath, path)
+									? null
+									: state.document.lastOpenedPath,
+							)
+						: {
+								...state.document,
+								lastOpenedPath:
+									state.document.lastOpenedPath &&
+									pathInFolder(state.document.lastOpenedPath, path)
+										? null
+										: state.document.lastOpenedPath,
+							},
+			}));
+			await deps.syncPins();
+			await deps.refreshFileList();
+		} catch (error) {
+			toast.error("Failed to delete folder", {
+				description: deps.handleError(error),
+			});
+		}
+	};
+
+	return {
+		deleteFolder,
+		deleteMarkdownFile,
+		deleteSidebarItems,
+		expireDeleteUndo,
+		isSaveBlocked,
+		undoDelete,
+	};
+}

--- a/apps/desktop/src/store/deleteActions.ts
+++ b/apps/desktop/src/store/deleteActions.ts
@@ -23,7 +23,7 @@ type PendingDelete = {
 	historyAfter: ReturnType<typeof historyStore.get>;
 	pinRemovalSaved: Promise<void>;
 	toastId: string | number | null;
-	state: "active" | "expiring" | "restoring";
+	claimed: boolean;
 };
 
 type DeleteDeps = {
@@ -59,20 +59,21 @@ export function createDeleteActions(deps: DeleteDeps) {
 	const isSaveBlocked = (path: string) =>
 		blockedItems ? covers(path, blockedItems) : false;
 
-	const claim = (state: "expiring" | "restoring", token?: string) => {
-		if (
-			!pending ||
-			pending.state !== "active" ||
-			(token && pending.token !== token)
-		) {
+	// The toast timeout, Cmd+Z, and the next delete all race to settle the
+	// pending deletion; exactly one caller may claim it. Passing a token
+	// limits the claim to that deletion, so a stale toast callback is a no-op.
+	const claim = (token?: string) => {
+		if (!pending || pending.claimed || (token && pending.token !== token)) {
 			return null;
 		}
-		pending.state = state;
+		pending.claimed = true;
 		if (pending.toastId !== null) toast.dismiss(pending.toastId);
 		void desktopApi.setDeleteUndoAvailable(false);
 		return pending;
 	};
 
+	// Saves to the deleted paths stay blocked while the claimed expire or
+	// restore is in flight, so cleanup happens here rather than in claim.
 	const finish = (finished: PendingDelete) => {
 		if (pending !== finished) return;
 		pending = null;
@@ -80,7 +81,7 @@ export function createDeleteActions(deps: DeleteDeps) {
 	};
 
 	const expireDeleteUndo = async (token?: string) => {
-		const deletion = claim("expiring", token);
+		const deletion = claim(token);
 		if (!deletion) return false;
 		try {
 			await deletion.pinRemovalSaved;
@@ -95,7 +96,7 @@ export function createDeleteActions(deps: DeleteDeps) {
 	};
 
 	const undoDelete = async (token?: string) => {
-		const deletion = claim("restoring", token);
+		const deletion = claim(token);
 		if (!deletion) return false;
 		try {
 			// The removal write must finish before restored pins are written back.
@@ -136,6 +137,51 @@ export function createDeleteActions(deps: DeleteDeps) {
 		return true;
 	};
 
+	/**
+	 * Blocks saves to the items, flushes the open note, and stages the items
+	 * for undoable deletion. Returns the deletion token, or null if the
+	 * delete was abandoned; abandoning unblocks saves.
+	 */
+	const stageItems = async (
+		items: SidebarDeleteItem[],
+		workspacePath: string,
+		viewer: { currentPath: string | null; content: string },
+	): Promise<string | null> => {
+		const abandon = () => {
+			blockedItems = null;
+			return null;
+		};
+		// Block new saves to the deleted paths before waiting out in-flight
+		// ones, so a queued autosave cannot recreate a staged file.
+		blockedItems = items;
+		await deps.waitForSaves((path) => covers(path, items));
+		if (viewer.currentPath && covers(viewer.currentPath, items)) {
+			try {
+				// Flush the open note so the staged copy holds its latest text.
+				await deps.saveBeforeDelete(viewer.currentPath, viewer.content);
+			} catch {
+				return abandon(); // The save already raised its own toast.
+			}
+		}
+		let token: string;
+		try {
+			token = await desktopApi.stageDelete(workspacePath, items.map(itemPath));
+		} catch (error) {
+			toast.error("Failed to delete items", {
+				description: deps.handleError(error),
+			});
+			return abandon();
+		}
+		if (workspaceStore.get().workspacePath !== workspacePath) {
+			// The user switched workspaces while staging; undo would restore
+			// into the wrong sidebar, so drop the staged files right away.
+			abandon();
+			await desktopApi.finalizeDelete(token);
+			return null;
+		}
+		return token;
+	};
+
 	const runDelete = async (items: SidebarDeleteItem[]) => {
 		if (items.length === 0) return;
 		await expireDeleteUndo();
@@ -145,36 +191,12 @@ export function createDeleteActions(deps: DeleteDeps) {
 		if (!workspaceBefore.workspacePath) return;
 		const viewerBefore = viewerStore.get();
 		const historyBefore = historyStore.get();
-		blockedItems = items;
-		await deps.waitForSaves((path) => covers(path, items));
-		const currentPath = viewerBefore.currentPath;
-		if (currentPath && covers(currentPath, items)) {
-			try {
-				await deps.saveBeforeDelete(currentPath, viewerBefore.content);
-			} catch {
-				blockedItems = null;
-				return;
-			}
-		}
-
-		let token: string;
-		try {
-			token = await desktopApi.stageDelete(
-				workspaceBefore.workspacePath,
-				items.map(itemPath),
-			);
-		} catch (error) {
-			blockedItems = null;
-			toast.error("Failed to delete items", {
-				description: deps.handleError(error),
-			});
-			return;
-		}
-		if (workspaceStore.get().workspacePath !== workspaceBefore.workspacePath) {
-			blockedItems = null;
-			await desktopApi.finalizeDelete(token);
-			return;
-		}
+		const token = await stageItems(
+			items,
+			workspaceBefore.workspacePath,
+			viewerBefore,
+		);
+		if (token === null) return;
 
 		const deletedPath = (path: string) => covers(path, items);
 		const deletedCurrent =
@@ -228,7 +250,7 @@ export function createDeleteActions(deps: DeleteDeps) {
 					},
 		}));
 		const pinRemovalSaved = deps.syncPins();
-		pending = {
+		const deletion: PendingDelete = {
 			token,
 			workspacePath: workspaceBefore.workspacePath,
 			reopenPath: deletedCurrent ? viewerBefore.currentPath : null,
@@ -238,10 +260,11 @@ export function createDeleteActions(deps: DeleteDeps) {
 			historyAfter: historyStore.get(),
 			pinRemovalSaved,
 			toastId: null,
-			state: "active",
+			claimed: false,
 		};
+		pending = deletion;
 		const count = items.length;
-		const toastId = toast(
+		deletion.toastId = toast(
 			`Deleted ${count === 1 ? "1 item" : `${count} items`}`,
 			{
 				duration: UNDO_MS,
@@ -256,7 +279,6 @@ export function createDeleteActions(deps: DeleteDeps) {
 				onDismiss: () => void expireDeleteUndo(token),
 			},
 		);
-		if (pending?.token === token) pending.toastId = toastId;
 		await desktopApi.setDeleteUndoAvailable(true);
 		await pinRemovalSaved;
 	};

--- a/apps/desktop/src/store/deleteActions.ts
+++ b/apps/desktop/src/store/deleteActions.ts
@@ -1,5 +1,6 @@
-import { formatShortcut, type SidebarDeleteItem } from "@hubble.md/ui";
+import type { SidebarDeleteItem } from "@hubble.md/ui";
 import { toast } from "sonner";
+import { undoToastLabel } from "../components/undoToastLabel";
 import { desktopApi } from "../desktopApi";
 import { pathInFolder } from "../lib/filePath";
 import { clearHistory, pruneHistory } from "./history";
@@ -269,7 +270,7 @@ export function createDeleteActions(deps: DeleteDeps) {
 			{
 				duration: UNDO_MS,
 				action: {
-					label: `Undo ${formatShortcut("CmdOrCtrl+Z")}`,
+					label: undoToastLabel(),
 					onClick: (event) => {
 						event.preventDefault();
 						void undoDelete(token);

--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -72,6 +72,8 @@ export type SidebarMoveItemInput = {
 	targetFolderId: string | null;
 };
 
+export type SidebarDeleteItem = SidebarMoveItem;
+
 export type SidebarFocusedItem =
 	| { kind: "file"; path: string }
 	| { kind: "folder"; folderId: string }
@@ -379,6 +381,7 @@ export function Sidebar({
 	onRenameFile,
 	onRenameFolder,
 	onDeleteFile,
+	onDeleteItems,
 	onTogglePinnedFile,
 	onCreateFile,
 	onCreateHtmlFile,
@@ -413,6 +416,7 @@ export function Sidebar({
 		targetDisplayPath: string,
 	) => void;
 	onDeleteFile?: (path: string) => void;
+	onDeleteItems?: (items: SidebarDeleteItem[]) => void;
 	onTogglePinnedFile?: (path: string) => void;
 	onCreateFile?: (folderId: string | null) => Promise<string | null>;
 	onCreateHtmlFile?: (folderId: string | null) => Promise<string | null>;
@@ -607,8 +611,8 @@ export function Sidebar({
 		const actionable = sidebarDeleteSelection(
 			targetSelection,
 			getDisplayPath,
-			Boolean(onDeleteFile),
-			Boolean(onDeleteFolder),
+			Boolean(onDeleteItems || onDeleteFile),
+			Boolean(onDeleteItems || onDeleteFolder),
 		);
 		if (actionable.count === 0) return;
 		if (
@@ -617,6 +621,19 @@ export function Sidebar({
 			)
 		)
 			return;
+		if (onDeleteItems) {
+			onDeleteItems([
+				...actionable.files.map((file) => ({
+					kind: "file" as const,
+					path: file.path,
+				})),
+				...actionable.folders.map((folderId) => ({
+					kind: "folder" as const,
+					folderId,
+				})),
+			]);
+			return;
+		}
 		for (const file of actionable.files) onDeleteFile?.(file.path);
 		for (const folderId of actionable.folders) onDeleteFolder?.(folderId);
 	};
@@ -979,6 +996,7 @@ export function Sidebar({
 											!onOpenFileInDefaultApp &&
 											!onCopyFilePath &&
 											!onRenameFile &&
+											!onDeleteItems &&
 											!onDeleteFile
 										)
 											return;
@@ -988,6 +1006,7 @@ export function Sidebar({
 											!onCreateFolder &&
 											!onRenameFolder &&
 											!onCreateFile &&
+											!onDeleteItems &&
 											!onDeleteFolder
 										)
 											return;
@@ -1092,6 +1111,7 @@ export function Sidebar({
 												onCreateFile ||
 												onCreateFolder ||
 												onRenameFolder ||
+												onDeleteItems ||
 												onDeleteFolder) && (
 												<FolderActionsMenu
 													id={row.id}
@@ -1125,6 +1145,7 @@ export function Sidebar({
 															: undefined
 													}
 													onDeleteFolder={onDeleteFolder}
+													onDeleteSelection={handleDeleteSelection}
 													selection={actionSelection}
 													onDeleteFiles={onDeleteFile}
 													onTogglePinnedFile={onTogglePinnedFile}
@@ -1150,6 +1171,7 @@ export function Sidebar({
 												onOpenFileInDefaultApp ||
 												onCopyFilePath ||
 												onRenameFile ||
+												onDeleteItems ||
 												onDeleteFile ||
 												onTogglePinnedFile) && (
 												<FileActionsMenu
@@ -1171,6 +1193,7 @@ export function Sidebar({
 													}
 													onTogglePinnedFile={onTogglePinnedFile}
 													onDeleteFile={onDeleteFile}
+													onDeleteSelection={handleDeleteSelection}
 													selection={actionSelection}
 													onDeleteFolders={onDeleteFolder}
 													getDisplayPath={getDisplayPath}
@@ -1844,6 +1867,7 @@ function FolderActionsMenu({
 	onRenameFolder,
 	onDeleteFolder,
 	onDeleteFiles,
+	onDeleteSelection,
 	onTogglePinnedFile,
 	getDisplayPath,
 }: {
@@ -1860,6 +1884,7 @@ function FolderActionsMenu({
 	onRenameFolder?: (id: string, label: string) => void;
 	onDeleteFolder?: (id: string) => void;
 	onDeleteFiles?: (path: string) => void;
+	onDeleteSelection?: (selection: SidebarActionSelection) => void;
 	onTogglePinnedFile?: (path: string) => void;
 	getDisplayPath: (path: string) => string;
 }) {
@@ -1874,6 +1899,7 @@ function FolderActionsMenu({
 					selection={selection}
 					onDeleteFile={onDeleteFiles}
 					onDeleteFolder={onDeleteFolder}
+					onDeleteSelection={onDeleteSelection}
 					getDisplayPath={getDisplayPath}
 				/>
 			</ActionsMenu>
@@ -1923,16 +1949,17 @@ function FolderActionsMenu({
 					Rename
 				</ActionItem>
 			)}
-			{onDeleteFolder && (
+			{(onDeleteSelection || onDeleteFolder) && (
 				<ActionItem
 					destructive
 					icon={<MingcuteDeleteLine />}
 					shortcut={formatCommandShortcut("app.delete")}
-					onClick={() => {
-						if (!window.confirm(`Delete ${label} and all its contents?`))
-							return;
-						onDeleteFolder(id);
-					}}
+					onClick={() =>
+						onDeleteSelection
+							? onDeleteSelection({ files: [], folders: [id], count: 1 })
+							: window.confirm(`Delete ${label} and all its contents?`) &&
+								onDeleteFolder?.(id)
+					}
 				>
 					Delete
 				</ActionItem>
@@ -1955,6 +1982,7 @@ function FileActionsMenu({
 	onTogglePinnedFile,
 	onDeleteFile,
 	onDeleteFolders,
+	onDeleteSelection,
 	getDisplayPath,
 }: {
 	file: SidebarFile;
@@ -1970,6 +1998,7 @@ function FileActionsMenu({
 	onTogglePinnedFile?: (path: string) => void;
 	onDeleteFile?: (path: string) => void;
 	onDeleteFolders?: (id: string) => void;
+	onDeleteSelection?: (selection: SidebarActionSelection) => void;
 	getDisplayPath: (path: string) => string;
 }) {
 	if (selection.count > 1) {
@@ -1983,6 +2012,7 @@ function FileActionsMenu({
 					selection={selection}
 					onDeleteFile={onDeleteFile}
 					onDeleteFolder={onDeleteFolders}
+					onDeleteSelection={onDeleteSelection}
 					getDisplayPath={getDisplayPath}
 				/>
 			</ActionsMenu>
@@ -2032,15 +2062,16 @@ function FileActionsMenu({
 					{file.pinned ? "Unpin" : "Pin"}
 				</ActionItem>
 			)}
-			{onDeleteFile && (
+			{(onDeleteSelection || onDeleteFile) && (
 				<ActionItem
 					destructive
 					icon={<MingcuteDeleteLine />}
 					shortcut={formatCommandShortcut("app.delete")}
-					onClick={() => {
-						if (!window.confirm(`Delete ${label}?`)) return;
-						onDeleteFile(file.path);
-					}}
+					onClick={() =>
+						onDeleteSelection
+							? onDeleteSelection({ files: [file], folders: [], count: 1 })
+							: window.confirm(`Delete ${label}?`) && onDeleteFile?.(file.path)
+					}
 				>
 					Delete
 				</ActionItem>
@@ -2078,18 +2109,20 @@ function BulkDeleteAction({
 	selection,
 	onDeleteFile,
 	onDeleteFolder,
+	onDeleteSelection,
 	getDisplayPath,
 }: {
 	selection: SidebarActionSelection;
 	onDeleteFile?: (path: string) => void;
 	onDeleteFolder?: (id: string) => void;
+	onDeleteSelection?: (selection: SidebarActionSelection) => void;
 	getDisplayPath: (path: string) => string;
 }) {
 	const actionable = sidebarDeleteSelection(
 		selection,
 		getDisplayPath,
-		Boolean(onDeleteFile),
-		Boolean(onDeleteFolder),
+		Boolean(onDeleteSelection || onDeleteFile),
+		Boolean(onDeleteSelection || onDeleteFolder),
 	);
 	if (actionable.count === 0) return null;
 	return (
@@ -2098,6 +2131,10 @@ function BulkDeleteAction({
 			icon={<MingcuteDeleteLine />}
 			shortcut={formatCommandShortcut("app.delete")}
 			onClick={() => {
+				if (onDeleteSelection) {
+					onDeleteSelection(actionable);
+					return;
+				}
 				if (
 					!window.confirm(
 						`Delete ${actionable.count} ${actionable.count === 1 ? "item" : "items"}?`,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -9,6 +9,7 @@ export {
 } from "./components/GlobalSearchPalette";
 export {
 	Sidebar,
+	type SidebarDeleteItem,
 	type SidebarFile,
 	type SidebarFocusedItem,
 	type SidebarFolder,


### PR DESCRIPTION
Closes #211

## Summary
- stage file and folder deletions atomically for an 5-second undo window
- restore via toast action or Cmd/Ctrl+Z
- expire deletion undo when editing resumes, preserving normal text undo
- treat multi-selection deletion as one undoable operation

## Validation
- `pnpm build:desktop`
- desktop Vitest suite: 150 passed
- live Electron QA: toast restore, Cmd+Z restore, fast type then Cmd+Z text undo

## Scope
This is transient undo only. Durable Trash remains tracked by #173.
