### PR TITLE
Retry WinGet fork sync before publishing

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -215,6 +215,37 @@ jobs:
         shell: pwsh
         run: Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
 
+      - name: Sync WinGet fork
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.WINGET_CREATE_GITHUB_TOKEN }}
+        run: |
+          if (-not $env:GH_TOKEN) {
+            throw "WINGET_CREATE_GITHUB_TOKEN is required"
+          }
+
+          $forkOwner = gh api user --jq .login
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not identify the WinGet fork owner"
+          }
+
+          $forkOwner = $forkOwner.Trim()
+          $maxAttempts = 5
+          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            gh repo sync "$forkOwner/winget-pkgs" --source microsoft/winget-pkgs
+            if ($LASTEXITCODE -eq 0) {
+              break
+            }
+
+            if ($attempt -eq $maxAttempts) {
+              throw "Could not sync $forkOwner/winget-pkgs after $maxAttempts attempts"
+            }
+
+            $delaySeconds = [math]::Pow(2, $attempt)
+            Write-Warning "WinGet fork sync failed; retrying in $delaySeconds seconds"
+            Start-Sleep -Seconds $delaySeconds
+          }
+
       - name: Submit manifest update
         shell: pwsh
         env:


### PR DESCRIPTION
## Description
Sync the token owner's `winget-pkgs` fork before WingetCreate submits an update. Retry transient failures five times with backoff.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update

## Testing
- [x] Existing tests pass
- [ ] Added new tests for changes
- [x] Tested manually (describe below)

**Manual Testing Details:**

- Parsed `desktop-release.yml` as YAML
- `git diff --check`
- `CI=true pnpm build:desktop`
- Confirmed local `gh repo sync` supports remote destination and `--source`

## Checklist
- [ ] I discussed this change in a GitHub issue before submitting this PR
- [x] I have run the linter, formatter, and tests to ensure my code is ready for review