### PR TITLE
Auto-name new notes from their first line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 
 ### Added
 
+- New notes name themselves from the first meaningful line as you type, until you choose a name yourself. [#244](https://github.com/bholmesdev/hubble.md/pull/244)
+
 ### Changed
 
 - Open recent workspaces with Ctrl+R, and add folders with Cmd+Shift+O. [#243](https://github.com/bholmesdev/hubble.md/pull/243)

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -868,6 +868,7 @@ function DocumentViewer({
 				key={`${documentId}:source:${HMR_REV}`}
 				path={path}
 				documentId={documentId}
+				preserveHistoryOnUpdate={documentId !== path}
 				initialMarkdown={content}
 				sourceLanguage={
 					isHtml ? "html" : hasTextExtension(path) ? "text" : "md"

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -18,7 +18,7 @@ import {
 } from "@hubble.md/ui";
 import { useStoreValue } from "@simplestack/store/react";
 import { keymatch } from "keymatch";
-import { useEffect, useRef, useState, useSyncExternalStore } from "react";
+import { useEffect, useState, useSyncExternalStore } from "react";
 import { toast } from "sonner";
 import MingcutePencilLine from "~icons/mingcute/pencil-line";
 import {
@@ -1039,8 +1039,7 @@ function MarkdownEditor({
 	onScrollContainerChange?: (el: HTMLDivElement | null) => void;
 }) {
 	const workspace = useStoreValue(workspaceStore);
-	const pathRef = useRef(path);
-	pathRef.current = path;
+	const getPath = () => viewerStore.get().currentPath ?? path;
 	// External-only files stay out of autocomplete; explicit links still work.
 	const wikiTargets: WikiTarget[] = workspace.files
 		.filter((file) => (file.kind ?? fileKindForPath(file.path)) !== "external")
@@ -1082,14 +1081,15 @@ function MarkdownEditor({
 		<EditorView
 			path={path}
 			documentId={documentId}
+			preserveHistoryOnUpdate={documentId !== path}
 			initialMarkdown={initialMarkdown}
 			editable={!isChangelogPath(path)}
 			wikiTargets={wikiTargets}
 			extensions={[
-				createImageExtension(() => pathRef.current),
+				createImageExtension(getPath),
 				createEmbedExtension({
 					workspacePath: workspace.workspacePath,
-					getFilePath: () => pathRef.current,
+					getFilePath: getPath,
 				}),
 			]}
 			onPaste={(editor, event) => handleImagePaste({ editor, event })}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1089,7 +1089,7 @@ function MarkdownEditor({
 				createImageExtension(() => pathRef.current),
 				createEmbedExtension({
 					workspacePath: workspace.workspacePath,
-					filePath: path,
+					getFilePath: () => pathRef.current,
 				}),
 			]}
 			onPaste={(editor, event) => handleImagePaste({ editor, event })}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -18,7 +18,7 @@ import {
 } from "@hubble.md/ui";
 import { useStoreValue } from "@simplestack/store/react";
 import { keymatch } from "keymatch";
-import { useEffect, useState, useSyncExternalStore } from "react";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { toast } from "sonner";
 import MingcutePencilLine from "~icons/mingcute/pencil-line";
 import {
@@ -68,6 +68,7 @@ import { resolveWikiPath } from "./lib/wikiPath";
 import { SIDEBAR_NAV_SELECTOR } from "./selectors";
 import {
 	createWorkspaceWithSidebar,
+	editorDocumentId,
 	forceKeepLocalEdits,
 	getPendingRenameTarget,
 	goBack,
@@ -859,12 +860,14 @@ function DocumentViewer({
 	viewMode: ViewMode;
 	onScrollContainerChange?: (el: HTMLDivElement | null) => void;
 }) {
+	const documentId = editorDocumentId(path);
 	if (viewMode === "source" && supportsSourceToggle(path)) {
 		const isHtml = hasHtmlExtension(path);
 		return (
 			<MarkdownSourceEditor
-				key={`${path}:source:${HMR_REV}`}
+				key={`${documentId}:source:${HMR_REV}`}
 				path={path}
+				documentId={documentId}
 				initialMarkdown={content}
 				sourceLanguage={
 					isHtml ? "html" : hasTextExtension(path) ? "text" : "md"
@@ -942,8 +945,9 @@ function DocumentViewer({
 
 	return (
 		<MarkdownEditor
-			key={`${path}:rich:${HMR_REV}`}
+			key={`${documentId}:rich:${HMR_REV}`}
 			path={path}
+			documentId={documentId}
 			initialMarkdown={content}
 			copyAsMarkdownRequest={copyAsMarkdownRequest}
 			onScrollContainerChange={onScrollContainerChange}
@@ -1023,16 +1027,20 @@ function ExternalChangeBanner({
 
 function MarkdownEditor({
 	path,
+	documentId,
 	initialMarkdown,
 	copyAsMarkdownRequest,
 	onScrollContainerChange,
 }: {
 	path: string;
+	documentId: string;
 	initialMarkdown: string;
 	copyAsMarkdownRequest: number;
 	onScrollContainerChange?: (el: HTMLDivElement | null) => void;
 }) {
 	const workspace = useStoreValue(workspaceStore);
+	const pathRef = useRef(path);
+	pathRef.current = path;
 	// External-only files stay out of autocomplete; explicit links still work.
 	const wikiTargets: WikiTarget[] = workspace.files
 		.filter((file) => (file.kind ?? fileKindForPath(file.path)) !== "external")
@@ -1073,11 +1081,12 @@ function MarkdownEditor({
 	return (
 		<EditorView
 			path={path}
+			documentId={documentId}
 			initialMarkdown={initialMarkdown}
 			editable={!isChangelogPath(path)}
 			wikiTargets={wikiTargets}
 			extensions={[
-				createImageExtension(path),
+				createImageExtension(() => pathRef.current),
 				createEmbedExtension({
 					workspacePath: workspace.workspacePath,
 					filePath: path,

--- a/apps/desktop/src/components/Toolbar.test.ts
+++ b/apps/desktop/src/components/Toolbar.test.ts
@@ -1,0 +1,24 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from "vitest";
+import { toolbarPathForTitlePreview } from "./Toolbar";
+
+describe("toolbarPathForTitlePreview", () => {
+	it("shows pending previews even when the current name has a numeric suffix", () => {
+		expect(
+			toolbarPathForTitlePreview("/workspace/draft-2.md", {
+				path: "/workspace/draft-2.md",
+				previewPath: "/workspace/draft.md",
+			}),
+		).toBe("/workspace/draft.md");
+	});
+
+	it("hides the preview only when it matches the current path", () => {
+		expect(
+			toolbarPathForTitlePreview("/workspace/draft-2.md", {
+				path: "/workspace/draft-2.md",
+				previewPath: "/workspace/draft-2.md",
+			}),
+		).toBe("/workspace/draft-2.md");
+	});
+});

--- a/apps/desktop/src/components/Toolbar.tsx
+++ b/apps/desktop/src/components/Toolbar.tsx
@@ -23,11 +23,11 @@ import type { AgentClient } from "../desktopApi/types";
 import { isChangelogPath } from "../lib/changelogNote";
 import { copyText } from "../lib/clipboard";
 import {
-	fileStem,
 	hasHtmlExtension,
 	hasMarkdownExtension,
 	hasTextExtension,
 	isEditableFile,
+	pathEquals,
 	relativeWorkspacePath,
 	supportsSourceToggle,
 } from "../lib/filePath";
@@ -57,6 +57,18 @@ const dragRegionStyle = {
 	WebkitAppRegion: "drag",
 } as CSSProperties;
 
+type TitlePreview = { path: string; previewPath: string } | null;
+
+export function toolbarPathForTitlePreview(
+	currentPath: string | null | undefined,
+	titlePreview: TitlePreview,
+) {
+	if (!currentPath || titlePreview?.path !== currentPath) return currentPath;
+	return pathEquals(currentPath, titlePreview.previewPath)
+		? currentPath
+		: titlePreview.previewPath;
+}
+
 // Traffic lights are hidden in fullscreen, so drop their reserved inset.
 function useIsFullScreen() {
 	const [isFullScreen, setIsFullScreen] = useState(false);
@@ -83,15 +95,7 @@ export function Toolbar({
 	// The changelog note is virtual: show a friendly title and disable the
 	// file actions (rename, reveal, copy path) that assume a file on disk.
 	const isChangelog = isChangelogPath(currentPath);
-	const previewIsSaved =
-		currentPath && titlePreview?.path === currentPath
-			? fileStem(currentPath).replace(/-\d+$/, "") ===
-				fileStem(titlePreview.previewPath)
-			: false;
-	const toolbarPath =
-		currentPath && titlePreview?.path === currentPath && !previewIsSaved
-			? titlePreview.previewPath
-			: currentPath;
+	const toolbarPath = toolbarPathForTitlePreview(currentPath, titlePreview);
 
 	return (
 		<SharedToolbar

--- a/apps/desktop/src/components/Toolbar.tsx
+++ b/apps/desktop/src/components/Toolbar.tsx
@@ -23,6 +23,7 @@ import type { AgentClient } from "../desktopApi/types";
 import { isChangelogPath } from "../lib/changelogNote";
 import { copyText } from "../lib/clipboard";
 import {
+	fileStem,
 	hasHtmlExtension,
 	hasMarkdownExtension,
 	hasTextExtension,
@@ -46,6 +47,7 @@ import {
 	currentPathStore,
 	reviewThreadsStore,
 	sidebarOpenStore,
+	titleGenerationPreviewStore,
 	viewerStore,
 	workspacePathStore,
 } from "../store/state";
@@ -75,15 +77,25 @@ export function Toolbar({
 	const workspacePath = useStoreValue(workspacePathStore);
 	const sidebarOpen = useStoreValue(sidebarOpenStore);
 	const currentPath = useStoreValue(currentPathStore);
+	const titlePreview = useStoreValue(titleGenerationPreviewStore);
 	const reviewThreads = useStoreValue(reviewThreadsStore);
 	const isFullScreen = useIsFullScreen();
 	// The changelog note is virtual: show a friendly title and disable the
 	// file actions (rename, reveal, copy path) that assume a file on disk.
 	const isChangelog = isChangelogPath(currentPath);
+	const previewIsSaved =
+		currentPath && titlePreview?.path === currentPath
+			? fileStem(currentPath).replace(/-\d+$/, "") ===
+				fileStem(titlePreview.previewPath)
+			: false;
+	const toolbarPath =
+		currentPath && titlePreview?.path === currentPath && !previewIsSaved
+			? titlePreview.previewPath
+			: currentPath;
 
 	return (
 		<SharedToolbar
-			currentPath={isChangelog ? "What's new" : (currentPath ?? null)}
+			currentPath={isChangelog ? "What's new" : (toolbarPath ?? null)}
 			sidebarOpen={sidebarOpen}
 			sidebarBadge={showSidebarBadge}
 			scrollContainer={scrollContainer}

--- a/apps/desktop/src/editor/EmbedExtension.tsx
+++ b/apps/desktop/src/editor/EmbedExtension.tsx
@@ -12,7 +12,7 @@ type EmbedAttrs = {
 
 type EmbedExtensionOptions = {
 	workspacePath: string | null;
-	filePath: string;
+	getFilePath: () => string;
 };
 
 export function createEmbedExtension(options: EmbedExtensionOptions) {
@@ -39,7 +39,7 @@ export function createEmbedExtension(options: EmbedExtensionOptions) {
 			return ReactNodeViewRenderer((props) => (
 				<IframeEmbedNodeView
 					attrs={props.node.attrs as EmbedAttrs}
-					filePath={options.filePath}
+					filePath={options.getFilePath()}
 					workspacePath={options.workspacePath}
 				/>
 			));

--- a/apps/desktop/src/editor/ImageExtension.tsx
+++ b/apps/desktop/src/editor/ImageExtension.tsx
@@ -1,7 +1,7 @@
 import Image from "@tiptap/extension-image";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 import { ImageNodeView } from "./ImageNodeView";
-export function createImageExtension(filePath: string) {
+export function createImageExtension(getFilePath: () => string) {
 	return Image.extend({
 		group: "block tableCellContent",
 		addAttributes() {
@@ -31,7 +31,7 @@ export function createImageExtension(filePath: string) {
 		},
 		addNodeView() {
 			return ReactNodeViewRenderer((props) => (
-				<ImageNodeView {...props} filePath={filePath} />
+				<ImageNodeView {...props} filePath={getFilePath()} />
 			));
 		},
 	}).configure({

--- a/apps/desktop/src/lib/filePath.test.ts
+++ b/apps/desktop/src/lib/filePath.test.ts
@@ -3,6 +3,7 @@ import {
 	dirname,
 	duplicateBasenames,
 	fileKindForPath,
+	fileStem,
 	hasDocumentExtension,
 	hasImageExtension,
 	isCodeFile,
@@ -29,6 +30,13 @@ describe("duplicateBasenames", () => {
 				"C:\\projects\\beta\\plans",
 			]),
 		).toEqual(new Set(["plans"]));
+	});
+});
+
+describe("fileStem", () => {
+	it("drops only the last extension", () => {
+		expect(fileStem("/notes/draft.post.md")).toBe("draft.post");
+		expect(fileStem("/notes/README")).toBe("README");
 	});
 });
 

--- a/apps/desktop/src/lib/filePath.ts
+++ b/apps/desktop/src/lib/filePath.ts
@@ -86,6 +86,12 @@ export function extname(filePath: string): string {
 	return dot > 0 ? name.slice(dot) : "";
 }
 
+export function fileStem(filePath: string): string {
+	const extension = extname(filePath);
+	const name = basename(filePath);
+	return extension ? name.slice(0, -extension.length) : name;
+}
+
 export function hasMarkdownExtension(path: string): boolean {
 	return MARKDOWN_EXTENSION_RE.test(path);
 }
@@ -162,11 +168,7 @@ export function withMarkdownExtension(path: string): string {
 export function markdownAssetFolderPath(path: string): string | null {
 	const parent = dirname(path);
 	if (!parent) return null;
-	const extension = extname(path);
-	const stem = extension
-		? basename(path).slice(0, -extension.length)
-		: basename(path);
-	return joinPath(parent, `${stem}.assets`);
+	return joinPath(parent, `${fileStem(path)}.assets`);
 }
 
 export function joinPath(parent: string, name: string): string {

--- a/apps/desktop/src/lib/titleGeneration.test.ts
+++ b/apps/desktop/src/lib/titleGeneration.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { generatedTitleStem } from "./titleGeneration";
+
+describe("generatedTitleStem", () => {
+	it("slugs the first meaningful line", () => {
+		expect(generatedTitleStem("\n# Don't Panic!\nSecond line")).toBe(
+			"dont-panic",
+		);
+	});
+
+	it("skips links and image alts", () => {
+		expect(
+			generatedTitleStem(
+				"![Hero image](hero.png)\n[Hubble](https://hubble.md)\nActual title",
+			),
+		).toBe("actual-title");
+		expect(generatedTitleStem("Read [this](https://example.com) today")).toBe(
+			"read-today",
+		);
+	});
+
+	it("ignores front matter", () => {
+		expect(
+			generatedTitleStem("---\ntitle: Metadata\n---\n\nVisible title"),
+		).toBe("visible-title");
+	});
+
+	it("caps the slug at 40 characters", () => {
+		const stem = generatedTitleStem(`${"word ".repeat(20)}ending`);
+		expect(stem?.length).toBeLessThanOrEqual(40);
+		expect(stem?.endsWith("-")).toBe(false);
+	});
+
+	it("returns null when no meaningful text remains", () => {
+		expect(
+			generatedTitleStem("![Alt](image.png)\nhttps://example.com"),
+		).toBeNull();
+	});
+});

--- a/apps/desktop/src/lib/titleGeneration.ts
+++ b/apps/desktop/src/lib/titleGeneration.ts
@@ -1,0 +1,48 @@
+import { parseMarkdownFrontMatter } from "@hubble.md/editor";
+
+export const MAX_GENERATED_TITLE_LENGTH = 40;
+
+export function generatedTitleStem(markdown: string): string | null {
+	const body = parseMarkdownFrontMatter(markdown).body;
+	for (const line of body.split("\n")) {
+		const text = meaningfulText(line);
+		if (!text) continue;
+		const slug = text
+			.toLocaleLowerCase()
+			.replace(/['’`]/g, "")
+			.replace(/[^\p{L}\p{N}]+/gu, "-")
+			.replace(/^-+|-+$/g, "");
+		const capped = Array.from(slug)
+			.slice(0, MAX_GENERATED_TITLE_LENGTH)
+			.join("")
+			.replace(/-+$/g, "");
+		return capped || null;
+	}
+	return null;
+}
+
+function meaningfulText(line: string): string {
+	const trimmed = line.trim();
+	if (
+		/^(?:-{3,}|_{3,}|\*{3,})$/.test(trimmed) ||
+		/^```|^~~~/.test(trimmed) ||
+		/^\[[^\]]+\]:\s*\S+/.test(trimmed)
+	) {
+		return "";
+	}
+
+	return trimmed
+		.replace(
+			/^(?:#{1,6}\s+|(?:>\s*)+|[-*+]\s+(?:\[[ xX]\]\s+)?|\d+[.)]\s+)/,
+			"",
+		)
+		.replace(/!?\[[^\]]*\]\([^)]*\)/g, "")
+		.replace(/!?\[[^\]]*\]\[[^\]]*\]/g, "")
+		.replace(/!?\[\[[^\]]*\]\]/g, "")
+		.replace(/<https?:\/\/[^>]+>/g, "")
+		.replace(/https?:\/\/\S+/g, "")
+		.replace(/<[^>]+>/g, "")
+		.replace(/[*_~`]/g, "")
+		.replace(/\s+/g, " ")
+		.trim();
+}

--- a/apps/desktop/src/lib/titleGeneration.ts
+++ b/apps/desktop/src/lib/titleGeneration.ts
@@ -2,6 +2,7 @@ import { parseMarkdownFrontMatter } from "@hubble.md/editor";
 
 export const MAX_GENERATED_TITLE_LENGTH = 40;
 
+/** Builds a file-safe stem from the first line with visible text. */
 export function generatedTitleStem(markdown: string): string | null {
 	const body = parseMarkdownFrontMatter(markdown).body;
 	for (const line of body.split("\n")) {
@@ -9,8 +10,11 @@ export function generatedTitleStem(markdown: string): string | null {
 		if (!text) continue;
 		const slug = text
 			.toLocaleLowerCase()
+			// Join contractions instead of treating apostrophes as word breaks.
 			.replace(/['’`]/g, "")
+			// Keep Unicode letters and numbers; turn each other run into one dash.
 			.replace(/[^\p{L}\p{N}]+/gu, "-")
+			// A file stem cannot start or end with a generated separator.
 			.replace(/^-+|-+$/g, "");
 		const capped = Array.from(slug)
 			.slice(0, MAX_GENERATED_TITLE_LENGTH)
@@ -21,9 +25,11 @@ export function generatedTitleStem(markdown: string): string | null {
 	return null;
 }
 
+/** Strips Markdown syntax that does not read as title text. */
 function meaningfulText(line: string): string {
 	const trimmed = line.trim();
 	if (
+		// Horizontal rules, fenced-code markers, and link definitions have no title.
 		/^(?:-{3,}|_{3,}|\*{3,})$/.test(trimmed) ||
 		/^```|^~~~/.test(trimmed) ||
 		/^\[[^\]]+\]:\s*\S+/.test(trimmed)
@@ -31,18 +37,24 @@ function meaningfulText(line: string): string {
 		return "";
 	}
 
-	return trimmed
-		.replace(
-			/^(?:#{1,6}\s+|(?:>\s*)+|[-*+]\s+(?:\[[ xX]\]\s+)?|\d+[.)]\s+)/,
-			"",
-		)
-		.replace(/!?\[[^\]]*\]\([^)]*\)/g, "")
-		.replace(/!?\[[^\]]*\]\[[^\]]*\]/g, "")
-		.replace(/!?\[\[[^\]]*\]\]/g, "")
-		.replace(/<https?:\/\/[^>]+>/g, "")
-		.replace(/https?:\/\/\S+/g, "")
-		.replace(/<[^>]+>/g, "")
-		.replace(/[*_~`]/g, "")
-		.replace(/\s+/g, " ")
-		.trim();
+	return (
+		trimmed
+			.replace(
+				// Drop heading, quote, list, ordered-list, and task-list prefixes.
+				/^(?:#{1,6}\s+|(?:>\s*)+|[-*+]\s+(?:\[[ xX]\]\s+)?|\d+[.)]\s+)/,
+				"",
+			)
+			// Links, images, and embeds contribute no visible title text here.
+			.replace(/!?\[[^\]]*\]\([^)]*\)/g, "")
+			.replace(/!?\[[^\]]*\]\[[^\]]*\]/g, "")
+			.replace(/!?\[\[[^\]]*\]\]/g, "")
+			// Strip autolinks, bare URLs, and HTML tags.
+			.replace(/<https?:\/\/[^>]+>/g, "")
+			.replace(/https?:\/\/\S+/g, "")
+			.replace(/<[^>]+>/g, "")
+			// Remove inline emphasis/code markers, then fold whitespace.
+			.replace(/[*_~`]/g, "")
+			.replace(/\s+/g, " ")
+			.trim()
+	);
 }

--- a/apps/desktop/src/store/actions.test.ts
+++ b/apps/desktop/src/store/actions.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 type MockDesktopApi = {
 	readFileText: ReturnType<typeof vi.fn>;
@@ -975,6 +975,206 @@ describe("desktop renameMarkdownFile", () => {
 		expect(viewerStore.get().content).toBe(
 			"[Target](renamed.md)\nunsaved edit",
 		);
+	});
+});
+
+describe("desktop title generation", () => {
+	beforeEach(() => {
+		vi.unstubAllGlobals();
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("keeps a new note filename synced to its first meaningful line", async () => {
+		const api = createDesktopApi();
+		api.readFileText.mockResolvedValue("");
+		const {
+			appStore,
+			createMarkdownFileInFolder,
+			editorDocumentId,
+			renameMarkdownFile,
+			titleGenerationPreviewStore,
+			updateEditorContent,
+			viewerStore,
+		} = await loadStoreActions(api);
+		appStore.set((state) => ({
+			...state,
+			workspace: { ...state.workspace, workspacePath: "/workspace" },
+		}));
+
+		const path = (await createMarkdownFileInFolder("/workspace")) as string;
+		expect(path).toBe("/workspace/new-file.md");
+		await renameMarkdownFile(path, "new-file");
+		updateEditorContent(path, "![Diagram](diagram.png)\n# First Title");
+		expect(titleGenerationPreviewStore.get()).toEqual({
+			path: "/workspace/new-file.md",
+			previewPath: "/workspace/first-title.md",
+		});
+		expect(editorDocumentId("/workspace/new-file.md")).toBe(
+			"/workspace/new-file.md",
+		);
+		api.listDirectory.mockClear();
+		api.readFileText.mockClear();
+		api.pathExists.mockClear();
+		await vi.advanceTimersByTimeAsync(499);
+		expect(api.renameFile).not.toHaveBeenCalled();
+		await vi.advanceTimersByTimeAsync(1);
+
+		expect(api.renameFile).toHaveBeenCalledWith(
+			"/workspace/new-file.md",
+			"/workspace/first-title.md",
+		);
+		expect(viewerStore.get().currentPath).toBe("/workspace/first-title.md");
+		expect(editorDocumentId("/workspace/first-title.md")).toBe(
+			"/workspace/new-file.md",
+		);
+		expect(api.listDirectory).not.toHaveBeenCalled();
+		expect(api.readFileText).not.toHaveBeenCalled();
+		expect(api.pathExists).toHaveBeenCalledWith("/workspace/first-title.md");
+
+		updateEditorContent("/workspace/first-title.md", "Second title");
+		await vi.advanceTimersByTimeAsync(500);
+		expect(api.renameFile).toHaveBeenLastCalledWith(
+			"/workspace/first-title.md",
+			"/workspace/second-title.md",
+		);
+	});
+
+	it("captures edits made before note creation finishes", async () => {
+		const api = createDesktopApi();
+		api.readFileText.mockResolvedValue("");
+		let finishRefresh: (() => void) | undefined;
+		api.listDirectory.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					finishRefresh = () => resolve({ files: [], folders: [] });
+				}),
+		);
+		const {
+			appStore,
+			createMarkdownFileInFolder,
+			updateEditorContent,
+			viewerStore,
+		} = await loadStoreActions(api);
+		appStore.set((state) => ({
+			...state,
+			workspace: { ...state.workspace, workspacePath: "/workspace" },
+		}));
+
+		const creation = createMarkdownFileInFolder("/workspace");
+		await vi.waitFor(() => {
+			expect(viewerStore.get().currentPath).toBe("/workspace/new-file.md");
+		});
+		updateEditorContent("/workspace/new-file.md", "Typed right away");
+		finishRefresh?.();
+		await creation;
+		await vi.advanceTimersByTimeAsync(500);
+
+		expect(api.renameFile).toHaveBeenCalledWith(
+			"/workspace/new-file.md",
+			"/workspace/typed-right-away.md",
+		);
+	});
+
+	it("writes edits made while a generated rename is in flight to the new path", async () => {
+		const api = createDesktopApi();
+		api.readFileText.mockResolvedValue("");
+		let finishRename: (() => void) | undefined;
+		api.renameFile.mockImplementationOnce(
+			() =>
+				new Promise<void>((resolve) => {
+					finishRename = resolve;
+				}),
+		);
+		const {
+			appStore,
+			createMarkdownFileInFolder,
+			savePathContent,
+			updateEditorContent,
+			viewerStore,
+		} = await loadStoreActions(api);
+		appStore.set((state) => ({
+			...state,
+			workspace: { ...state.workspace, workspacePath: "/workspace" },
+		}));
+
+		const path = (await createMarkdownFileInFolder("/workspace")) as string;
+		api.writeFileText.mockClear();
+		updateEditorContent(path, "First title");
+		await vi.advanceTimersByTimeAsync(500);
+		updateEditorContent(path, "Second title");
+		const oldPathSave = savePathContent(path, "Second title");
+		finishRename?.();
+		await oldPathSave;
+		await vi.waitFor(() => {
+			expect(viewerStore.get().currentPath).toBe("/workspace/first-title.md");
+			expect(api.writeFileText).toHaveBeenCalledWith(
+				"/workspace/first-title.md",
+				"Second title",
+			);
+		});
+		expect(api.writeFileText).not.toHaveBeenCalledWith(
+			"/workspace/new-file.md",
+			"Second title",
+		);
+	});
+
+	it("stops syncing after a manual title edit", async () => {
+		const api = createDesktopApi();
+		api.readFileText.mockResolvedValue("");
+		const {
+			appStore,
+			createMarkdownFileInFolder,
+			renameMarkdownFile,
+			titleGenerationPreviewStore,
+			updateEditorContent,
+		} = await loadStoreActions(api);
+		appStore.set((state) => ({
+			...state,
+			workspace: { ...state.workspace, workspacePath: "/workspace" },
+		}));
+
+		const path = (await createMarkdownFileInFolder("/workspace")) as string;
+		updateEditorContent(path, "Generated title");
+		expect(titleGenerationPreviewStore.get()?.previewPath).toBe(
+			"/workspace/generated-title.md",
+		);
+		await renameMarkdownFile(path, "chosen-title");
+		expect(titleGenerationPreviewStore.get()).toBeNull();
+		updateEditorContent("/workspace/chosen-title.md", "Generated title");
+		await vi.advanceTimersByTimeAsync(500);
+
+		expect(api.renameFile).toHaveBeenCalledTimes(1);
+		expect(api.renameFile).toHaveBeenCalledWith(
+			"/workspace/new-file.md",
+			"/workspace/chosen-title.md",
+		);
+	});
+
+	it("does not enable title generation for notes reopened this session", async () => {
+		const api = createDesktopApi();
+		const { appStore, updateEditorContent } = await loadStoreActions(api);
+		appStore.set((state) => ({
+			...state,
+			workspace: {
+				...state.workspace,
+				workspacePath: "/workspace",
+				files: [{ path: "/workspace/new-file.md", modified_at: 1 }],
+			},
+			document: {
+				...state.document,
+				currentPath: "/workspace/new-file.md",
+				content: "",
+			},
+		}));
+
+		updateEditorContent("/workspace/new-file.md", "Reopened note");
+		await vi.advanceTimersByTimeAsync(500);
+
+		expect(api.renameFile).not.toHaveBeenCalled();
 	});
 });
 

--- a/apps/desktop/src/store/actions.test.ts
+++ b/apps/desktop/src/store/actions.test.ts
@@ -1403,40 +1403,6 @@ describe("desktop title generation", () => {
 
 		expect(api.renameFile).not.toHaveBeenCalled();
 	});
-
-	it("stops title generation when deleting the open auto-named note", async () => {
-		const api = createDesktopApi();
-		api.readFileText.mockResolvedValue("");
-		const toast = Object.assign(
-			vi.fn(() => "delete-undo"),
-			{
-				dismiss: vi.fn(),
-				success: vi.fn(),
-				error: vi.fn(),
-			},
-		);
-		vi.doMock("sonner", () => ({ toast }));
-		const {
-			appStore,
-			createMarkdownFileInFolder,
-			deleteSidebarItems,
-			updateEditorContent,
-			viewerStore,
-		} = await loadStoreActions(api);
-		appStore.set((state) => ({
-			...state,
-			workspace: { ...state.workspace, workspacePath: "/workspace" },
-		}));
-
-		const path = (await createMarkdownFileInFolder("/workspace")) as string;
-		updateEditorContent(path, "First title");
-		await deleteSidebarItems([{ kind: "file", path }]);
-		expect(viewerStore.get().currentPath).toBeNull();
-		await vi.advanceTimersByTimeAsync(500);
-
-		expect(api.renameFile).not.toHaveBeenCalled();
-		vi.doUnmock("sonner");
-	});
 });
 
 describe("desktop folder actions", () => {

--- a/apps/desktop/src/store/actions.test.ts
+++ b/apps/desktop/src/store/actions.test.ts
@@ -1199,6 +1199,7 @@ describe("desktop title generation", () => {
 		const {
 			appStore,
 			createMarkdownFileInFolder,
+			savePathContent,
 			updateEditorContent,
 			viewerStore,
 		} = await loadStoreActions(api);
@@ -1214,6 +1215,13 @@ describe("desktop title generation", () => {
 
 		updateEditorContent(oldPath, "Late edit");
 		expect(viewerStore.get().content).toBe("Late edit");
+		api.writeFileText.mockClear();
+		api.readFileText.mockResolvedValue("First title");
+		await savePathContent(oldPath, "Late edit");
+		expect(api.writeFileText).toHaveBeenCalledWith(
+			"/workspace/first-title.md",
+			"Late edit",
+		);
 		await vi.advanceTimersByTimeAsync(500);
 		expect(api.renameFile).toHaveBeenLastCalledWith(
 			"/workspace/first-title.md",

--- a/apps/desktop/src/store/actions.test.ts
+++ b/apps/desktop/src/store/actions.test.ts
@@ -1018,7 +1018,6 @@ describe("desktop title generation", () => {
 		);
 		api.listDirectory.mockClear();
 		api.readFileText.mockClear();
-		api.pathExists.mockClear();
 		await vi.advanceTimersByTimeAsync(499);
 		expect(api.renameFile).not.toHaveBeenCalled();
 		await vi.advanceTimersByTimeAsync(1);
@@ -1040,6 +1039,38 @@ describe("desktop title generation", () => {
 		expect(api.renameFile).toHaveBeenLastCalledWith(
 			"/workspace/first-title.md",
 			"/workspace/second-title.md",
+		);
+	});
+
+	it("previews the collision suffix used for the generated filename", async () => {
+		const api = createDesktopApi();
+		api.readFileText.mockResolvedValue("");
+		api.pathExists.mockImplementation(
+			async (path: string) => path === "/workspace/first-title.md",
+		);
+		const {
+			appStore,
+			createMarkdownFileInFolder,
+			titleGenerationPreviewStore,
+			updateEditorContent,
+		} = await loadStoreActions(api);
+		appStore.set((state) => ({
+			...state,
+			workspace: { ...state.workspace, workspacePath: "/workspace" },
+		}));
+
+		const path = (await createMarkdownFileInFolder("/workspace")) as string;
+		updateEditorContent(path, "First title");
+		await vi.waitFor(() => {
+			expect(titleGenerationPreviewStore.get()?.previewPath).toBe(
+				"/workspace/first-title-2.md",
+			);
+		});
+		await vi.advanceTimersByTimeAsync(500);
+
+		expect(api.renameFile).toHaveBeenCalledWith(
+			"/workspace/new-file.md",
+			"/workspace/first-title-2.md",
 		);
 	});
 
@@ -1159,6 +1190,34 @@ describe("desktop title generation", () => {
 		expect(api.writeFileText).not.toHaveBeenCalledWith(
 			"/workspace/new-file.md",
 			"Second title",
+		);
+	});
+
+	it("accepts an edit emitted with the old path after a generated rename", async () => {
+		const api = createDesktopApi();
+		api.readFileText.mockResolvedValue("");
+		const {
+			appStore,
+			createMarkdownFileInFolder,
+			updateEditorContent,
+			viewerStore,
+		} = await loadStoreActions(api);
+		appStore.set((state) => ({
+			...state,
+			workspace: { ...state.workspace, workspacePath: "/workspace" },
+		}));
+
+		const oldPath = (await createMarkdownFileInFolder("/workspace")) as string;
+		updateEditorContent(oldPath, "First title");
+		await vi.advanceTimersByTimeAsync(500);
+		expect(viewerStore.get().currentPath).toBe("/workspace/first-title.md");
+
+		updateEditorContent(oldPath, "Late edit");
+		expect(viewerStore.get().content).toBe("Late edit");
+		await vi.advanceTimersByTimeAsync(500);
+		expect(api.renameFile).toHaveBeenLastCalledWith(
+			"/workspace/first-title.md",
+			"/workspace/late-edit.md",
 		);
 	});
 

--- a/apps/desktop/src/store/actions.test.ts
+++ b/apps/desktop/src/store/actions.test.ts
@@ -1185,6 +1185,55 @@ describe("desktop title generation", () => {
 		await rename;
 	});
 
+	it("does not clobber a newly opened note after generated rename publish", async () => {
+		const api = createDesktopApi();
+		api.readFileText.mockImplementation(async (path: string) =>
+			path === "/workspace/other.md" ? "other content" : "",
+		);
+		let finishAssetCheck: (() => void) | undefined;
+		api.pathExists.mockImplementation(async (path: string) => {
+			if (path === "/workspace/new-file.assets") {
+				return new Promise<boolean>((resolve) => {
+					finishAssetCheck = () => resolve(true);
+				});
+			}
+			return false;
+		});
+		const {
+			appStore,
+			createMarkdownFileInFolder,
+			loadPath,
+			updateEditorContent,
+			viewerStore,
+		} = await loadStoreActions(api);
+		appStore.set((state) => ({
+			...state,
+			workspace: {
+				...state.workspace,
+				workspacePath: "/workspace",
+				files: [{ path: "/workspace/other.md", modified_at: 1 }],
+			},
+		}));
+
+		const path = (await createMarkdownFileInFolder("/workspace")) as string;
+		updateEditorContent(
+			path,
+			"![Diagram](new-file.assets/diagram.png)\nFirst title",
+		);
+		const rename = vi.advanceTimersByTimeAsync(500);
+		await vi.waitFor(() => {
+			expect(api.pathExists).toHaveBeenCalledWith("/workspace/new-file.assets");
+		});
+		expect(viewerStore.get().currentPath).toBe("/workspace/first-title.md");
+
+		await loadPath("/workspace/other.md");
+		finishAssetCheck?.();
+		await rename;
+
+		expect(viewerStore.get().currentPath).toBe("/workspace/other.md");
+		expect(viewerStore.get().content).toBe("other content");
+	});
+
 	it("captures edits made before note creation finishes", async () => {
 		const api = createDesktopApi();
 		api.readFileText.mockResolvedValue("");

--- a/apps/desktop/src/store/actions.test.ts
+++ b/apps/desktop/src/store/actions.test.ts
@@ -1074,6 +1074,41 @@ describe("desktop title generation", () => {
 		);
 	});
 
+	it("retries with a new suffix when a generated rename target appears late", async () => {
+		const api = createDesktopApi();
+		api.readFileText.mockResolvedValue("");
+		api.renameFile
+			.mockRejectedValueOnce(new Error("EEXIST"))
+			.mockResolvedValue(undefined);
+		let firstTitleChecks = 0;
+		api.pathExists.mockImplementation(async (path: string) => {
+			if (path !== "/workspace/first-title.md") return false;
+			firstTitleChecks += 1;
+			return firstTitleChecks > 1;
+		});
+		const { appStore, createMarkdownFileInFolder, updateEditorContent } =
+			await loadStoreActions(api);
+		appStore.set((state) => ({
+			...state,
+			workspace: { ...state.workspace, workspacePath: "/workspace" },
+		}));
+
+		const path = (await createMarkdownFileInFolder("/workspace")) as string;
+		updateEditorContent(path, "First title");
+		await vi.advanceTimersByTimeAsync(500);
+
+		expect(api.renameFile).toHaveBeenNthCalledWith(
+			1,
+			"/workspace/new-file.md",
+			"/workspace/first-title.md",
+		);
+		expect(api.renameFile).toHaveBeenNthCalledWith(
+			2,
+			"/workspace/new-file.md",
+			"/workspace/first-title-2.md",
+		);
+	});
+
 	it("moves a new note's assets when its title changes the filename", async () => {
 		const api = createDesktopApi();
 		api.readFileText.mockResolvedValue("");
@@ -1112,6 +1147,42 @@ describe("desktop title generation", () => {
 			"/workspace/first-title.md",
 			renamedMarkdown,
 		);
+	});
+
+	it("publishes the new path before generated asset moves finish", async () => {
+		const api = createDesktopApi();
+		api.readFileText.mockResolvedValue("");
+		let finishAssetCheck: (() => void) | undefined;
+		api.pathExists.mockImplementation(async (path: string) => {
+			if (path === "/workspace/new-file.assets") {
+				return new Promise<boolean>((resolve) => {
+					finishAssetCheck = () => resolve(false);
+				});
+			}
+			return false;
+		});
+		const {
+			appStore,
+			createMarkdownFileInFolder,
+			updateEditorContent,
+			viewerStore,
+		} = await loadStoreActions(api);
+		appStore.set((state) => ({
+			...state,
+			workspace: { ...state.workspace, workspacePath: "/workspace" },
+		}));
+
+		const path = (await createMarkdownFileInFolder("/workspace")) as string;
+		updateEditorContent(path, "First title");
+		const rename = vi.advanceTimersByTimeAsync(500);
+		await vi.waitFor(() => {
+			expect(api.pathExists).toHaveBeenCalledWith("/workspace/new-file.assets");
+		});
+
+		expect(viewerStore.get().currentPath).toBe("/workspace/first-title.md");
+
+		finishAssetCheck?.();
+		await rename;
 	});
 
 	it("captures edits made before note creation finishes", async () => {
@@ -1282,6 +1353,40 @@ describe("desktop title generation", () => {
 		await vi.advanceTimersByTimeAsync(500);
 
 		expect(api.renameFile).not.toHaveBeenCalled();
+	});
+
+	it("stops title generation when deleting the open auto-named note", async () => {
+		const api = createDesktopApi();
+		api.readFileText.mockResolvedValue("");
+		const toast = Object.assign(
+			vi.fn(() => "delete-undo"),
+			{
+				dismiss: vi.fn(),
+				success: vi.fn(),
+				error: vi.fn(),
+			},
+		);
+		vi.doMock("sonner", () => ({ toast }));
+		const {
+			appStore,
+			createMarkdownFileInFolder,
+			deleteSidebarItems,
+			updateEditorContent,
+			viewerStore,
+		} = await loadStoreActions(api);
+		appStore.set((state) => ({
+			...state,
+			workspace: { ...state.workspace, workspacePath: "/workspace" },
+		}));
+
+		const path = (await createMarkdownFileInFolder("/workspace")) as string;
+		updateEditorContent(path, "First title");
+		await deleteSidebarItems([{ kind: "file", path }]);
+		expect(viewerStore.get().currentPath).toBeNull();
+		await vi.advanceTimersByTimeAsync(500);
+
+		expect(api.renameFile).not.toHaveBeenCalled();
+		vi.doUnmock("sonner");
 	});
 });
 

--- a/apps/desktop/src/store/actions.test.ts
+++ b/apps/desktop/src/store/actions.test.ts
@@ -1043,6 +1043,46 @@ describe("desktop title generation", () => {
 		);
 	});
 
+	it("moves a new note's assets when its title changes the filename", async () => {
+		const api = createDesktopApi();
+		api.readFileText.mockResolvedValue("");
+		api.listDirectory.mockResolvedValue({
+			files: [{ path: "/workspace/new-file.md", modified_at: 1 }],
+			folders: [],
+		});
+		api.pathExists.mockImplementation(
+			async (path: string) => path === "/workspace/new-file.assets",
+		);
+		const {
+			appStore,
+			createMarkdownFileInFolder,
+			updateEditorContent,
+			viewerStore,
+		} = await loadStoreActions(api);
+		appStore.set((state) => ({
+			...state,
+			workspace: { ...state.workspace, workspacePath: "/workspace" },
+		}));
+
+		const path = (await createMarkdownFileInFolder("/workspace")) as string;
+		api.writeFileText.mockClear();
+		const markdown = "![Diagram](new-file.assets/diagram.png)\n# First Title";
+		updateEditorContent(path, markdown);
+		await vi.advanceTimersByTimeAsync(500);
+
+		expect(api.renameFile).toHaveBeenCalledWith(
+			"/workspace/new-file.assets",
+			"/workspace/first-title.assets",
+		);
+		const renamedMarkdown =
+			"![Diagram](first-title.assets/diagram.png)\n# First Title";
+		expect(viewerStore.get().content).toBe(renamedMarkdown);
+		expect(api.writeFileText).toHaveBeenLastCalledWith(
+			"/workspace/first-title.md",
+			renamedMarkdown,
+		);
+	});
+
 	it("captures edits made before note creation finishes", async () => {
 		const api = createDesktopApi();
 		api.readFileText.mockResolvedValue("");

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -35,7 +35,6 @@ import {
 	pathAfterMove,
 	rewriteMovedLinks,
 } from "../lib/markdownLinkRewrite";
-import { generatedTitleStem } from "../lib/titleGeneration";
 import {
 	setThemePreference as applyThemePreference,
 	initTheme,
@@ -74,19 +73,18 @@ import {
 	sidebarOpenStore,
 	switcherOpenStore,
 	themePreferenceStore,
-	titleGenerationPreviewStore,
 	uiStore,
 	type ViewMode,
 	viewerStore,
 	withOpenedDoc,
 	workspaceStore,
 } from "./state";
+import { createTitleManager } from "./titleManagement";
 import { applyWorkspaceDelta } from "./workspaceDelta";
 
 const REFRESH_FILES_DEBOUNCE_MS = 250;
 const SELF_SAVE_TTL_MS = 5000;
 const missingPathErrorPattern = /\bENOENT\b|\bENOTDIR\b/;
-const existingPathErrorPattern = /\bEEXIST\b|\balready exists\b/i;
 let refreshFilesTimer: ReturnType<typeof setTimeout> | null = null;
 type RefreshRun = {
 	reloadActive: boolean;
@@ -99,16 +97,6 @@ const workspaceSidebarQueues = new Map<string, Promise<void>>();
 // conflict; it is just the disk baseline catching up to a save we started.
 const selfSaves = new Map<string, Map<string, number>>();
 const saves = keyedQueue<string>();
-const TITLE_RENAME_DELAY_MS = 500;
-type TitleSession = {
-	path: string;
-	documentId: string;
-	markdown: string;
-	pendingTitle?: { markdown: string; path: Promise<string | null> };
-	timer?: number;
-	running: boolean;
-};
-const titleSessions = new Map<string, TitleSession>();
 
 type SidebarMoveItem =
 	| { kind: "file"; path: string }
@@ -494,6 +482,16 @@ function uniqueFolderPath(parent: string): string {
 }
 
 const pendingRenames = new Map<string, string>();
+const titleManager = createTitleManager({
+	pendingRenames,
+	runFileTask: saves.run,
+	savePathContent,
+	moveAssociatedAssetFolder,
+	updateMovedLinks,
+	syncPinnedNotes,
+	errorMessage,
+	handleFileError,
+});
 
 type LoadPathOptions = {
 	history?: "push" | "none";
@@ -608,7 +606,7 @@ export function clearPendingTerminalCommand() {
 
 export function clearViewer() {
 	const path = viewerStore.get().currentPath;
-	if (path) stopTitleRenames(path);
+	if (path) titleManager.stop(path);
 	viewerStore.set((state) => emptyDoc(state.lastOpenedPath));
 }
 
@@ -683,8 +681,7 @@ export async function openWorkspace(path?: string) {
 }
 
 export function updateEditorContent(path: string, content: string) {
-	const session = titleSessions.get(path);
-	const currentPath = session?.path ?? path;
+	const currentPath = titleManager.currentPath(path);
 	const current = viewerStore.get();
 	if (current.currentPath !== currentPath || current.content === content)
 		return;
@@ -708,269 +705,11 @@ export function updateEditorContent(path: string, content: string) {
 			error: null,
 		};
 	});
-	if (session) scheduleTitleRename(session, content);
-}
-
-function scheduleTitleRename(session: TitleSession, markdown: string) {
-	session.markdown = markdown;
-	const stem = generatedTitleStem(markdown);
-	const previewPath = stem
-		? joinPath(dirname(session.path) ?? "", `${stem}${extname(session.path)}`)
-		: null;
-	titleGenerationPreviewStore.set(
-		previewPath ? { path: session.path, previewPath } : null,
-	);
-	const pendingTitle = {
-		markdown,
-		path: generatedTitlePath(session.path, markdown),
-	};
-	session.pendingTitle = pendingTitle;
-	void pendingTitle.path.then((previewPath) => {
-		if (
-			session.pendingTitle !== pendingTitle ||
-			titleSessions.get(session.path) !== session
-		) {
-			return;
-		}
-		titleGenerationPreviewStore.set(
-			previewPath ? { path: session.path, previewPath } : null,
-		);
-	});
-	if (session.timer !== undefined) window.clearTimeout(session.timer);
-	session.timer = window.setTimeout(() => {
-		session.timer = undefined;
-		void runTitleRename(session);
-	}, TITLE_RENAME_DELAY_MS);
-}
-
-async function generatedTitlePath(path: string, markdown: string) {
-	const stem = generatedTitleStem(markdown);
-	if (!stem) return null;
-	const parent = dirname(path) ?? "";
-	const extension = extname(path);
-	for (let index = 1; ; index++) {
-		const name = index === 1 ? stem : `${stem}-${index}`;
-		const candidate = joinPath(parent, `${name}${extension}`);
-		if (pathEquals(candidate, path)) return path;
-		if (!(await desktopApi.pathExists(candidate))) return candidate;
-	}
-}
-
-async function runTitleRename(session: TitleSession) {
-	if (session.running || titleSessions.get(session.path) !== session) return;
-	if (viewerStore.get().currentPath !== session.path) {
-		stopTitleRenames(session.path);
-		return;
-	}
-	const markdown = session.markdown;
-	const previousPath = session.path;
-	const nextPath =
-		session.pendingTitle?.markdown === markdown
-			? await session.pendingTitle.path
-			: await generatedTitlePath(previousPath, markdown);
-	if (!isLiveTitleSession(session)) return;
-	if (!nextPath || pathEquals(nextPath, previousPath)) return;
-
-	session.running = true;
-	try {
-		await renameGeneratedFile(session, previousPath, nextPath);
-	} finally {
-		session.running = false;
-	}
-	if (isLiveTitleSession(session) && session.markdown !== markdown) {
-		scheduleTitleRename(session, session.markdown);
-	}
-}
-
-async function renameGeneratedFile(
-	session: TitleSession,
-	previousPath: string,
-	nextPath: string,
-) {
-	const { files: filesBeforeRename, workspacePath } = workspaceStore.get();
-	let renamed = false;
-	let renamedPath = nextPath;
-	await saves.run(previousPath, async () => {
-		if (
-			titleSessions.get(previousPath) !== session ||
-			viewerStore.get().currentPath !== previousPath
-		) {
-			return;
-		}
-		try {
-			const retryPath = await renameGeneratedFileWithRetry(
-				previousPath,
-				nextPath,
-				session.markdown,
-				() =>
-					titleSessions.get(previousPath) === session &&
-					viewerStore.get().currentPath === previousPath,
-			);
-			if (!retryPath) return;
-			renamedPath = retryPath;
-			const movedFiles = [{ fromPath: previousPath, toPath: renamedPath }];
-			publishGeneratedRename(session, previousPath, renamedPath);
-			if (!isLiveTitleSession(session)) stopTitleRenames(renamedPath);
-			renamed = true;
-			const movedAssetFolder = await moveAssociatedAssetFolder(
-				previousPath,
-				renamedPath,
-			);
-			if (movedAssetFolder) movedFiles.push(movedAssetFolder);
-			if (workspacePath) {
-				session.markdown = rewriteMovedLinks({
-					content: session.markdown,
-					filePath: previousPath,
-					nextPath: renamedPath,
-					workspacePath,
-					movedByOldPath: indexMovedFiles(movedFiles),
-				});
-			}
-
-			updateGeneratedContentIfLive(session, session.markdown);
-			await updateMovedLinks(movedFiles, filesBeforeRename);
-			if (workspaceStore.get().pinnedNotes.includes(renamedPath)) {
-				void syncPinnedNotes();
-			}
-		} catch (err) {
-			const message = handleFileError(err);
-			toast.error("Failed to rename file", { description: message });
-		} finally {
-			window.setTimeout(() => pendingRenames.delete(previousPath), 1000);
-		}
-	});
-
-	if (!renamed) return;
-	// Flush link rewrites at the path that won, including retry suffixes.
-	if (isLiveTitleSession(session)) {
-		await savePathContent(renamedPath, session.markdown, { force: true });
-	}
-}
-
-async function renameGeneratedFileWithRetry(
-	previousPath: string,
-	initialNextPath: string,
-	markdown: string,
-	isLive: () => boolean,
-) {
-	let nextPath = initialNextPath;
-	for (let attempt = 0; ; attempt++) {
-		if (!isLive()) return null;
-		try {
-			pendingRenames.set(previousPath, nextPath);
-			await desktopApi.renameFile(previousPath, nextPath);
-			return nextPath;
-		} catch (err) {
-			if (attempt >= 4 || !existingPathErrorPattern.test(errorMessage(err))) {
-				throw err;
-			}
-			const retryPath = await generatedTitlePath(previousPath, markdown);
-			if (!isLive()) return null;
-			if (
-				!retryPath ||
-				pathEquals(retryPath, previousPath) ||
-				pathEquals(retryPath, nextPath)
-			) {
-				throw err;
-			}
-			nextPath = retryPath;
-		}
-	}
-}
-
-function publishGeneratedRename(
-	session: TitleSession,
-	previousPath: string,
-	nextPath: string,
-) {
-	// Keep the prior path for events from the pre-rename render, but drop
-	// older aliases so the session stays bounded.
-	for (const [sessionPath, candidate] of titleSessions) {
-		if (candidate === session && sessionPath !== previousPath) {
-			titleSessions.delete(sessionPath);
-		}
-	}
-	session.path = nextPath;
-	titleSessions.set(nextPath, session);
-	titleGenerationPreviewStore.set({
-		path: nextPath,
-		previewPath: nextPath,
-	});
-	rewriteHistory(previousPath, nextPath);
-	appStore.set((state) => ({
-		...state,
-		workspace: {
-			...state.workspace,
-			files: state.workspace.files.map((file) =>
-				pathEquals(file.path, previousPath)
-					? { ...file, path: nextPath }
-					: file,
-			),
-			pinnedNotes: state.workspace.pinnedNotes.map((path) =>
-				pathEquals(path, previousPath) ? nextPath : path,
-			),
-			lastOpenedPaths: Object.fromEntries(
-				Object.entries(state.workspace.lastOpenedPaths).map(
-					([workspacePath, openedPath]) => [
-						workspacePath,
-						pathEquals(openedPath, previousPath) ? nextPath : openedPath,
-					],
-				),
-			),
-		},
-		document: {
-			...state.document,
-			currentPath: pathEquals(state.document.currentPath ?? "", previousPath)
-				? nextPath
-				: state.document.currentPath,
-			lastOpenedPath: pathEquals(
-				state.document.lastOpenedPath ?? "",
-				previousPath,
-			)
-				? nextPath
-				: state.document.lastOpenedPath,
-		},
-	}));
-}
-
-function isLiveTitleSession(session: TitleSession) {
-	return (
-		titleSessions.get(session.path) === session &&
-		viewerStore.get().currentPath === session.path
-	);
-}
-
-function updateGeneratedContentIfLive(session: TitleSession, content: string) {
-	appStore.set((state) => {
-		if (
-			state.document.currentPath !== session.path ||
-			titleSessions.get(session.path) !== session
-		) {
-			return state;
-		}
-		return {
-			...state,
-			document: {
-				...state.document,
-				content,
-			},
-		};
-	});
-}
-
-function stopTitleRenames(path: string) {
-	const session = titleSessions.get(path);
-	if (!session) return;
-	if (session.timer !== undefined) window.clearTimeout(session.timer);
-	for (const [sessionPath, candidate] of titleSessions) {
-		if (candidate === session) titleSessions.delete(sessionPath);
-	}
-	const preview = titleGenerationPreviewStore.get();
-	if (preview?.path === session.path) titleGenerationPreviewStore.set(null);
+	titleManager.update(path, content);
 }
 
 export function editorDocumentId(path: string) {
-	return titleSessions.get(path)?.documentId ?? path;
+	return titleManager.editorDocumentId(path);
 }
 
 export function setViewerMode(viewMode: ViewMode) {
@@ -1073,7 +812,7 @@ export function savePathContent(
 	content: string,
 	options?: { force?: boolean; throwOnError?: boolean },
 ) {
-	const currentPath = titleSessions.get(path)?.path ?? path;
+	const currentPath = titleManager.currentPath(path);
 	return saves.run(currentPath, () =>
 		savePathContentNow(currentPath, content, options),
 	);
@@ -1093,7 +832,7 @@ const deletionActions = createDeleteActions({
 	refreshFileList,
 	loadPath,
 	syncPins: syncPinnedNotes,
-	stopTitleRenames,
+	stopTitleRenames: titleManager.stop,
 	handleError: handleFileError,
 });
 
@@ -1108,7 +847,7 @@ export const {
 export async function renameMarkdownFile(path: string, nextName: string) {
 	const currentExt = extname(path);
 	if (renameStem(nextName, currentExt) !== fileStem(path)) {
-		stopTitleRenames(path);
+		titleManager.stop(path);
 	}
 	const current = viewerStore.get();
 	const isCurrentFile = current.currentPath === path;
@@ -1442,12 +1181,7 @@ async function createEmptyFileInFolder(
 	try {
 		await desktopApi.writeFileText(path, "");
 		if (extension === ".md") {
-			titleSessions.set(path, {
-				path,
-				documentId: path,
-				markdown: "",
-				running: false,
-			});
+			titleManager.start(path);
 		}
 		const modified_at = Math.floor(Date.now() / 1000);
 		workspaceStore.set((state) => ({
@@ -1461,7 +1195,7 @@ async function createEmptyFileInFolder(
 		await refreshFileList();
 		return path;
 	} catch (err) {
-		stopTitleRenames(path);
+		titleManager.stop(path);
 		const message = handleFileError(err);
 		toast.error("Failed to create file", { description: message });
 		return null;
@@ -1556,7 +1290,7 @@ const { run: loadInternalPath, invalidate: invalidateLoadPath } = takeLatest(
 			if (isStale()) return;
 			const currentPath = viewerStore.get().currentPath;
 			if (currentPath && !pathEquals(currentPath, path)) {
-				stopTitleRenames(currentPath);
+				titleManager.stop(currentPath);
 			}
 			appStore.set((state) => withOpenedDoc(state, path, content));
 			if (historyMode === "push") pushHistory(path);

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -606,6 +606,8 @@ export function clearPendingTerminalCommand() {
 }
 
 export function clearViewer() {
+	const path = viewerStore.get().currentPath;
+	if (path) stopTitleRenames(path);
 	viewerStore.set((state) => emptyDoc(state.lastOpenedPath));
 }
 
@@ -755,6 +757,10 @@ async function generatedTitlePath(path: string, markdown: string) {
 
 async function runTitleRename(session: TitleSession) {
 	if (session.running || titleSessions.get(session.path) !== session) return;
+	if (viewerStore.get().currentPath !== session.path) {
+		stopTitleRenames(session.path);
+		return;
+	}
 	const markdown = session.markdown;
 	const previousPath = session.path;
 	const nextPath =
@@ -807,8 +813,13 @@ async function renameGeneratedFile(
 				});
 			}
 
-			// Add the new path before publishing it. The next React
-			// render can then retain this note's editor identity.
+			// Keep the prior path for events from the pre-rename render, but drop
+			// older aliases so the session stays bounded.
+			for (const [sessionPath, candidate] of titleSessions) {
+				if (candidate === session && sessionPath !== previousPath) {
+					titleSessions.delete(sessionPath);
+				}
+			}
 			session.path = nextPath;
 			titleSessions.set(nextPath, session);
 			titleGenerationPreviewStore.set({
@@ -982,7 +993,10 @@ export function savePathContent(
 	content: string,
 	options?: { force?: boolean; throwOnError?: boolean },
 ) {
-	return saves.run(path, () => savePathContentNow(path, content, options));
+	const currentPath = titleSessions.get(path)?.path ?? path;
+	return saves.run(currentPath, () =>
+		savePathContentNow(currentPath, content, options),
+	);
 }
 
 const deletionActions = createDeleteActions({
@@ -1459,6 +1473,10 @@ const { run: loadInternalPath, invalidate: invalidateLoadPath } = takeLatest(
 				content = await desktopApi.readFileText(path);
 			}
 			if (isStale()) return;
+			const currentPath = viewerStore.get().currentPath;
+			if (currentPath && !pathEquals(currentPath, path)) {
+				stopTitleRenames(currentPath);
+			}
 			appStore.set((state) => withOpenedDoc(state, path, content));
 			if (historyMode === "push") pushHistory(path);
 		} catch (err) {

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -768,6 +768,7 @@ async function runTitleRename(session: TitleSession) {
 		session.pendingTitle?.markdown === markdown
 			? await session.pendingTitle.path
 			: await generatedTitlePath(previousPath, markdown);
+	if (!isLiveTitleSession(session)) return;
 	if (!nextPath || pathEquals(nextPath, previousPath)) return;
 
 	session.running = true;
@@ -776,7 +777,7 @@ async function runTitleRename(session: TitleSession) {
 	} finally {
 		session.running = false;
 	}
-	if (session.markdown !== markdown) {
+	if (isLiveTitleSession(session) && session.markdown !== markdown) {
 		scheduleTitleRename(session, session.markdown);
 	}
 }
@@ -797,13 +798,19 @@ async function renameGeneratedFile(
 			return;
 		}
 		try {
-			renamedPath = await renameGeneratedFileWithRetry(
+			const retryPath = await renameGeneratedFileWithRetry(
 				previousPath,
 				nextPath,
 				session.markdown,
+				() =>
+					titleSessions.get(previousPath) === session &&
+					viewerStore.get().currentPath === previousPath,
 			);
+			if (!retryPath) return;
+			renamedPath = retryPath;
 			const movedFiles = [{ fromPath: previousPath, toPath: renamedPath }];
 			publishGeneratedRename(session, previousPath, renamedPath);
+			if (!isLiveTitleSession(session)) stopTitleRenames(renamedPath);
 			renamed = true;
 			const movedAssetFolder = await moveAssociatedAssetFolder(
 				previousPath,
@@ -820,13 +827,7 @@ async function renameGeneratedFile(
 				});
 			}
 
-			appStore.set((state) => ({
-				...state,
-				document: {
-					...state.document,
-					content: session.markdown,
-				},
-			}));
+			updateGeneratedContentIfLive(session, session.markdown);
 			await updateMovedLinks(movedFiles, filesBeforeRename);
 			if (workspaceStore.get().pinnedNotes.includes(renamedPath)) {
 				void syncPinnedNotes();
@@ -841,16 +842,20 @@ async function renameGeneratedFile(
 
 	if (!renamed) return;
 	// Flush link rewrites at the path that won, including retry suffixes.
-	await savePathContent(renamedPath, session.markdown, { force: true });
+	if (isLiveTitleSession(session)) {
+		await savePathContent(renamedPath, session.markdown, { force: true });
+	}
 }
 
 async function renameGeneratedFileWithRetry(
 	previousPath: string,
 	initialNextPath: string,
 	markdown: string,
+	isLive: () => boolean,
 ) {
 	let nextPath = initialNextPath;
 	for (let attempt = 0; ; attempt++) {
+		if (!isLive()) return null;
 		try {
 			pendingRenames.set(previousPath, nextPath);
 			await desktopApi.renameFile(previousPath, nextPath);
@@ -860,6 +865,7 @@ async function renameGeneratedFileWithRetry(
 				throw err;
 			}
 			const retryPath = await generatedTitlePath(previousPath, markdown);
+			if (!isLive()) return null;
 			if (
 				!retryPath ||
 				pathEquals(retryPath, previousPath) ||
@@ -925,6 +931,31 @@ function publishGeneratedRename(
 				: state.document.lastOpenedPath,
 		},
 	}));
+}
+
+function isLiveTitleSession(session: TitleSession) {
+	return (
+		titleSessions.get(session.path) === session &&
+		viewerStore.get().currentPath === session.path
+	);
+}
+
+function updateGeneratedContentIfLive(session: TitleSession, content: string) {
+	appStore.set((state) => {
+		if (
+			state.document.currentPath !== session.path ||
+			titleSessions.get(session.path) !== session
+		) {
+			return state;
+		}
+		return {
+			...state,
+			document: {
+				...state.document,
+				content,
+			},
+		};
+	});
 }
 
 function stopTitleRenames(path: string) {

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -16,6 +16,7 @@ import {
 	dirname,
 	extname,
 	fileKindForPath,
+	fileStem,
 	hasMarkdownExtension,
 	isCodeFile,
 	isEditableFile,
@@ -34,6 +35,7 @@ import {
 	pathAfterMove,
 	rewriteMovedLinks,
 } from "../lib/markdownLinkRewrite";
+import { generatedTitleStem } from "../lib/titleGeneration";
 import {
 	setThemePreference as applyThemePreference,
 	initTheme,
@@ -72,6 +74,7 @@ import {
 	sidebarOpenStore,
 	switcherOpenStore,
 	themePreferenceStore,
+	titleGenerationPreviewStore,
 	uiStore,
 	type ViewMode,
 	viewerStore,
@@ -95,6 +98,15 @@ const workspaceSidebarQueues = new Map<string, Promise<void>>();
 // conflict; it is just the disk baseline catching up to a save we started.
 const selfSaves = new Map<string, Map<string, number>>();
 const saves = keyedQueue<string>();
+const TITLE_RENAME_DELAY_MS = 500;
+type TitleSession = {
+	path: string;
+	documentId: string;
+	markdown: string;
+	timer?: number;
+	running: boolean;
+};
+const titleSessions = new Map<string, TitleSession>();
 
 type SidebarMoveItem =
 	| { kind: "file"; path: string }
@@ -689,6 +701,145 @@ export function updateEditorContent(path: string, content: string) {
 			error: null,
 		};
 	});
+	scheduleTitleRename(path, content);
+}
+
+function scheduleTitleRename(path: string, markdown: string) {
+	const session = titleSessions.get(path);
+	if (!session) return;
+	session.markdown = markdown;
+	const stem = generatedTitleStem(markdown);
+	const previewPath = stem
+		? joinPath(dirname(session.path) ?? "", `${stem}${extname(session.path)}`)
+		: null;
+	titleGenerationPreviewStore.set(
+		previewPath ? { path: session.path, previewPath } : null,
+	);
+	if (session.timer !== undefined) window.clearTimeout(session.timer);
+	session.timer = window.setTimeout(() => {
+		session.timer = undefined;
+		void runTitleRename(session);
+	}, TITLE_RENAME_DELAY_MS);
+}
+
+async function generatedTitlePath(path: string, markdown: string) {
+	const stem = generatedTitleStem(markdown);
+	if (!stem) return null;
+	const parent = dirname(path) ?? "";
+	const extension = extname(path);
+	for (let index = 1; ; index++) {
+		const name = index === 1 ? stem : `${stem}-${index}`;
+		const candidate = joinPath(parent, `${name}${extension}`);
+		if (pathEquals(candidate, path)) return path;
+		if (!(await desktopApi.pathExists(candidate))) return candidate;
+	}
+}
+
+async function runTitleRename(session: TitleSession) {
+	if (session.running || titleSessions.get(session.path) !== session) return;
+	const markdown = session.markdown;
+	const previousPath = session.path;
+	const nextPath = await generatedTitlePath(previousPath, markdown);
+	if (!nextPath || pathEquals(nextPath, previousPath)) return;
+
+	session.running = true;
+	try {
+		await renameGeneratedFile(session, previousPath, nextPath);
+	} finally {
+		session.running = false;
+	}
+	if (session.markdown !== markdown) {
+		scheduleTitleRename(session.path, session.markdown);
+	}
+}
+
+async function renameGeneratedFile(
+	session: TitleSession,
+	previousPath: string,
+	nextPath: string,
+) {
+	let renamed = false;
+	await saves.run(previousPath, async () => {
+		if (
+			titleSessions.get(previousPath) !== session ||
+			viewerStore.get().currentPath !== previousPath
+		) {
+			return;
+		}
+		try {
+			pendingRenames.set(previousPath, nextPath);
+			await desktopApi.renameFile(previousPath, nextPath);
+
+			// Migrate the session before publishing the new path. The next React
+			// render can then retain this note's editor identity.
+			titleSessions.delete(previousPath);
+			session.path = nextPath;
+			titleSessions.set(nextPath, session);
+			titleGenerationPreviewStore.set({
+				path: nextPath,
+				previewPath: nextPath,
+			});
+			rewriteHistory(previousPath, nextPath);
+			const wasPinned = workspaceStore.get().pinnedNotes.includes(previousPath);
+			appStore.set((state) => ({
+				...state,
+				workspace: {
+					...state.workspace,
+					files: state.workspace.files.map((file) =>
+						pathEquals(file.path, previousPath)
+							? { ...file, path: nextPath }
+							: file,
+					),
+					pinnedNotes: state.workspace.pinnedNotes.map((path) =>
+						pathEquals(path, previousPath) ? nextPath : path,
+					),
+					lastOpenedPaths: Object.fromEntries(
+						Object.entries(state.workspace.lastOpenedPaths).map(
+							([workspacePath, openedPath]) => [
+								workspacePath,
+								pathEquals(openedPath, previousPath) ? nextPath : openedPath,
+							],
+						),
+					),
+				},
+				document: {
+					...state.document,
+					currentPath: nextPath,
+					lastOpenedPath: pathEquals(
+						state.document.lastOpenedPath ?? "",
+						previousPath,
+					)
+						? nextPath
+						: state.document.lastOpenedPath,
+				},
+			}));
+			renamed = true;
+			if (wasPinned) void syncPinnedNotes();
+		} catch (err) {
+			const message = handleFileError(err);
+			toast.error("Failed to rename file", { description: message });
+		} finally {
+			window.setTimeout(() => pendingRenames.delete(previousPath), 1000);
+		}
+	});
+
+	if (!renamed) return;
+	// Write the newest body after the move. Old-path saves queued during the move
+	// now fail their current-path guard instead of recreating the old file.
+	await savePathContent(nextPath, session.markdown, { force: true });
+}
+
+function stopTitleRenames(path: string) {
+	const session = titleSessions.get(path);
+	if (!session) return;
+	if (session.timer !== undefined) window.clearTimeout(session.timer);
+	titleSessions.delete(path);
+	const preview = titleGenerationPreviewStore.get();
+	if (preview?.path === path) titleGenerationPreviewStore.set(null);
+}
+
+export function editorDocumentId(path: string) {
+	return titleSessions.get(path)?.documentId ?? path;
 }
 
 export function setViewerMode(viewMode: ViewMode) {
@@ -820,6 +971,10 @@ export const {
 } = deletionActions;
 
 export async function renameMarkdownFile(path: string, nextName: string) {
+	const currentExt = extname(path);
+	if (renameStem(nextName, currentExt) !== fileStem(path)) {
+		stopTitleRenames(path);
+	}
 	const current = viewerStore.get();
 	const isCurrentFile = current.currentPath === path;
 	const { files: filesBeforeRename, workspacePath } = workspaceStore.get();
@@ -830,13 +985,7 @@ export async function renameMarkdownFile(path: string, nextName: string) {
 	const parent = dirname(path);
 	if (!parent) return;
 
-	const currentExt = extname(path);
-	const proposedExt = extname(trimmedName);
-	const proposedStem =
-		proposedExt.length > 0 &&
-		proposedExt.toLocaleLowerCase() === currentExt.toLocaleLowerCase()
-			? trimmedName.slice(0, -proposedExt.length)
-			: trimmedName;
+	const proposedStem = renameStem(trimmedName, currentExt);
 	const nextNameWithExt = `${proposedStem}${currentExt}`;
 	// Slash paths are relative to the current file's folder, matching sidebar
 	// rename behavior for nested notes.
@@ -899,6 +1048,15 @@ export async function renameMarkdownFile(path: string, nextName: string) {
 	} finally {
 		window.setTimeout(() => pendingRenames.delete(path), 1000);
 	}
+}
+
+function renameStem(name: string, currentExt: string) {
+	const trimmed = name.trim();
+	const proposedExt = extname(trimmed);
+	return proposedExt.length > 0 &&
+		proposedExt.toLocaleLowerCase() === currentExt.toLocaleLowerCase()
+		? trimmed.slice(0, -proposedExt.length)
+		: trimmed;
 }
 
 export async function renameCurrentMarkdownFile(nextName: string) {
@@ -1148,6 +1306,14 @@ async function createEmptyFileInFolder(
 	const path = uniqueFilePath(parentPath, stem, extension);
 	try {
 		await desktopApi.writeFileText(path, "");
+		if (extension === ".md") {
+			titleSessions.set(path, {
+				path,
+				documentId: path,
+				markdown: "",
+				running: false,
+			});
+		}
 		const modified_at = Math.floor(Date.now() / 1000);
 		workspaceStore.set((state) => ({
 			...state,
@@ -1160,6 +1326,7 @@ async function createEmptyFileInFolder(
 		await refreshFileList();
 		return path;
 	} catch (err) {
+		stopTitleRenames(path);
 		const message = handleFileError(err);
 		toast.error("Failed to create file", { description: message });
 		return null;

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -86,6 +86,7 @@ import { applyWorkspaceDelta } from "./workspaceDelta";
 const REFRESH_FILES_DEBOUNCE_MS = 250;
 const SELF_SAVE_TTL_MS = 5000;
 const missingPathErrorPattern = /\bENOENT\b|\bENOTDIR\b/;
+const existingPathErrorPattern = /\bEEXIST\b|\balready exists\b/i;
 let refreshFilesTimer: ReturnType<typeof setTimeout> | null = null;
 type RefreshRun = {
 	reloadActive: boolean;
@@ -787,6 +788,7 @@ async function renameGeneratedFile(
 ) {
 	const { files: filesBeforeRename, workspacePath } = workspaceStore.get();
 	let renamed = false;
+	let renamedPath = nextPath;
 	await saves.run(previousPath, async () => {
 		if (
 			titleSessions.get(previousPath) !== session ||
@@ -795,75 +797,40 @@ async function renameGeneratedFile(
 			return;
 		}
 		try {
-			pendingRenames.set(previousPath, nextPath);
-			await desktopApi.renameFile(previousPath, nextPath);
-			const movedFiles = [{ fromPath: previousPath, toPath: nextPath }];
-			const movedAssetFolder = await moveAssociatedAssetFolder(
+			renamedPath = await renameGeneratedFileWithRetry(
 				previousPath,
 				nextPath,
+				session.markdown,
+			);
+			const movedFiles = [{ fromPath: previousPath, toPath: renamedPath }];
+			publishGeneratedRename(session, previousPath, renamedPath);
+			renamed = true;
+			const movedAssetFolder = await moveAssociatedAssetFolder(
+				previousPath,
+				renamedPath,
 			);
 			if (movedAssetFolder) movedFiles.push(movedAssetFolder);
 			if (workspacePath) {
 				session.markdown = rewriteMovedLinks({
 					content: session.markdown,
 					filePath: previousPath,
-					nextPath,
+					nextPath: renamedPath,
 					workspacePath,
 					movedByOldPath: indexMovedFiles(movedFiles),
 				});
 			}
 
-			// Keep the prior path for events from the pre-rename render, but drop
-			// older aliases so the session stays bounded.
-			for (const [sessionPath, candidate] of titleSessions) {
-				if (candidate === session && sessionPath !== previousPath) {
-					titleSessions.delete(sessionPath);
-				}
-			}
-			session.path = nextPath;
-			titleSessions.set(nextPath, session);
-			titleGenerationPreviewStore.set({
-				path: nextPath,
-				previewPath: nextPath,
-			});
-			rewriteHistory(previousPath, nextPath);
-			const wasPinned = workspaceStore.get().pinnedNotes.includes(previousPath);
 			appStore.set((state) => ({
 				...state,
-				workspace: {
-					...state.workspace,
-					files: state.workspace.files.map((file) =>
-						pathEquals(file.path, previousPath)
-							? { ...file, path: nextPath }
-							: file,
-					),
-					pinnedNotes: state.workspace.pinnedNotes.map((path) =>
-						pathEquals(path, previousPath) ? nextPath : path,
-					),
-					lastOpenedPaths: Object.fromEntries(
-						Object.entries(state.workspace.lastOpenedPaths).map(
-							([workspacePath, openedPath]) => [
-								workspacePath,
-								pathEquals(openedPath, previousPath) ? nextPath : openedPath,
-							],
-						),
-					),
-				},
 				document: {
 					...state.document,
-					currentPath: nextPath,
 					content: session.markdown,
-					lastOpenedPath: pathEquals(
-						state.document.lastOpenedPath ?? "",
-						previousPath,
-					)
-						? nextPath
-						: state.document.lastOpenedPath,
 				},
 			}));
 			await updateMovedLinks(movedFiles, filesBeforeRename);
-			renamed = true;
-			if (wasPinned) void syncPinnedNotes();
+			if (workspaceStore.get().pinnedNotes.includes(renamedPath)) {
+				void syncPinnedNotes();
+			}
 		} catch (err) {
 			const message = handleFileError(err);
 			toast.error("Failed to rename file", { description: message });
@@ -873,9 +840,91 @@ async function renameGeneratedFile(
 	});
 
 	if (!renamed) return;
-	// Write the newest body after the move. Old-path saves queued during the move
-	// now fail their current-path guard instead of recreating the old file.
-	await savePathContent(nextPath, session.markdown, { force: true });
+	// Flush link rewrites at the path that won, including retry suffixes.
+	await savePathContent(renamedPath, session.markdown, { force: true });
+}
+
+async function renameGeneratedFileWithRetry(
+	previousPath: string,
+	initialNextPath: string,
+	markdown: string,
+) {
+	let nextPath = initialNextPath;
+	for (let attempt = 0; ; attempt++) {
+		try {
+			pendingRenames.set(previousPath, nextPath);
+			await desktopApi.renameFile(previousPath, nextPath);
+			return nextPath;
+		} catch (err) {
+			if (attempt >= 4 || !existingPathErrorPattern.test(errorMessage(err))) {
+				throw err;
+			}
+			const retryPath = await generatedTitlePath(previousPath, markdown);
+			if (
+				!retryPath ||
+				pathEquals(retryPath, previousPath) ||
+				pathEquals(retryPath, nextPath)
+			) {
+				throw err;
+			}
+			nextPath = retryPath;
+		}
+	}
+}
+
+function publishGeneratedRename(
+	session: TitleSession,
+	previousPath: string,
+	nextPath: string,
+) {
+	// Keep the prior path for events from the pre-rename render, but drop
+	// older aliases so the session stays bounded.
+	for (const [sessionPath, candidate] of titleSessions) {
+		if (candidate === session && sessionPath !== previousPath) {
+			titleSessions.delete(sessionPath);
+		}
+	}
+	session.path = nextPath;
+	titleSessions.set(nextPath, session);
+	titleGenerationPreviewStore.set({
+		path: nextPath,
+		previewPath: nextPath,
+	});
+	rewriteHistory(previousPath, nextPath);
+	appStore.set((state) => ({
+		...state,
+		workspace: {
+			...state.workspace,
+			files: state.workspace.files.map((file) =>
+				pathEquals(file.path, previousPath)
+					? { ...file, path: nextPath }
+					: file,
+			),
+			pinnedNotes: state.workspace.pinnedNotes.map((path) =>
+				pathEquals(path, previousPath) ? nextPath : path,
+			),
+			lastOpenedPaths: Object.fromEntries(
+				Object.entries(state.workspace.lastOpenedPaths).map(
+					([workspacePath, openedPath]) => [
+						workspacePath,
+						pathEquals(openedPath, previousPath) ? nextPath : openedPath,
+					],
+				),
+			),
+		},
+		document: {
+			...state.document,
+			currentPath: pathEquals(state.document.currentPath ?? "", previousPath)
+				? nextPath
+				: state.document.currentPath,
+			lastOpenedPath: pathEquals(
+				state.document.lastOpenedPath ?? "",
+				previousPath,
+			)
+				? nextPath
+				: state.document.lastOpenedPath,
+		},
+	}));
 }
 
 function stopTitleRenames(path: string) {
@@ -1013,6 +1062,7 @@ const deletionActions = createDeleteActions({
 	refreshFileList,
 	loadPath,
 	syncPins: syncPinnedNotes,
+	stopTitleRenames,
 	handleError: handleFileError,
 });
 

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -758,6 +758,7 @@ async function renameGeneratedFile(
 	previousPath: string,
 	nextPath: string,
 ) {
+	const { files: filesBeforeRename, workspacePath } = workspaceStore.get();
 	let renamed = false;
 	await saves.run(previousPath, async () => {
 		if (
@@ -769,6 +770,21 @@ async function renameGeneratedFile(
 		try {
 			pendingRenames.set(previousPath, nextPath);
 			await desktopApi.renameFile(previousPath, nextPath);
+			const movedFiles = [{ fromPath: previousPath, toPath: nextPath }];
+			const movedAssetFolder = await moveAssociatedAssetFolder(
+				previousPath,
+				nextPath,
+			);
+			if (movedAssetFolder) movedFiles.push(movedAssetFolder);
+			if (workspacePath) {
+				session.markdown = rewriteMovedLinks({
+					content: session.markdown,
+					filePath: previousPath,
+					nextPath,
+					workspacePath,
+					movedByOldPath: indexMovedFiles(movedFiles),
+				});
+			}
 
 			// Migrate the session before publishing the new path. The next React
 			// render can then retain this note's editor identity.
@@ -805,6 +821,7 @@ async function renameGeneratedFile(
 				document: {
 					...state.document,
 					currentPath: nextPath,
+					content: session.markdown,
 					lastOpenedPath: pathEquals(
 						state.document.lastOpenedPath ?? "",
 						previousPath,
@@ -813,6 +830,7 @@ async function renameGeneratedFile(
 						: state.document.lastOpenedPath,
 				},
 			}));
+			await updateMovedLinks(movedFiles, filesBeforeRename);
 			renamed = true;
 			if (wasPinned) void syncPinnedNotes();
 		} catch (err) {

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -103,6 +103,7 @@ type TitleSession = {
 	path: string;
 	documentId: string;
 	markdown: string;
+	pendingTitle?: { markdown: string; path: Promise<string | null> };
 	timer?: number;
 	running: boolean;
 };
@@ -679,12 +680,15 @@ export async function openWorkspace(path?: string) {
 }
 
 export function updateEditorContent(path: string, content: string) {
+	const session = titleSessions.get(path);
+	const currentPath = session?.path ?? path;
 	const current = viewerStore.get();
-	if (current.currentPath !== path || current.content === content) return;
+	if (current.currentPath !== currentPath || current.content === content)
+		return;
 	void expireDeleteUndo();
 
 	viewerStore.set((state) => {
-		if (state.currentPath !== path) return state;
+		if (state.currentPath !== currentPath) return state;
 		if (
 			state.externalChange.kind === "conflict" &&
 			content === state.externalChange.diskContent
@@ -701,12 +705,10 @@ export function updateEditorContent(path: string, content: string) {
 			error: null,
 		};
 	});
-	scheduleTitleRename(path, content);
+	if (session) scheduleTitleRename(session, content);
 }
 
-function scheduleTitleRename(path: string, markdown: string) {
-	const session = titleSessions.get(path);
-	if (!session) return;
+function scheduleTitleRename(session: TitleSession, markdown: string) {
 	session.markdown = markdown;
 	const stem = generatedTitleStem(markdown);
 	const previewPath = stem
@@ -715,6 +717,22 @@ function scheduleTitleRename(path: string, markdown: string) {
 	titleGenerationPreviewStore.set(
 		previewPath ? { path: session.path, previewPath } : null,
 	);
+	const pendingTitle = {
+		markdown,
+		path: generatedTitlePath(session.path, markdown),
+	};
+	session.pendingTitle = pendingTitle;
+	void pendingTitle.path.then((previewPath) => {
+		if (
+			session.pendingTitle !== pendingTitle ||
+			titleSessions.get(session.path) !== session
+		) {
+			return;
+		}
+		titleGenerationPreviewStore.set(
+			previewPath ? { path: session.path, previewPath } : null,
+		);
+	});
 	if (session.timer !== undefined) window.clearTimeout(session.timer);
 	session.timer = window.setTimeout(() => {
 		session.timer = undefined;
@@ -739,7 +757,10 @@ async function runTitleRename(session: TitleSession) {
 	if (session.running || titleSessions.get(session.path) !== session) return;
 	const markdown = session.markdown;
 	const previousPath = session.path;
-	const nextPath = await generatedTitlePath(previousPath, markdown);
+	const nextPath =
+		session.pendingTitle?.markdown === markdown
+			? await session.pendingTitle.path
+			: await generatedTitlePath(previousPath, markdown);
 	if (!nextPath || pathEquals(nextPath, previousPath)) return;
 
 	session.running = true;
@@ -749,7 +770,7 @@ async function runTitleRename(session: TitleSession) {
 		session.running = false;
 	}
 	if (session.markdown !== markdown) {
-		scheduleTitleRename(session.path, session.markdown);
+		scheduleTitleRename(session, session.markdown);
 	}
 }
 
@@ -786,9 +807,8 @@ async function renameGeneratedFile(
 				});
 			}
 
-			// Migrate the session before publishing the new path. The next React
+			// Add the new path before publishing it. The next React
 			// render can then retain this note's editor identity.
-			titleSessions.delete(previousPath);
 			session.path = nextPath;
 			titleSessions.set(nextPath, session);
 			titleGenerationPreviewStore.set({
@@ -851,9 +871,11 @@ function stopTitleRenames(path: string) {
 	const session = titleSessions.get(path);
 	if (!session) return;
 	if (session.timer !== undefined) window.clearTimeout(session.timer);
-	titleSessions.delete(path);
+	for (const [sessionPath, candidate] of titleSessions) {
+		if (candidate === session) titleSessions.delete(sessionPath);
+	}
 	const preview = titleGenerationPreviewStore.get();
-	if (preview?.path === path) titleGenerationPreviewStore.set(null);
+	if (preview?.path === session.path) titleGenerationPreviewStore.set(null);
 }
 
 export function editorDocumentId(path: string) {

--- a/apps/desktop/src/store/deleteActions.ts
+++ b/apps/desktop/src/store/deleteActions.ts
@@ -37,6 +37,7 @@ type DeleteDeps = {
 		options: { history: "none"; launchExternal: false },
 	) => Promise<void>;
 	syncPins: () => Promise<void>;
+	stopTitleRenames: (path: string) => void;
 	handleError: (error: unknown) => string;
 };
 
@@ -210,6 +211,8 @@ export function createDeleteActions(deps: DeleteDeps) {
 			),
 		);
 		if (deletedCurrent) {
+			if (viewerBefore.currentPath)
+				deps.stopTitleRenames(viewerBefore.currentPath);
 			clearHistory();
 		} else {
 			for (const item of items) {
@@ -300,8 +303,10 @@ export function createDeleteActions(deps: DeleteDeps) {
 	) => {
 		try {
 			await desktopApi.deleteFile(path);
-			if (viewerStore.get().currentPath === path) clearHistory();
-			else pruneHistory(path);
+			if (viewerStore.get().currentPath === path) {
+				deps.stopTitleRenames(path);
+				clearHistory();
+			} else pruneHistory(path);
 			appStore.set((state) => ({
 				...state,
 				workspace: {

--- a/apps/desktop/src/store/state.ts
+++ b/apps/desktop/src/store/state.ts
@@ -168,6 +168,12 @@ export const historyStore = store<HistoryState>({
 // Derived from the open document, so it stays out of the persisted app store
 export const reviewThreadsStore = store<ReviewThread[]>([]);
 
+// Keep title previews out of appStore so they do not survive a relaunch.
+export const titleGenerationPreviewStore = store<{
+	path: string;
+	previewPath: string;
+} | null>(null);
+
 export const workspaceStore = appStore.select("workspace");
 export const viewerStore = appStore.select("document");
 export const uiStore = appStore.select("ui");

--- a/apps/desktop/src/store/titleManagement.ts
+++ b/apps/desktop/src/store/titleManagement.ts
@@ -1,0 +1,343 @@
+import { toast } from "sonner";
+import { desktopApi } from "../desktopApi";
+import { dirname, extname, joinPath, pathEquals } from "../lib/filePath";
+import {
+	indexMovedFiles,
+	type MovedFile,
+	rewriteMovedLinks,
+} from "../lib/markdownLinkRewrite";
+import { generatedTitleStem } from "../lib/titleGeneration";
+import { rewriteHistory } from "./history";
+import {
+	appStore,
+	type FileEntry,
+	titleGenerationPreviewStore,
+	viewerStore,
+	workspaceStore,
+} from "./state";
+
+const TITLE_RENAME_DELAY_MS = 500;
+const existingPathErrorPattern = /\bEEXIST\b|\balready exists\b/i;
+
+type TitleSession = {
+	path: string;
+	documentId: string;
+	markdown: string;
+	pendingTitle?: { markdown: string; path: Promise<string | null> };
+	timer?: number;
+	running: boolean;
+};
+
+type SaveOptions = { force?: boolean; throwOnError?: boolean };
+
+type TitleManagerDeps = {
+	pendingRenames: Map<string, string>;
+	runFileTask: (path: string, task: () => Promise<void>) => Promise<void>;
+	savePathContent: (
+		path: string,
+		content: string,
+		options?: SaveOptions,
+	) => Promise<void>;
+	moveAssociatedAssetFolder: (
+		fromFilePath: string,
+		toFilePath: string,
+	) => Promise<MovedFile | null>;
+	updateMovedLinks: (
+		movedFiles: MovedFile[],
+		files: FileEntry[],
+	) => Promise<void>;
+	syncPinnedNotes: () => Promise<void>;
+	errorMessage: (err: unknown) => string;
+	handleFileError: (err: unknown) => string;
+};
+
+export function createTitleManager(deps: TitleManagerDeps) {
+	const sessions = new Map<string, TitleSession>();
+
+	function start(path: string) {
+		sessions.set(path, {
+			path,
+			documentId: path,
+			markdown: "",
+			running: false,
+		});
+	}
+
+	function stop(path: string) {
+		const session = sessions.get(path);
+		if (!session) return;
+		if (session.timer !== undefined) window.clearTimeout(session.timer);
+		for (const [sessionPath, candidate] of sessions) {
+			if (candidate === session) sessions.delete(sessionPath);
+		}
+		const preview = titleGenerationPreviewStore.get();
+		if (preview?.path === session.path) titleGenerationPreviewStore.set(null);
+	}
+
+	function currentPath(path: string) {
+		return sessions.get(path)?.path ?? path;
+	}
+
+	function editorDocumentId(path: string) {
+		return sessions.get(path)?.documentId ?? path;
+	}
+
+	function update(path: string, markdown: string) {
+		const session = sessions.get(path);
+		if (session) schedule(session, markdown);
+	}
+
+	function schedule(session: TitleSession, markdown: string) {
+		session.markdown = markdown;
+		const stem = generatedTitleStem(markdown);
+		const previewPath = stem
+			? joinPath(dirname(session.path) ?? "", `${stem}${extname(session.path)}`)
+			: null;
+		titleGenerationPreviewStore.set(
+			previewPath ? { path: session.path, previewPath } : null,
+		);
+		const pendingTitle = {
+			markdown,
+			path: generatedTitlePath(session.path, markdown),
+		};
+		session.pendingTitle = pendingTitle;
+		void pendingTitle.path.then((previewPath) => {
+			if (
+				session.pendingTitle !== pendingTitle ||
+				sessions.get(session.path) !== session
+			) {
+				return;
+			}
+			titleGenerationPreviewStore.set(
+				previewPath ? { path: session.path, previewPath } : null,
+			);
+		});
+		if (session.timer !== undefined) window.clearTimeout(session.timer);
+		session.timer = window.setTimeout(() => {
+			session.timer = undefined;
+			void run(session);
+		}, TITLE_RENAME_DELAY_MS);
+	}
+
+	async function generatedTitlePath(path: string, markdown: string) {
+		const stem = generatedTitleStem(markdown);
+		if (!stem) return null;
+		const parent = dirname(path) ?? "";
+		const extension = extname(path);
+		for (let index = 1; ; index++) {
+			const name = index === 1 ? stem : `${stem}-${index}`;
+			const candidate = joinPath(parent, `${name}${extension}`);
+			if (pathEquals(candidate, path)) return path;
+			if (!(await desktopApi.pathExists(candidate))) return candidate;
+		}
+	}
+
+	async function run(session: TitleSession) {
+		if (session.running || sessions.get(session.path) !== session) return;
+		if (viewerStore.get().currentPath !== session.path) {
+			stop(session.path);
+			return;
+		}
+		const markdown = session.markdown;
+		const previousPath = session.path;
+		const nextPath =
+			session.pendingTitle?.markdown === markdown
+				? await session.pendingTitle.path
+				: await generatedTitlePath(previousPath, markdown);
+		if (!isLive(session)) return;
+		if (!nextPath || pathEquals(nextPath, previousPath)) return;
+
+		session.running = true;
+		try {
+			await renameGeneratedFile(session, previousPath, nextPath);
+		} finally {
+			session.running = false;
+		}
+		if (isLive(session) && session.markdown !== markdown) {
+			schedule(session, session.markdown);
+		}
+	}
+
+	async function renameGeneratedFile(
+		session: TitleSession,
+		previousPath: string,
+		nextPath: string,
+	) {
+		const { files: filesBeforeRename, workspacePath } = workspaceStore.get();
+		let renamed = false;
+		let renamedPath = nextPath;
+		await deps.runFileTask(previousPath, async () => {
+			if (
+				sessions.get(previousPath) !== session ||
+				viewerStore.get().currentPath !== previousPath
+			) {
+				return;
+			}
+			try {
+				const retryPath = await renameGeneratedFileWithRetry(
+					previousPath,
+					nextPath,
+					session.markdown,
+					() =>
+						sessions.get(previousPath) === session &&
+						viewerStore.get().currentPath === previousPath,
+				);
+				if (!retryPath) return;
+				renamedPath = retryPath;
+				const movedFiles = [{ fromPath: previousPath, toPath: renamedPath }];
+				publishRename(session, previousPath, renamedPath);
+				if (!isLive(session)) stop(renamedPath);
+				renamed = true;
+				const movedAssetFolder = await deps.moveAssociatedAssetFolder(
+					previousPath,
+					renamedPath,
+				);
+				if (movedAssetFolder) movedFiles.push(movedAssetFolder);
+				if (workspacePath) {
+					session.markdown = rewriteMovedLinks({
+						content: session.markdown,
+						filePath: previousPath,
+						nextPath: renamedPath,
+						workspacePath,
+						movedByOldPath: indexMovedFiles(movedFiles),
+					});
+				}
+
+				updateContentIfLive(session, session.markdown);
+				await deps.updateMovedLinks(movedFiles, filesBeforeRename);
+				if (workspaceStore.get().pinnedNotes.includes(renamedPath)) {
+					void deps.syncPinnedNotes();
+				}
+			} catch (err) {
+				const message = deps.handleFileError(err);
+				toast.error("Failed to rename file", { description: message });
+			} finally {
+				window.setTimeout(() => deps.pendingRenames.delete(previousPath), 1000);
+			}
+		});
+
+		if (!renamed) return;
+		// Flush link rewrites at the path that won, including retry suffixes.
+		if (isLive(session)) {
+			await deps.savePathContent(renamedPath, session.markdown, {
+				force: true,
+			});
+		}
+	}
+
+	async function renameGeneratedFileWithRetry(
+		previousPath: string,
+		initialNextPath: string,
+		markdown: string,
+		isLiveSession: () => boolean,
+	) {
+		let nextPath = initialNextPath;
+		for (let attempt = 0; ; attempt++) {
+			if (!isLiveSession()) return null;
+			try {
+				deps.pendingRenames.set(previousPath, nextPath);
+				await desktopApi.renameFile(previousPath, nextPath);
+				return nextPath;
+			} catch (err) {
+				if (
+					attempt >= 4 ||
+					!existingPathErrorPattern.test(deps.errorMessage(err))
+				) {
+					throw err;
+				}
+				const retryPath = await generatedTitlePath(previousPath, markdown);
+				if (!isLiveSession()) return null;
+				if (
+					!retryPath ||
+					pathEquals(retryPath, previousPath) ||
+					pathEquals(retryPath, nextPath)
+				) {
+					throw err;
+				}
+				nextPath = retryPath;
+			}
+		}
+	}
+
+	function publishRename(
+		session: TitleSession,
+		previousPath: string,
+		nextPath: string,
+	) {
+		// Keep the prior path for events from the pre-rename render, but drop
+		// older aliases so the session stays bounded.
+		for (const [sessionPath, candidate] of sessions) {
+			if (candidate === session && sessionPath !== previousPath) {
+				sessions.delete(sessionPath);
+			}
+		}
+		session.path = nextPath;
+		sessions.set(nextPath, session);
+		titleGenerationPreviewStore.set({
+			path: nextPath,
+			previewPath: nextPath,
+		});
+		rewriteHistory(previousPath, nextPath);
+		appStore.set((state) => ({
+			...state,
+			workspace: {
+				...state.workspace,
+				files: state.workspace.files.map((file) =>
+					pathEquals(file.path, previousPath)
+						? { ...file, path: nextPath }
+						: file,
+				),
+				pinnedNotes: state.workspace.pinnedNotes.map((path) =>
+					pathEquals(path, previousPath) ? nextPath : path,
+				),
+				lastOpenedPaths: Object.fromEntries(
+					Object.entries(state.workspace.lastOpenedPaths).map(
+						([workspacePath, openedPath]) => [
+							workspacePath,
+							pathEquals(openedPath, previousPath) ? nextPath : openedPath,
+						],
+					),
+				),
+			},
+			document: {
+				...state.document,
+				currentPath: pathEquals(state.document.currentPath ?? "", previousPath)
+					? nextPath
+					: state.document.currentPath,
+				lastOpenedPath: pathEquals(
+					state.document.lastOpenedPath ?? "",
+					previousPath,
+				)
+					? nextPath
+					: state.document.lastOpenedPath,
+			},
+		}));
+	}
+
+	function isLive(session: TitleSession) {
+		return (
+			sessions.get(session.path) === session &&
+			viewerStore.get().currentPath === session.path
+		);
+	}
+
+	function updateContentIfLive(session: TitleSession, content: string) {
+		appStore.set((state) => {
+			if (
+				state.document.currentPath !== session.path ||
+				sessions.get(session.path) !== session
+			) {
+				return state;
+			}
+			return {
+				...state,
+				document: {
+					...state.document,
+					content,
+				},
+			};
+		});
+	}
+
+	return { currentPath, editorDocumentId, start, stop, update };
+}

--- a/packages/ui/src/editor/EditorPathAttribution.test.tsx
+++ b/packages/ui/src/editor/EditorPathAttribution.test.tsx
@@ -163,6 +163,37 @@ describe("editor path attribution", () => {
 		expect(onSave).toHaveBeenNthCalledWith(1, "/old.md", "old edited");
 		expect(onSave).toHaveBeenNthCalledWith(2, "/new.md", "edited");
 	});
+
+	it("preserves source-editor history when a rename rewrites the body", async () => {
+		const root = createTestRoot();
+		const getEditor = captureEditorCreation();
+
+		await renderSourceEditor(
+			root,
+			"/old.md",
+			"before",
+			vi.fn(),
+			vi.fn(),
+			getEditor,
+			null,
+			"note-1",
+		);
+		const editor = getEditor();
+		act(() => changeEditorText(editor, "after"));
+		await renderSourceEditor(
+			root,
+			"/renamed.md",
+			"rewritten after",
+			vi.fn(),
+			vi.fn(),
+			getEditor,
+			null,
+			"note-1",
+			true,
+		);
+
+		expect(editor.can().undo()).toBe(true);
+	});
 });
 
 function createTestRoot() {
@@ -212,12 +243,16 @@ async function renderSourceEditor(
 	onSave: ReturnType<typeof vi.fn>,
 	getEditor: () => Editor,
 	editText: string | null = null,
+	documentId?: string,
+	preserveHistoryOnUpdate = false,
 ) {
 	await act(async () => {
 		root.render(
 			<EditAfterChildLayout editText={editText} getEditor={getEditor}>
 				<MarkdownSourceEditor
 					path={path}
+					documentId={documentId}
+					preserveHistoryOnUpdate={preserveHistoryOnUpdate}
 					initialMarkdown={initialMarkdown}
 					saveDebounceMs={LONG_SAVE_DEBOUNCE_MS}
 					onLocalChange={onLocalChange}

--- a/packages/ui/src/editor/EditorPathAttribution.test.tsx
+++ b/packages/ui/src/editor/EditorPathAttribution.test.tsx
@@ -46,6 +46,7 @@ describe("editor path attribution", () => {
 			getEditor,
 			null,
 			"note-1",
+			true,
 		);
 		const editor = getEditor();
 		act(() => changeEditorText(editor, "after"));
@@ -62,6 +63,37 @@ describe("editor path attribution", () => {
 
 		act(() => editor.commands.undo());
 		expect(editor.getText()).toBe("before");
+	});
+
+	it("preserves rich-editor history when a rename rewrites the body", async () => {
+		const root = createTestRoot();
+		const getEditor = captureEditorCreation();
+
+		await renderRichEditor(
+			root,
+			"/old.md",
+			"before",
+			vi.fn(),
+			vi.fn(),
+			getEditor,
+			null,
+			"note-1",
+		);
+		const editor = getEditor();
+		act(() => changeEditorText(editor, "after"));
+		await renderRichEditor(
+			root,
+			"/renamed.md",
+			"rewritten after",
+			vi.fn(),
+			vi.fn(),
+			getEditor,
+			null,
+			"note-1",
+			true,
+		);
+
+		expect(editor.can().undo()).toBe(true);
 	});
 
 	it("attributes a rich editor change and save to the new path", async () => {
@@ -150,6 +182,7 @@ async function renderRichEditor(
 	getEditor: () => Editor,
 	editText: string | null = null,
 	documentId?: string,
+	preserveHistoryOnUpdate = false,
 ) {
 	await act(async () => {
 		root.render(
@@ -157,6 +190,7 @@ async function renderRichEditor(
 				<EditorView
 					path={path}
 					documentId={documentId}
+					preserveHistoryOnUpdate={preserveHistoryOnUpdate}
 					initialMarkdown={initialMarkdown}
 					editable={false}
 					saveDebounceMs={LONG_SAVE_DEBOUNCE_MS}

--- a/packages/ui/src/editor/EditorPathAttribution.test.tsx
+++ b/packages/ui/src/editor/EditorPathAttribution.test.tsx
@@ -31,6 +31,39 @@ afterEach(() => {
 });
 
 describe("editor path attribution", () => {
+	it("preserves rich-editor history when only the physical path changes", async () => {
+		const onLocalChange = vi.fn();
+		const onSave = vi.fn();
+		const root = createTestRoot();
+		const getEditor = captureEditorCreation();
+
+		await renderRichEditor(
+			root,
+			"/old.md",
+			"before",
+			onLocalChange,
+			onSave,
+			getEditor,
+			null,
+			"note-1",
+		);
+		const editor = getEditor();
+		act(() => changeEditorText(editor, "after"));
+		await renderRichEditor(
+			root,
+			"/renamed.md",
+			"after",
+			onLocalChange,
+			onSave,
+			getEditor,
+			null,
+			"note-1",
+		);
+
+		act(() => editor.commands.undo());
+		expect(editor.getText()).toBe("before");
+	});
+
 	it("attributes a rich editor change and save to the new path", async () => {
 		const onLocalChange = vi.fn();
 		const onSave = vi.fn();
@@ -116,12 +149,14 @@ async function renderRichEditor(
 	onSave: ReturnType<typeof vi.fn>,
 	getEditor: () => Editor,
 	editText: string | null = null,
+	documentId?: string,
 ) {
 	await act(async () => {
 		root.render(
 			<EditAfterChildLayout editText={editText} getEditor={getEditor}>
 				<EditorView
 					path={path}
+					documentId={documentId}
 					initialMarkdown={initialMarkdown}
 					editable={false}
 					saveDebounceMs={LONG_SAVE_DEBOUNCE_MS}

--- a/packages/ui/src/editor/EditorView.tsx
+++ b/packages/ui/src/editor/EditorView.tsx
@@ -70,6 +70,8 @@ export type EditorViewProps = {
 	path: string;
 	/** Stable note identity; physical paths may change without replacing a note. */
 	documentId?: string;
+	/** Keep undo history when the same note receives rewritten Markdown. */
+	preserveHistoryOnUpdate?: boolean;
 	initialMarkdown: string;
 	editable?: boolean;
 	wikiTargets?: WikiTarget[];
@@ -93,6 +95,7 @@ export type EditorViewProps = {
 export function EditorView({
 	path,
 	documentId = path,
+	preserveHistoryOnUpdate = false,
 	initialMarkdown,
 	editable = true,
 	wikiTargets = [],
@@ -265,9 +268,9 @@ export function EditorView({
 				.setMeta("addToHistory", false)
 				.setContent(markdownToTiptapDoc(parsed.body), { emitUpdate: false })
 				.run();
-			resetEditorHistory(editor);
+			if (!preserveHistoryOnUpdate) resetEditorHistory(editor);
 		}
-	}, [editor, initialMarkdown]);
+	}, [editor, initialMarkdown, preserveHistoryOnUpdate]);
 
 	useEffect(() => {
 		// One editor instance can serve every file, so each new document starts its own

--- a/packages/ui/src/editor/EditorView.tsx
+++ b/packages/ui/src/editor/EditorView.tsx
@@ -68,6 +68,8 @@ export type { WikiTarget };
 
 export type EditorViewProps = {
 	path: string;
+	/** Stable note identity; physical paths may change without replacing a note. */
+	documentId?: string;
 	initialMarkdown: string;
 	editable?: boolean;
 	wikiTargets?: WikiTarget[];
@@ -90,6 +92,7 @@ export type EditorViewProps = {
 
 export function EditorView({
 	path,
+	documentId = path,
 	initialMarkdown,
 	editable = true,
 	wikiTargets = [],
@@ -267,20 +270,20 @@ export function EditorView({
 	}, [editor, initialMarkdown]);
 
 	useEffect(() => {
-		// One editor instance serves every file, so each new path starts its own
+		// One editor instance can serve every file, so each new document starts its own
 		// undo stack. Otherwise undo replays the last file's edits into this one.
-		void path;
+		void documentId;
 		if (!editor) return;
 		resetEditorHistory(editor);
-	}, [editor, path]);
+	}, [editor, documentId]);
 
 	useEffect(() => {
-		// Path changes flush the pending edit before the next document takes over.
-		void path;
+		// Flush the pending edit before the next document takes over.
+		void documentId;
 		return () => {
 			flushPendingSave(pendingSaveRef);
 		};
-	}, [path]);
+	}, [documentId]);
 
 	useEffect(() => {
 		if (!onMessage) return;

--- a/packages/ui/src/editor/MarkdownSourceEditor.tsx
+++ b/packages/ui/src/editor/MarkdownSourceEditor.tsx
@@ -16,6 +16,8 @@ const SourceDocument = Document.extend({ content: "codeBlock" });
 
 export type MarkdownSourceEditorProps = {
 	path: string;
+	/** Stable note identity; physical paths may change without replacing a note. */
+	documentId?: string;
 	initialMarkdown: string;
 	sourceLanguage?: string;
 	/** Focus on mount; wanted for the source-mode toggle, not for navigation. */
@@ -28,6 +30,7 @@ export type MarkdownSourceEditorProps = {
 
 export function MarkdownSourceEditor({
 	path,
+	documentId = path,
 	initialMarkdown,
 	sourceLanguage = "md",
 	autoFocus = true,
@@ -103,12 +106,12 @@ export function MarkdownSourceEditor({
 	}, [editor, initialMarkdown, sourceLanguage]);
 
 	useEffect(() => {
-		// Path changes flush the pending edit before the next document takes over.
-		void path;
+		// Flush the pending edit before the next document takes over.
+		void documentId;
 		return () => {
 			flushPendingSave(pendingSaveRef);
 		};
-	}, [path]);
+	}, [documentId]);
 
 	return (
 		<div

--- a/packages/ui/src/editor/MarkdownSourceEditor.tsx
+++ b/packages/ui/src/editor/MarkdownSourceEditor.tsx
@@ -1,3 +1,4 @@
+import { resetEditorHistory } from "@hubble.md/editor";
 import type { Editor } from "@tiptap/core";
 import Document from "@tiptap/extension-document";
 import { EditorContent, type JSONContent, useEditor } from "@tiptap/react";
@@ -22,6 +23,7 @@ export type MarkdownSourceEditorProps = {
 	sourceLanguage?: string;
 	/** Focus on mount; wanted for the source-mode toggle, not for navigation. */
 	autoFocus?: boolean;
+	preserveHistoryOnUpdate?: boolean;
 	saveDebounceMs?: number;
 	onLocalChange: (path: string, markdown: string) => void;
 	onSave: (path: string, markdown: string) => void | Promise<void>;
@@ -34,6 +36,7 @@ export function MarkdownSourceEditor({
 	initialMarkdown,
 	sourceLanguage = "md",
 	autoFocus = true,
+	preserveHistoryOnUpdate = false,
 	saveDebounceMs = DEFAULT_SAVE_DEBOUNCE_MS,
 	onLocalChange,
 	onSave,
@@ -97,13 +100,21 @@ export function MarkdownSourceEditor({
 		if (!editor) return;
 		if (initialMarkdown === latestMarkdownRef.current) return;
 		latestMarkdownRef.current = initialMarkdown;
-		editor.commands.setContent(
-			sourceDocFromMarkdown(initialMarkdown, sourceLanguage),
-			{
+		editor
+			.chain()
+			.setMeta("addToHistory", false)
+			.setContent(sourceDocFromMarkdown(initialMarkdown, sourceLanguage), {
 				emitUpdate: false,
-			},
-		);
-	}, [editor, initialMarkdown, sourceLanguage]);
+			})
+			.run();
+		if (!preserveHistoryOnUpdate) resetEditorHistory(editor);
+	}, [editor, initialMarkdown, preserveHistoryOnUpdate, sourceLanguage]);
+
+	useEffect(() => {
+		void documentId;
+		if (!editor) return;
+		resetEditorHistory(editor);
+	}, [editor, documentId]);
 
 	useEffect(() => {
 		// Flush the pending edit before the next document takes over.


### PR DESCRIPTION
## Description

If a new file isn't yet named, the file name will be auto-generated from the first line of meaningful text in the file. Once you name the file yourself, auto-naming is switched off. We'll also stop auto-naming if you've closed and reopened the app; it's tracked in-memory.

https://github.com/user-attachments/assets/3f634236-02b0-4cd6-b4f2-56a1d116be66


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update

## Testing

- [x] Existing tests pass
- [x] Added new tests for changes
- [ ] Tested manually (describe below)

**Manual Testing Details:**

Not run. Automated desktop and UI suites cover title parsing, rename timing, saves during renames, manual opt-out, reopened notes, and editor history.

## Checklist

- [ ] I discussed this change in a GitHub issue before submitting this PR
- [x] I have run the linter, formatter, and tests to ensure my code is ready for review