### PR TITLE
Allow late macOS release reruns to upload

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -86,6 +86,8 @@ jobs:
       - name: Build and publish release
         env:
           GH_TOKEN: ${{ github.token }}
+          # Electron Builder otherwise skips releases published over two hours ago.
+          EP_GH_IGNORE_TIME: "true"
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}


### PR DESCRIPTION
## Description
Allow Electron Builder to upload macOS assets when rerunning a release more than two hours after publication.

Related to #250 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update

## Testing
- [x] Existing tests pass
- [ ] Added new tests for changes
- [x] Tested manually (describe below)

**Manual Testing Details:**

- Parsed `desktop-release.yml` as YAML
- `git diff --check`
- `CI=true pnpm build:desktop`
- Verified Electron Builder 26.8.1 reads `EP_GH_IGNORE_TIME` before its two-hour release cutoff

## Checklist
- [ ] I discussed this change in a GitHub issue before submitting this PR
- [x] I have run the linter, formatter, and tests to ensure my code is ready for review