### PR TITLE
Fix pinned notes after restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 
 ### Fixed
 
+- Pinned notes remain visible after restarting or updating the desktop app. [#254](https://github.com/bholmesdev/hubble.md/pull/254)
 - Pressing Enter in a list item containing an image now creates a new list item instead of dropping out of the list. Thanks [@MonisMS](https://github.com/MonisMS)! [#241](https://github.com/bholmesdev/hubble.md/pull/241)
 
 ## [0.1.26] - 2026-08-09

--- a/apps/desktop/src/store/actions.test.ts
+++ b/apps/desktop/src/store/actions.test.ts
@@ -2502,6 +2502,25 @@ describe("desktop pinned notes", () => {
 		vi.unstubAllGlobals();
 	});
 
+	it("loads persisted pins for the startup workspace", async () => {
+		const api = createDesktopApi();
+		api.readWorkspaceConfig.mockResolvedValue({
+			version: 1,
+			pinnedNotes: ["notes/a.md"],
+		});
+		const { workspaceStore } = await loadStoreActions(
+			api,
+			JSON.stringify({ workspace: { workspacePath: "/workspace" } }),
+		);
+
+		await vi.waitFor(() =>
+			expect(workspaceStore.get().pinnedNotes).toEqual([
+				"/workspace/notes/a.md",
+			]),
+		);
+		expect(api.readWorkspaceConfig).toHaveBeenCalledWith("/workspace");
+	});
+
 	it("loads missing workspace config as an empty pin set", async () => {
 		const api = createDesktopApi();
 		api.readWorkspaceConfig.mockResolvedValue({ version: 1, pinnedNotes: [] });

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -504,8 +504,12 @@ export function getPendingRenameTarget(path: string) {
 	return pendingRenames.get(path) ?? null;
 }
 
-if (workspaceStore.get().workspacePath) {
-	void refreshFiles();
+const initialWorkspacePath = workspaceStore.get().workspacePath;
+if (initialWorkspacePath) {
+	void Promise.all([
+		refreshFiles(initialWorkspacePath),
+		loadPinnedNotes(initialWorkspacePath),
+	]);
 }
 
 export function setSortMode(mode: SortMode) {


### PR DESCRIPTION
## Description
Reload workspace pin metadata alongside the file list during startup, so saved pins remain visible after relaunches and app updates. Adds regression coverage for a persisted startup workspace.

Related to #64

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update

## Testing
- [x] Existing tests pass
- [x] Added new tests for changes
- [x] Tested manually (describe below)

**Manual Testing Details:**
Pinned `project-ideas.md` in the isolated desktop playground, stopped Hubble, relaunched without the dev workspace override, and confirmed the note remained in the Pinned section through the persisted-workspace startup path.

## Checklist
- [x] I discussed this change in a GitHub issue before submitting this PR
- [x] I have run the linter, formatter, and tests to ensure my code is ready for review

Validation: `pnpm --filter @hubble.md/desktop test -- src/store/actions.test.ts` (202 tests), `pnpm check`, `pnpm build:desktop`.