### PR TITLE
Check out workflow revision for PR review

### DIFF
--- a/.github/workflows/review-pull-requests.yml
+++ b/.github/workflows/review-pull-requests.yml
@@ -1,7 +1,8 @@
 name: Review Pull Requests
 
-# The agent checks out only the trusted PR base and reads contributor changes as
-# review data. A separate job validates its review before publishing it.
+# The agent checks out only the workflow's trusted repository revision and reads
+# contributor changes as review data. A separate job validates its review before
+# publishing it.
 
 on:
   pull_request_target:
@@ -71,10 +72,9 @@ jobs:
     outputs:
       artifact_name: ${{ steps.artifact.outputs.name }}
     steps:
-      - name: Checkout trusted PR base
+      - name: Checkout trusted workflow revision
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.resolve.outputs.base_sha }}
           fetch-depth: 0
           persist-credentials: false
 


### PR DESCRIPTION
## Description
Removes `ref: ${{ needs.resolve.outputs.base_sha }}` from the review job checkout so it uses the trusted workflow revision instead of a PR-derived sha. Step name and header comment updated to match.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update

## Testing
- [x] Existing tests pass
- [ ] Added new tests for changes
- [ ] Tested manually (describe below)

**Manual Testing Details:**
Workflow-only change; will exercise itself on this PR via `pull_request_target`.

## Checklist
- [ ] I discussed this change in a GitHub issue before submitting this PR
- [x] I have run the linter, formatter, and tests to ensure my code is ready for review

---
[Warp conversation](https://app.warp.dev/conversation/03890f4a-7e41-4d1a-97f7-cc411887d471)

Co-Authored-By: Oz <oz-agent@warp.dev>