### PR TITLE
Label duplicate issues during triage

### DIFF
--- a/.agents/skills/triage/SKILL.md
+++ b/.agents/skills/triage/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: triage
-description: Triage an incoming GitHub, Jira, Linear, or other issue-tracker issue against the current codebase and related open issues, then return a structured decision with exactly one implementation-readiness state. Use whenever the user asks to triage, classify, assess, prioritize, or label an issue for implementation readiness, especially when an issue URL, key, or number is supplied in the prompt.
+description: Triage an incoming GitHub, Jira, Linear, or other issue-tracker issue against the current codebase and related issues, then return a structured decision with exactly one triage state. Use whenever the user asks to triage, classify, assess, prioritize, or label an issue for implementation readiness, especially when an issue URL, key, or number is supplied in the prompt.
 ---
 
 # Triage
 
-Assess the issue passed in the user's prompt and decide exactly one implementation-readiness state:
+Assess the issue passed in the user's prompt and decide exactly one triage state:
 
 - `Ready to implement`
 - `Needs discussion`
+- `Duplicate`
 
 The goal is to route work honestly, not to make every issue appear actionable. Base the decision on evidence from the issue tracker, current checkout, and related open issues.
 
@@ -37,7 +38,7 @@ Fetch:
 - Existing labels, status, assignee, project, and linked issues
 - Attachments or screenshots when they materially affect understanding
 - The tracker's available labels
-- Related open issues, including likely duplicates, dependencies, and nearby product work
+- Related open and closed issues, including likely duplicates, dependencies, and nearby product work
 
 Do not classify solely from the title. Do not expose credentials or secrets while fetching tracker data.
 
@@ -80,25 +81,34 @@ Choose for everything else:
 - Multiple valid designs, broad surface-area changes, or non-trivial dependencies make one-shot implementation risky
 - The expected behavior, problem, scope, or reproduction is ambiguous
 - Critical environment details, evidence, or acceptance criteria are missing
-- The request may not fit the current product direction, duplicates or conflicts with planned work, or a dependency makes it premature
+- The request may not fit the current product direction, conflicts with planned work, or a dependency makes it premature
 
+#### Duplicate
+
+Choose when another issue already tracks the same underlying behavior and scope. Require concrete tracker evidence; similar symptoms or overlapping implementation areas alone are not enough.
+
+- Identify the canonical issue in the comment
+- Prefer the issue with clearer acceptance criteria, more discussion, or active implementation
+- If the canonical issue was closed as fixed but the behavior recurs, verify it is not a regression before choosing `Duplicate`
+- Do not close or otherwise mutate the issue; the caller owns tracker changes
 
 ### 5. Return the result
 
-Pick the tracker label that matches the chosen state, preferring an existing label with the same meaning and the tracker's established naming and casing (for example `ready-to-implement` for `Ready to implement` and `needs-discussion` for `Needs discussion`). List any existing triage-state labels that should be removed.
+Pick the tracker label that matches the chosen state, preferring an existing label with the same meaning and the tracker's established naming and casing (for example `ready-to-implement`, `needs-discussion`, or `duplicate`). List any existing triage-state labels that should be removed.
 
 Return a single raw JSON object as your final response — no prose and no markdown code fences:
 
 ```json
 {
-  "state": "Ready to implement | Needs discussion",
+  "state": "Ready to implement | Needs discussion | Duplicate",
   "label": "exact tracker label matching the chosen state",
+  "duplicate_of": "canonical issue URL or tracker key when state is Duplicate; otherwise null",
   "remove_labels": ["existing triage-state labels that should be removed"],
   "comment": "markdown body for the issue"
 }
 ```
 
-Write `comment` as reporter-facing markdown: a short lead sentence with the decision, then the evidence-based rationale, using a brief bullet list where it aids readability. For `Needs discussion`, end the comment with the concrete questions and open decisions from step 4. Because `comment` is a JSON string, encode every line break as `\n` (a literal newline would make the JSON invalid).
+Write `comment` as reporter-facing markdown: a short lead sentence with the decision, then the evidence-based rationale, using a brief bullet list where it aids readability. For `Needs discussion`, end with the concrete questions and open decisions from step 4. For `Duplicate`, lead with `Duplicate of <canonical issue>` and briefly state why it covers this report. Because `comment` is a JSON string, encode every line break as `\n` (a literal newline would make the JSON invalid).
 
 ## Guardrails
 

--- a/.agents/skills/triage/SKILL.md
+++ b/.agents/skills/triage/SKILL.md
@@ -11,7 +11,7 @@ Assess the issue passed in the user's prompt and decide exactly one triage state
 - `Duplicate`
 - `Needs discussion`
 
-The goal is to route work honestly, not to make every issue appear actionable. Base the decision on evidence from the issue tracker, current checkout, and related open issues.
+The goal is to route work honestly, not to make every issue appear actionable. Base the decision on evidence from the issue tracker, current checkout, and related issues.
 
 This is a read-only analysis: inspect the issue and codebase but do not mutate the tracker. Return the structured decision described in step 5; the caller applies the label and comment.
 
@@ -53,7 +53,7 @@ Assess:
 - Whether the issue has a bounded implementation path
 - Dependencies, migrations, platform differences, and testing requirements
 - Existing abstractions that make the change cohesive or indicate it does not fit
-- Whether related open issues or active work change the recommendation
+- Whether related issues or active work change the recommendation
 
 Prefer targeted searches and reads. This is triage, not implementation: do not edit product code.
 
@@ -107,7 +107,7 @@ Return a single raw JSON object as your final response — no prose and no markd
 }
 ```
 
-Write `comment` as reporter-facing markdown: a short lead sentence with the decision, then the evidence-based rationale, using a brief bullet list where it aids readability. For `Needs discussion`, end with the concrete questions and open decisions from step 4. For `Duplicate`, lead with `Duplicate of <canonical issue>` and briefly state why it covers this report. Because `comment` is a JSON string, encode every line break as `\n` (a literal newline would make the JSON invalid).
+Write `comment` as reporter-facing markdown: a short lead sentence with the decision, then the evidence-based rationale, using a brief bullet list where it aids readability. For `Needs discussion`, end with the concrete questions and open decisions from step 4. For `Duplicate`, lead with `Duplicate of <duplicate_of>`, using the exact `duplicate_of` value from the result, and briefly state why it covers this report. Because `comment` is a JSON string, encode every line break as `\n` (a literal newline would make the JSON invalid).
 
 ## Guardrails
 

--- a/.agents/skills/triage/SKILL.md
+++ b/.agents/skills/triage/SKILL.md
@@ -8,8 +8,8 @@ description: Triage an incoming GitHub, Jira, Linear, or other issue-tracker iss
 Assess the issue passed in the user's prompt and decide exactly one triage state:
 
 - `Ready to implement`
-- `Needs discussion`
 - `Duplicate`
+- `Needs discussion`
 
 The goal is to route work honestly, not to make every issue appear actionable. Base the decision on evidence from the issue tracker, current checkout, and related open issues.
 
@@ -73,16 +73,6 @@ Choose when:
 
 Small bugs with clear reproduction steps and straightforward improvements usually belong here.
 
-#### Needs discussion
-
-Choose for everything else:
-
-- Material product or technical decisions remain open
-- Multiple valid designs, broad surface-area changes, or non-trivial dependencies make one-shot implementation risky
-- The expected behavior, problem, scope, or reproduction is ambiguous
-- Critical environment details, evidence, or acceptance criteria are missing
-- The request may not fit the current product direction, conflicts with planned work, or a dependency makes it premature
-
 #### Duplicate
 
 Choose when another issue already tracks the same underlying behavior and scope. Require concrete tracker evidence; similar symptoms or overlapping implementation areas alone are not enough.
@@ -92,18 +82,27 @@ Choose when another issue already tracks the same underlying behavior and scope.
 - If the canonical issue was closed as fixed but the behavior recurs, verify it is not a regression before choosing `Duplicate`
 - Do not close or otherwise mutate the issue; the caller owns tracker changes
 
+#### Needs discussion
+
+Choose when neither implementation nor duplicate status is clear:
+
+- Material product or technical decisions remain open
+- Multiple valid designs, broad surface-area changes, or non-trivial dependencies make one-shot implementation risky
+- The expected behavior, problem, scope, or reproduction is ambiguous
+- Critical environment details, evidence, or acceptance criteria are missing
+- The request may not fit the current product direction, conflicts with planned work, or a dependency makes it premature
+
 ### 5. Return the result
 
-Pick the tracker label that matches the chosen state, preferring an existing label with the same meaning and the tracker's established naming and casing (for example `ready-to-implement`, `needs-discussion`, or `duplicate`). List any existing triage-state labels that should be removed.
+Pick the tracker label that matches the chosen state, preferring an existing label with the same meaning and the tracker's established naming and casing (for example `ready-to-implement`, `needs-discussion`, or `duplicate`).
 
 Return a single raw JSON object as your final response — no prose and no markdown code fences:
 
 ```json
 {
-  "state": "Ready to implement | Needs discussion | Duplicate",
+  "state": "Ready to implement | Duplicate | Needs discussion",
   "label": "exact tracker label matching the chosen state",
   "duplicate_of": "canonical issue URL or tracker key when state is Duplicate; otherwise null",
-  "remove_labels": ["existing triage-state labels that should be removed"],
   "comment": "markdown body for the issue"
 }
 ```

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -179,8 +179,8 @@ jobs:
                 echo "::error::Duplicate result is missing 'duplicate_of'; keeping seeded needs-triage." >&2
                 exit 1
               fi
-              if ! grep -Fq -- "$DUPLICATE_OF" comment.md; then
-                echo "::error::Duplicate comment does not link 'duplicate_of'; keeping seeded needs-triage." >&2
+              if [ "$(head -n 1 comment.md)" != "Duplicate of $DUPLICATE_OF" ]; then
+                echo "::error::Duplicate comment does not start with 'Duplicate of <duplicate_of>'; keeping seeded needs-triage." >&2
                 exit 1
               fi
               ;;

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -159,10 +159,9 @@ jobs:
           STATE="$(jq -r '.state // ""' triage_result.json)"
           LABEL="$(jq -r '.label // ""' triage_result.json)"
           DUPLICATE_OF="$(jq -r '.duplicate_of // ""' triage_result.json)"
+          jq -r '.comment // ""' triage_result.json > comment.md
 
-          # Require the structured fields the apply step needs. The set of valid
-          # states/labels is owned by the triage skill, so it is intentionally
-          # not duplicated here.
+          # Require the fields and state/label pairs the apply step supports.
           if [ -z "$STATE" ]; then
             echo "::error::Triage result is missing a 'state'; keeping seeded needs-triage." >&2
             exit 1
@@ -178,6 +177,10 @@ jobs:
             "Duplicate:duplicate")
               if [ -z "$DUPLICATE_OF" ]; then
                 echo "::error::Duplicate result is missing 'duplicate_of'; keeping seeded needs-triage." >&2
+                exit 1
+              fi
+              if ! grep -Fq -- "$DUPLICATE_OF" comment.md; then
+                echo "::error::Duplicate comment does not link 'duplicate_of'; keeping seeded needs-triage." >&2
                 exit 1
               fi
               ;;
@@ -205,7 +208,6 @@ jobs:
 
           # Post the triage comment to the triggering issue only, signed so it
           # is clear the decision came from a Warp Factory agent.
-          jq -r '.comment // ""' triage_result.json > comment.md
           if [ -s comment.md ]; then
             printf '\n---\n\n_Triaged by a [Warp Factory agent](https://www.warp.dev/oz)._\n' >> comment.md
             gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body-file comment.md

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -1,14 +1,14 @@
 name: Triage New Issues
 
-# Guarantees every newly opened issue carries a readiness label, then triages
+# Guarantees every newly opened issue carries a triage-state label, then triages
 # it with a Warp Factory agent when possible.
 #
 # Flow:
-# 1. `seed` always applies `needs-triage` if the issue has no readiness label.
+# 1. `seed` always applies `needs-triage` if the issue has no triage-state label.
 #    This covers blank issues, API/CLI creates, and template misses — so agent
 #    failure still leaves the issue in a known inbox state.
 # 2. `triage` runs the read-only triage skill and emits structured JSON.
-# 3. `apply` replaces `needs-triage` with the agent's readiness label and posts
+# 3. `apply` replaces `needs-triage` with the agent's triage-state label and posts
 #    the triage comment. If triage/apply fail, the seeded `needs-triage` remains.
 # 4. `implement` starts Implement Ready Issues when the applied label is ready-to-implement.
 #
@@ -26,7 +26,7 @@ concurrency:
 env:
   # Exactly one of these should be present on every open issue after triage
   # (or after seed, if triage has not finished yet).
-  READINESS_LABELS: needs-triage,ready-to-implement,needs-discussion,wontfix
+  TRIAGE_LABELS: needs-triage,ready-to-implement,needs-discussion,duplicate,wontfix
 
 jobs:
   seed:
@@ -35,7 +35,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - name: Ensure a readiness label exists
+      - name: Ensure a triage-state label exists
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -44,26 +44,26 @@ jobs:
         run: |
           set -euo pipefail
 
-          IFS=',' read -r -a readiness <<< "$READINESS_LABELS"
+          IFS=',' read -r -a triage_labels <<< "$TRIAGE_LABELS"
           IFS=',' read -r -a existing <<< "${EXISTING_LABELS:-}"
 
-          has_readiness=false
+          has_triage_state=false
           for label in "${existing[@]}"; do
             [ -z "$label" ] && continue
-            for ready in "${readiness[@]}"; do
-              if [ "$label" = "$ready" ]; then
-                has_readiness=true
+            for triage_label in "${triage_labels[@]}"; do
+              if [ "$label" = "$triage_label" ]; then
+                has_triage_state=true
                 break 2
               fi
             done
           done
 
-          if [ "$has_readiness" = true ]; then
-            echo "Issue already has a readiness label; leaving labels unchanged."
+          if [ "$has_triage_state" = true ]; then
+            echo "Issue already has a triage-state label; leaving labels unchanged."
             exit 0
           fi
 
-          echo "No readiness label present; applying needs-triage."
+          echo "No triage-state label present; applying needs-triage."
           gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "needs-triage"
 
   triage:
@@ -158,6 +158,7 @@ jobs:
 
           STATE="$(jq -r '.state // ""' triage_result.json)"
           LABEL="$(jq -r '.label // ""' triage_result.json)"
+          DUPLICATE_OF="$(jq -r '.duplicate_of // ""' triage_result.json)"
 
           # Require the structured fields the apply step needs. The set of valid
           # states/labels is owned by the triage skill, so it is intentionally
@@ -172,24 +173,30 @@ jobs:
             exit 1
           fi
 
+          case "$STATE:$LABEL" in
+            "Ready to implement:ready-to-implement"|"Needs discussion:needs-discussion") ;;
+            "Duplicate:duplicate")
+              if [ -z "$DUPLICATE_OF" ]; then
+                echo "::error::Duplicate result is missing 'duplicate_of'; keeping seeded needs-triage." >&2
+                exit 1
+              fi
+              ;;
+            *)
+              echo "::error::Invalid triage state/label pair: $STATE / $LABEL; keeping seeded needs-triage." >&2
+              exit 1
+              ;;
+          esac
+
           echo "Triage state: $STATE"
           echo "Applying label: $LABEL"
           echo "label=$LABEL" >> "$GITHUB_OUTPUT"
 
-          # Always clear other readiness labels so exactly one remains after apply.
-          # Agent-listed remove_labels are applied first; then every readiness
-          # label other than the chosen one is removed as a safety net.
-          while IFS= read -r remove_label; do
-            [ -z "$remove_label" ] && continue
-            echo "Removing label: $remove_label"
-            gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --remove-label "$remove_label" || true
-          done < <(jq -r '(.remove_labels // [])[]' triage_result.json)
-
-          IFS=',' read -r -a readiness <<< "$READINESS_LABELS"
-          for ready in "${readiness[@]}"; do
-            if [ "$ready" != "$LABEL" ]; then
-              echo "Ensuring readiness label removed: $ready"
-              gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --remove-label "$ready" || true
+          # Always clear other triage-state labels so exactly one remains after apply.
+          IFS=',' read -r -a triage_labels <<< "$TRIAGE_LABELS"
+          for triage_label in "${triage_labels[@]}"; do
+            if [ "$triage_label" != "$LABEL" ]; then
+              echo "Ensuring triage-state label removed: $triage_label"
+              gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --remove-label "$triage_label" || true
             fi
           done
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ GitHub Issues on `bholmesdev/hubble.md` via the `gh` CLI. See `docs/agents/issue
 
 ### Triage labels
 
-Defaults: `needs-triage`, `ready-to-implement`, `needs-discussion`, `wontfix`. See `docs/agents/triage-labels.md`.
+Defaults: `needs-triage`, `ready-to-implement`, `needs-discussion`, `duplicate`, `wontfix`. See `docs/agents/triage-labels.md`.
 
 ### Domain docs
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ pnpm typecheck        # typecheck all packages
 
 Hubble's repository automation runs on [Warp Factory agents](https://www.warp.dev/oz). When you open an issue or a pull request, an agent handles it:
 
-- **Triage.** New issues get a readiness label and a comment explaining the decision.
+- **Triage.** New issues get a triage-state label and a comment explaining the decision.
 - **Implementation.** Issues labeled `ready-to-implement` get a draft pull request.
 - **Review.** Pull requests get a code review before a human looks at them.
 

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -6,15 +6,15 @@ Every open issue should carry **exactly one** triage-state label. Bug/feature te
 | -------------------- | ----------------------------------------------------------------------------------- |
 | `needs-triage`       | Maintainer or triage agent needs to evaluate this issue                             |
 | `ready-to-implement` | Behavior and scope are clear; anyone (contributor or agent) can pick this up        |
-| `needs-discussion`   | Open product or technical questions; discuss on the issue before implementing       |
 | `duplicate`          | Another issue already tracks the same underlying behavior and scope                  |
+| `needs-discussion`   | Open product or technical questions; discuss on the issue before implementing       |
 | `wontfix`            | Will not be actioned (human-applied)                                                |
 
 Use `ready-to-implement` when the issue is clearly outlined and implementation can start without further product decisions.
 
-Use `needs-discussion` for everything else: ambiguity, open design decisions, or uncertain fit. The triage comment should leave concrete clarifying questions so the discussion can start immediately.
-
 Use `duplicate` only when a canonical issue clearly covers the same behavior and scope. Link that issue in the triage comment. Do not use `needs-discussion` merely because parallel implementation would conflict.
+
+Use `needs-discussion` when neither implementation nor duplicate status is clear due to ambiguity, open design decisions, or uncertain fit. The triage comment should leave concrete clarifying questions so the discussion can start immediately.
 
 Other labels (`bug`, `enhancement`, priority, etc.) are orthogonal and may coexist with a triage-state label. Do not leave an open issue with only non-triage labels.
 

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,18 +1,21 @@
 # Triage Labels
 
-Every open issue should carry **exactly one** readiness label. Bug/feature templates pre-apply `needs-triage`; the `Triage New Issues` workflow also seeds `needs-triage` on open when no readiness label is present (blank issues, CLI/API creates, template misses). The triage agent then replaces that with a decision label when it can.
+Every open issue should carry **exactly one** triage-state label. Bug/feature templates pre-apply `needs-triage`; the `Triage New Issues` workflow also seeds `needs-triage` on open when no triage-state label is present (blank issues, CLI/API creates, template misses). The triage agent then replaces that with a decision label when it can.
 
 | Label                | Meaning                                                                             |
 | -------------------- | ----------------------------------------------------------------------------------- |
 | `needs-triage`       | Maintainer or triage agent needs to evaluate this issue                             |
 | `ready-to-implement` | Behavior and scope are clear; anyone (contributor or agent) can pick this up        |
 | `needs-discussion`   | Open product or technical questions; discuss on the issue before implementing       |
+| `duplicate`          | Another issue already tracks the same underlying behavior and scope                  |
 | `wontfix`            | Will not be actioned (human-applied)                                                |
 
 Use `ready-to-implement` when the issue is clearly outlined and implementation can start without further product decisions.
 
 Use `needs-discussion` for everything else: ambiguity, open design decisions, or uncertain fit. The triage comment should leave concrete clarifying questions so the discussion can start immediately.
 
-Other labels (`bug`, `enhancement`, priority, etc.) are orthogonal and may coexist with a readiness label. Do not leave an open issue with only non-readiness labels.
+Use `duplicate` only when a canonical issue clearly covers the same behavior and scope. Link that issue in the triage comment. Do not use `needs-discussion` merely because parallel implementation would conflict.
+
+Other labels (`bug`, `enhancement`, priority, etc.) are orthogonal and may coexist with a triage-state label. Do not leave an open issue with only non-triage labels.
 
 Older labels (`ready-for-spec`, `ready-for-agent`, `needs-info`, `wait-to-implement`) are retired from the triage flow; `ready-for-spec` was renamed to `needs-discussion` and `ready-for-agent` to `ready-to-implement`.


### PR DESCRIPTION
## Description
Teach the triage agent to return a first-class Duplicate state, link the canonical issue, and apply the existing duplicate label. Validate state/label pairs before mutating labels.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update

## Testing
- [x] Existing tests pass
- [ ] Added new tests for changes
- [x] Tested manually (describe below)

**Manual Testing Details:**
- pnpm check
- pnpm build:desktop
- Parsed workflow YAML and embedded shell scripts

## Checklist
- [x] I discussed this change in a GitHub issue before submitting this PR
- [x] I have run the linter, formatter, and tests to ensure my code is ready for review