### PR TITLE
Fix sidebar folder double-highlight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 Check work: `pnpm build:desktop` (builds packages, runs biome check, tsc, vite build, cargo check). For quick iteration use `pnpm check` and desktop tsc.
 
+After React changes, run `pnpm check:react-compiler`; CI rejects components the compiler skips.
+
 When asked why you made a decision, answer why. Don't take it as a challenge to your approach, or pressure to change your solution.
 
 ## Agent skills

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 
 ### Fixed
 
-- Folders in the sidebar no longer take the active-note highlight when clicked; they use the muted hover/focus style instead. Thanks [@JoeJoeflyn](https://github.com/JoeJoeflyn)! [#235](https://github.com/bholmesdev/hubble.md/pull/235)
+- Sidebar rows now use one focus-aware highlight, so folders and open notes no longer appear selected at the same time. Thanks [@JoeJoeflyn](https://github.com/JoeJoeflyn)! [#235](https://github.com/bholmesdev/hubble.md/pull/235)
 - Scrollbars now match the selected light or dark theme. Thanks [@ggbao666](https://github.com/ggbao666) for the suggestion! [#239](https://github.com/bholmesdev/hubble.md/pull/239)
 
 ## [0.1.25] - 2026-08-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 
 ### Fixed
 
-- Folders in the sidebar no longer take the active-note highlight when clicked; they use the muted hover/focus style instead. [#207](https://github.com/bholmesdev/hubble.md/issues/207)
+- Folders in the sidebar no longer take the active-note highlight when clicked; they use the muted hover/focus style instead. Thanks [@JoeJoeflyn](https://github.com/JoeJoeflyn)! [#235](https://github.com/bholmesdev/hubble.md/pull/235)
 
 ## [0.1.25] - 2026-08-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 
 ### Fixed
 
+- Folders in the sidebar no longer take the active-note highlight when clicked; they use the muted hover/focus style instead. [#207](https://github.com/bholmesdev/hubble.md/issues/207)
+
 ## [0.1.25] - 2026-08-06
 
 ### Added

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -71,8 +71,7 @@
 	--sidebar-foreground: var(--foreground);
 	--sidebar-primary: var(--primary);
 	--sidebar-primary-foreground: var(--primary-foreground);
-	/* gray until sidebar focused; :focus-within (theme.css) swaps to --selected */
-	--sidebar-accent: oklch(0.32 0.006 60);
+	--sidebar-accent: var(--accent);
 	--sidebar-accent-foreground: var(--foreground);
 	--sidebar-border: var(--border);
 	--sidebar-ring: var(--ring);

--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -52,7 +52,10 @@ import { shouldShowFooterDivider } from "../lib/scrollOverflow";
 import { formatCommandShortcut } from "../lib/shortcut";
 import { cn } from "../lib/utils";
 import { Button } from "../primitives/button";
-import { useSidebarKeyboardNav } from "./useSidebarKeyboardNav";
+import {
+	EDITOR_INPUT_SELECTOR,
+	useSidebarKeyboardNav,
+} from "./useSidebarKeyboardNav";
 import {
 	type SidebarFile,
 	type SidebarFolder,
@@ -133,11 +136,6 @@ export function sidebarRowKey(row: SidebarRow): string | null {
 		: `folder:${row.id}`;
 }
 
-/**
- * Snaps the click selection to the active file. A file can become active
- * without a row click (history navigation, note links), and the selection
- * highlight would otherwise stay on the last clicked row.
- */
 export function snapSidebarSelection(
 	selection: SidebarSelectionState,
 	activePath: string | null,
@@ -544,16 +542,7 @@ export function Sidebar({
 		);
 	};
 	const replaceSelection = (row: SidebarRow) => {
-		const targetKey = sidebarRowKey(row);
-		setSelection((current) =>
-			applySidebarSelection({
-				anchorKey: current.anchorKey,
-				mode: "replace",
-				rows,
-				selectedKeys: current.selectedKeys,
-				targetKey,
-			}),
-		);
+		updateSelection(row, "replace");
 	};
 	const handleRowClick = (
 		row: SidebarSelectableRow,
@@ -598,6 +587,8 @@ export function Sidebar({
 	const activeIndex = rows.findIndex(
 		(row) => row.kind === "file" && row.file.path === highlightPath,
 	);
+	const activeIndexRef = useRef(activeIndex);
+	activeIndexRef.current = activeIndex;
 	const { focusedIndex, setFocusedIndex, onKeyDown } = useSidebarKeyboardNav({
 		items: rows,
 		onSelect: activateRow,
@@ -606,6 +597,7 @@ export function Sidebar({
 		onCollapse: collapseRow,
 		navRef,
 		activeIndex,
+		onNavigate: replaceSelection,
 	});
 	const handleDeleteSelection = (targetSelection: SidebarActionSelection) => {
 		const actionable = sidebarDeleteSelection(
@@ -693,8 +685,20 @@ export function Sidebar({
 	}, [rows]);
 
 	useEffect(() => {
-		setSelection((current) => snapSidebarSelection(current, highlightPath));
-	}, [highlightPath]);
+		const selectOpenFile = () => {
+			const index = activeIndexRef.current;
+			setFocusedIndex(index >= 0 ? index : null);
+			setSelection((current) => snapSidebarSelection(current, highlightPath));
+		};
+		const isEditorTarget = (target: EventTarget | null) =>
+			target instanceof Element && target.closest(EDITOR_INPUT_SELECTOR);
+		const onFocusIn = (event: FocusEvent) => {
+			if (isEditorTarget(event.target)) selectOpenFile();
+		};
+		if (isEditorTarget(document.activeElement)) selectOpenFile();
+		document.addEventListener("focusin", onFocusIn);
+		return () => document.removeEventListener("focusin", onFocusIn);
+	}, [highlightPath, setFocusedIndex]);
 
 	const handleDragStart = (event: DragStartEvent) => {
 		const data = event.active.data.current as DragItemData | undefined;
@@ -805,6 +809,7 @@ export function Sidebar({
 				onDeleteFolder(deleteOnCancel.path);
 		}
 		resetRename();
+		requestAnimationFrame(() => navRef.current?.focus());
 	};
 
 	const getRenameError = (item: RenameItem, draft: string) => {
@@ -865,13 +870,15 @@ export function Sidebar({
 				ref={navRef}
 				active={isRootDropTarget(dropTarget)}
 				enabled={Boolean(onMoveItem)}
+				onBlur={(event) => {
+					if (!event.currentTarget.contains(event.relatedTarget)) {
+						setFocusedIndex(null);
+					}
+				}}
 				onKeyDown={handleTreeKeyDown}
 			>
 				{rows.length === 0 && emptyState}
 				{rows.map((row, index) => {
-					const isActive =
-						row.kind === "file" && row.file.path === highlightPath;
-					const isFocused = focusedIndex === index;
 					const rowKey = sidebarRowKey(row);
 					const isSelected = rowKey ? selectedKeys.has(rowKey) : false;
 					const actionSelection =
@@ -948,22 +955,15 @@ export function Sidebar({
 									aria-expanded={
 										row.kind === "folder" ? row.expanded : undefined
 									}
-									aria-selected={isSelected || isActive}
+									aria-selected={isSelected}
 									data-selected={isSelected ? "true" : undefined}
 									className={cn(
 										"group/sidebar-row relative flex w-full items-center text-sidebar-foreground",
 										"transition-[background-color,opacity,filter] duration-150 ease-out motion-reduce:transition-none",
-										!isActive &&
-											isSelected &&
-											row.kind === "file" &&
-											"bg-selected text-selected-foreground",
-										!isActive &&
-											isSelected &&
-											row.kind === "folder" &&
-											"bg-accent",
-										!isActive && !isSelected && isFocused && "bg-accent",
-										isActive &&
-											"bg-sidebar-accent text-sidebar-accent-foreground font-medium",
+										isSelected &&
+											"bg-sidebar-accent text-sidebar-accent-foreground",
+										// Hover must not move the keyboard cursor.
+										!isSelected && "hover:bg-accent",
 										dropGroup
 											? [
 													"bg-sidebar-accent/40",
@@ -992,8 +992,6 @@ export function Sidebar({
 											"opacity-60 grayscale",
 										isDragging && "opacity-50",
 									)}
-									onPointerEnter={() => setFocusedIndex(index)}
-									onPointerLeave={() => setFocusedIndex(null)}
 									onContextMenu={(event) => {
 										if (
 											row.kind === "file" &&
@@ -1016,6 +1014,7 @@ export function Sidebar({
 										)
 											return;
 										event.preventDefault();
+										setFocusedIndex(index);
 										if (!isSelected) replaceSelection(row);
 										setOpenActionsPath(
 											row.kind === "file" ? row.file.path : row.id,
@@ -1067,7 +1066,10 @@ export function Sidebar({
 												"truncate border-none bg-transparent",
 											)}
 											style={rowStyle}
-											onClick={(event) => handleRowClick(row, event)}
+											onClick={(event) => {
+												setFocusedIndex(index);
+												handleRowClick(row, event);
+											}}
 											onDoubleClick={(event) => {
 												if (row.kind !== "file" || !onRenameFile) return;
 												event.preventDefault();
@@ -1102,11 +1104,9 @@ export function Sidebar({
 										<span
 											className={cn(
 												"pointer-events-none absolute inset-y-0 end-0 w-16 rounded-e-[var(--radius-row)] opacity-0 transition-opacity group-hover/sidebar-row:opacity-100",
-												isActive
+												isSelected
 													? "bg-linear-to-r from-transparent from-0% via-sidebar-accent via-25% to-sidebar-accent"
-													: isSelected
-														? "bg-linear-to-r from-transparent from-0% via-selected via-25% to-selected"
-														: "bg-linear-to-r from-transparent from-0% via-accent via-25% to-accent",
+													: "bg-linear-to-r from-transparent from-0% via-accent via-25% to-accent",
 											)}
 										/>
 									)}
@@ -1357,9 +1357,13 @@ const DroppableSidebarNav = forwardRef<
 		active: boolean;
 		children: ReactNode;
 		enabled: boolean;
+		onBlur: (event: React.FocusEvent<HTMLDivElement>) => void;
 		onKeyDown: (event: ReactKeyboardEvent<HTMLDivElement>) => void;
 	}
->(function DroppableSidebarNav({ active, children, enabled, onKeyDown }, ref) {
+>(function DroppableSidebarNav(
+	{ active, children, enabled, onBlur, onKeyDown },
+	ref,
+) {
 	const { setNodeRef } = useDroppable({
 		id: "sidebar-drop:root",
 		data: { folderId: null } satisfies DropTargetData,
@@ -1380,6 +1384,7 @@ const DroppableSidebarNav = forwardRef<
 				active && "inset-ring-sidebar-accent/70",
 			)}
 			tabIndex={0}
+			onBlur={onBlur}
 			onKeyDown={onKeyDown}
 			data-sidebar-nav
 		>

--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -958,9 +958,10 @@ export function Sidebar({
 											row.kind === "file" &&
 											"bg-selected text-selected-foreground",
 										!isActive &&
-											(!isSelected || row.kind === "folder") &&
-											isFocused &&
+											isSelected &&
+											row.kind === "folder" &&
 											"bg-accent",
+										!isActive && !isSelected && isFocused && "bg-accent",
 										isActive &&
 											"bg-sidebar-accent text-sidebar-accent-foreground font-medium",
 										dropGroup

--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -688,7 +688,7 @@ export function Sidebar({
 	useEffect(() => {
 		const selectOpenFile = () => {
 			const index = activeIndexRef.current;
-			setFocusedIndex(index >= 0 ? index : null);
+			setFocusedIndex(selectedKeys.size > 1 ? null : index >= 0 ? index : null);
 			setSelection((current) => snapSidebarSelection(current, highlightPath));
 		};
 		const isEditorTarget = (target: EventTarget | null) =>
@@ -699,7 +699,7 @@ export function Sidebar({
 		if (isEditorTarget(document.activeElement)) selectOpenFile();
 		document.addEventListener("focusin", onFocusIn);
 		return () => document.removeEventListener("focusin", onFocusIn);
-	}, [highlightPath, setFocusedIndex]);
+	}, [highlightPath, selectedKeys, setFocusedIndex]);
 
 	const handleDragStart = (event: DragStartEvent) => {
 		const data = event.active.data.current as DragItemData | undefined;
@@ -880,6 +880,8 @@ export function Sidebar({
 			>
 				{rows.length === 0 && emptyState}
 				{rows.map((row, index) => {
+					const isFocused = focusedIndex === index;
+					const isOpen = row.kind === "file" && row.file.path === highlightPath;
 					const rowKey = sidebarRowKey(row);
 					const isSelected = rowKey ? selectedKeys.has(rowKey) : false;
 					const actionSelection =
@@ -956,6 +958,7 @@ export function Sidebar({
 									aria-expanded={
 										row.kind === "folder" ? row.expanded : undefined
 									}
+									aria-current={isOpen ? "page" : undefined}
 									aria-selected={isSelected}
 									data-selected={isSelected ? "true" : undefined}
 									className={cn(
@@ -963,8 +966,10 @@ export function Sidebar({
 										"transition-[background-color,opacity,filter] duration-150 ease-out motion-reduce:transition-none",
 										isSelected &&
 											"bg-sidebar-accent text-sidebar-accent-foreground",
+										isOpen && "font-medium",
 										// Hover must not move the keyboard cursor.
 										!isSelected && "hover:bg-accent",
+										!isSelected && isFocused && "bg-accent",
 										dropGroup
 											? [
 													"bg-sidebar-accent/40",

--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -458,6 +458,8 @@ export function Sidebar({
 		anchorKey: null,
 	});
 	const selectedKeys = selection.selectedKeys;
+	const selectionCountRef = useRef(selectedKeys.size);
+	selectionCountRef.current = selectedKeys.size;
 	const sensors = useSensors(
 		useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
 	);
@@ -598,6 +600,7 @@ export function Sidebar({
 		onCollapse: collapseRow,
 		navRef,
 		activeIndex,
+		// Arrow keys leave multi-select mode.
 		onNavigate: replaceSelection,
 	});
 	const handleDeleteSelection = (targetSelection: SidebarActionSelection) => {
@@ -688,7 +691,9 @@ export function Sidebar({
 	useEffect(() => {
 		const selectOpenFile = () => {
 			const index = activeIndexRef.current;
-			setFocusedIndex(selectedKeys.size > 1 ? null : index >= 0 ? index : null);
+			setFocusedIndex(
+				selectionCountRef.current > 1 ? null : index >= 0 ? index : null,
+			);
 			setSelection((current) => snapSidebarSelection(current, highlightPath));
 		};
 		const isEditorTarget = (target: EventTarget | null) =>
@@ -699,7 +704,7 @@ export function Sidebar({
 		if (isEditorTarget(document.activeElement)) selectOpenFile();
 		document.addEventListener("focusin", onFocusIn);
 		return () => document.removeEventListener("focusin", onFocusIn);
-	}, [highlightPath, selectedKeys, setFocusedIndex]);
+	}, [highlightPath, setFocusedIndex]);
 
 	const handleDragStart = (event: DragStartEvent) => {
 		const data = event.active.data.current as DragItemData | undefined;

--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -140,6 +140,7 @@ export function snapSidebarSelection(
 	selection: SidebarSelectionState,
 	activePath: string | null,
 ): SidebarSelectionState {
+	if (selection.selectedKeys.size > 1) return selection;
 	const key = activePath ? sidebarFileKey(activePath) : null;
 	const unchanged = key
 		? selection.selectedKeys.size === 1 && selection.selectedKeys.has(key)

--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -955,8 +955,12 @@ export function Sidebar({
 										"transition-[background-color,opacity,filter] duration-150 ease-out motion-reduce:transition-none",
 										!isActive &&
 											isSelected &&
+											row.kind === "file" &&
 											"bg-selected text-selected-foreground",
-										!isActive && !isSelected && isFocused && "bg-accent",
+										!isActive &&
+											(!isSelected || row.kind === "folder") &&
+											isFocused &&
+											"bg-accent",
 										isActive &&
 											"bg-sidebar-accent text-sidebar-accent-foreground font-medium",
 										dropGroup

--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -23,6 +23,7 @@ import {
 	type KeyboardEvent as ReactKeyboardEvent,
 	type ReactNode,
 	useEffect,
+	useLayoutEffect,
 	useRef,
 	useState,
 } from "react";
@@ -459,7 +460,9 @@ export function Sidebar({
 	});
 	const selectedKeys = selection.selectedKeys;
 	const selectionCountRef = useRef(selectedKeys.size);
-	selectionCountRef.current = selectedKeys.size;
+	useLayoutEffect(() => {
+		selectionCountRef.current = selectedKeys.size;
+	}, [selectedKeys.size]);
 	const sensors = useSensors(
 		useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
 	);
@@ -591,7 +594,9 @@ export function Sidebar({
 		(row) => row.kind === "file" && row.file.path === highlightPath,
 	);
 	const activeIndexRef = useRef(activeIndex);
-	activeIndexRef.current = activeIndex;
+	useLayoutEffect(() => {
+		activeIndexRef.current = activeIndex;
+	}, [activeIndex]);
 	const { focusedIndex, setFocusedIndex, onKeyDown } = useSidebarKeyboardNav({
 		items: rows,
 		onSelect: activateRow,

--- a/packages/ui/src/components/sidebarSelection.test.ts
+++ b/packages/ui/src/components/sidebarSelection.test.ts
@@ -134,6 +134,13 @@ describe("sidebar selection helpers", () => {
 		expect(snapSidebarSelection(selection, "/workspace/a.md")).toBe(selection);
 	});
 
+	it("keeps multi-selection when the editor regains focus", () => {
+		let selection = select(emptySelection, 1, "toggle");
+		selection = select(selection, 5, "toggle");
+
+		expect(snapSidebarSelection(selection, "/workspace/a.md")).toBe(selection);
+	});
+
 	it("clears the selection when no file is active", () => {
 		const selection = select(emptySelection, 1, "replace");
 		const snapped = snapSidebarSelection(selection, null);

--- a/packages/ui/src/components/useSidebarKeyboardNav.test.ts
+++ b/packages/ui/src/components/useSidebarKeyboardNav.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment happy-dom
+
+import {
+	act,
+	createElement,
+	type KeyboardEvent as ReactKeyboardEvent,
+	type ReactNode,
+	useRef,
+} from "react";
+// @ts-expect-error This package does not ship @types/react-dom; the test only
+// needs createRoot's render/unmount surface.
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useSidebarKeyboardNav } from "./useSidebarKeyboardNav";
+
+type Root = {
+	render(children: ReactNode): void;
+	unmount(): void;
+};
+
+const roots: Root[] = [];
+
+(
+	globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+afterEach(() => {
+	act(() => {
+		for (const root of roots) root.unmount();
+	});
+	roots.length = 0;
+	document.body.replaceChildren();
+});
+
+describe("useSidebarKeyboardNav", () => {
+	it("advances on repeated arrow keys before a render", () => {
+		const onNavigate = vi.fn();
+		let onKeyDown: ((event: ReactKeyboardEvent) => void) | undefined;
+		const root = createRoot(
+			document.body.appendChild(document.createElement("div")),
+		);
+		roots.push(root);
+
+		function Harness() {
+			const navRef = useRef<HTMLDivElement>(null);
+			onKeyDown = useSidebarKeyboardNav({
+				items: ["a", "b", "c"],
+				onSelect: vi.fn(),
+				onNavigate,
+				navRef,
+			}).onKeyDown;
+			return createElement("div", { ref: navRef });
+		}
+
+		act(() => root.render(createElement(Harness)));
+		const handleKeyDown = onKeyDown;
+		if (!handleKeyDown) throw new Error("Expected keyboard handler");
+
+		act(() => {
+			handleKeyDown(keyEvent("ArrowDown"));
+			handleKeyDown(keyEvent("ArrowDown"));
+		});
+
+		expect(onNavigate.mock.calls).toEqual([["a"], ["b"]]);
+	});
+});
+
+function keyEvent(key: string) {
+	return {
+		key,
+		preventDefault: vi.fn(),
+		target: document.createElement("div"),
+	} as unknown as ReactKeyboardEvent;
+}

--- a/packages/ui/src/components/useSidebarKeyboardNav.ts
+++ b/packages/ui/src/components/useSidebarKeyboardNav.ts
@@ -1,4 +1,10 @@
-import { type RefObject, useEffect, useRef, useState } from "react";
+import {
+	type RefObject,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useState,
+} from "react";
 import { isEditableEventTarget } from "../lib/dom";
 
 export const EDITOR_INPUT_SELECTOR = "[data-editor-input]";
@@ -24,7 +30,9 @@ export function useSidebarKeyboardNav<T>({
 }) {
 	const [focusedIndex, setFocusedIndex] = useState<number | null>(null);
 	const focusedIndexRef = useRef(focusedIndex);
-	focusedIndexRef.current = focusedIndex;
+	useLayoutEffect(() => {
+		focusedIndexRef.current = focusedIndex;
+	}, [focusedIndex]);
 	const getActionIndex = () =>
 		focusedIndexRef.current ?? (activeIndex >= 0 ? activeIndex : null);
 

--- a/packages/ui/src/components/useSidebarKeyboardNav.ts
+++ b/packages/ui/src/components/useSidebarKeyboardNav.ts
@@ -1,4 +1,4 @@
-import { type RefObject, useEffect, useState } from "react";
+import { type RefObject, useEffect, useRef, useState } from "react";
 import { isEditableEventTarget } from "../lib/dom";
 
 export const EDITOR_INPUT_SELECTOR = "[data-editor-input]";
@@ -23,8 +23,10 @@ export function useSidebarKeyboardNav<T>({
 	onNavigate?: (item: T) => void;
 }) {
 	const [focusedIndex, setFocusedIndex] = useState<number | null>(null);
+	const focusedIndexRef = useRef(focusedIndex);
+	focusedIndexRef.current = focusedIndex;
 	const getActionIndex = () =>
-		focusedIndex ?? (activeIndex >= 0 ? activeIndex : null);
+		focusedIndexRef.current ?? (activeIndex >= 0 ? activeIndex : null);
 
 	useEffect(() => {
 		if (focusedIndex === null) return;
@@ -42,8 +44,10 @@ export function useSidebarKeyboardNav<T>({
 			case "ArrowUp": {
 				event.preventDefault();
 				const delta = event.key === "ArrowDown" ? 1 : -1;
-				const start = focusedIndex ?? (activeIndex >= 0 ? activeIndex : -1);
+				const start =
+					focusedIndexRef.current ?? (activeIndex >= 0 ? activeIndex : -1);
 				const next = Math.max(0, Math.min(start + delta, items.length - 1));
+				focusedIndexRef.current = next;
 				setFocusedIndex(next);
 				if (items[next]) onNavigate?.(items[next]);
 				break;
@@ -82,6 +86,7 @@ export function useSidebarKeyboardNav<T>({
 			}
 			case "Escape": {
 				event.preventDefault();
+				focusedIndexRef.current = null;
 				setFocusedIndex(null);
 				document.querySelector<HTMLElement>(EDITOR_INPUT_SELECTOR)?.focus();
 				break;

--- a/packages/ui/src/components/useSidebarKeyboardNav.ts
+++ b/packages/ui/src/components/useSidebarKeyboardNav.ts
@@ -11,6 +11,7 @@ export function useSidebarKeyboardNav<T>({
 	onCollapse,
 	navRef,
 	activeIndex = -1,
+	onNavigate,
 }: {
 	items: T[];
 	onSelect: (item: T) => void;
@@ -19,6 +20,7 @@ export function useSidebarKeyboardNav<T>({
 	onCollapse?: (item: T) => void;
 	navRef: RefObject<HTMLElement | null>;
 	activeIndex?: number;
+	onNavigate?: (item: T) => void;
 }) {
 	const [focusedIndex, setFocusedIndex] = useState<number | null>(null);
 	const getActionIndex = () =>
@@ -40,10 +42,10 @@ export function useSidebarKeyboardNav<T>({
 			case "ArrowUp": {
 				event.preventDefault();
 				const delta = event.key === "ArrowDown" ? 1 : -1;
-				setFocusedIndex((prev) => {
-					const start = prev ?? (activeIndex >= 0 ? activeIndex : -1);
-					return Math.max(0, Math.min(start + delta, items.length - 1));
-				});
+				const start = focusedIndex ?? (activeIndex >= 0 ? activeIndex : -1);
+				const next = Math.max(0, Math.min(start + delta, items.length - 1));
+				setFocusedIndex(next);
+				if (items[next]) onNavigate?.(items[next]);
 				break;
 			}
 			case "Enter": {

--- a/packages/ui/src/theme.css
+++ b/packages/ui/src/theme.css
@@ -43,8 +43,7 @@
 	--cursor-motion-easing: linear(0, 0.44 25%, 0.75 50%, 0.94 75%, 1);
 	--sidebar: oklch(0.989 0.004 95); /* faint tint vs the white editor */
 	--sidebar-foreground: var(--foreground);
-	/* gray until the sidebar is focused (yellow via :focus-within below) */
-	--sidebar-accent: oklch(0.915 0.004 95);
+	--sidebar-accent: var(--accent);
 	--sidebar-accent-foreground: var(--selected-foreground);
 	--sidebar-border: var(--border);
 }
@@ -96,7 +95,6 @@
 	box-sizing: border-box;
 }
 
-/* Selected row goes yellow only while the sidebar pane is focused (else gray). */
 [data-sidebar-root]:focus-within {
 	--sidebar-accent: var(--selected);
 	--sidebar-accent-foreground: var(--selected-foreground);


### PR DESCRIPTION
## Description

Unifies sidebar row feedback around one focus-aware selection highlight. The open file keeps a subtle text-weight marker when it sits outside the current selection. Keyboard arrows move a single selection cursor, while switching to the editor preserves multi-selection.

Closes #207

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Testing

- [x] Biome check
- [x] UI tests
- [x] UI TypeScript check
- [x] Manual sidebar interaction testing

## Checklist

- [x] Discussed in a GitHub issue
- [x] Lint and tests pass