### PR TITLE
Add Homebrew installation documentation for macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 ### Added
 
 - Add a spellcheck option to Settings. Allows for enabling / disabling, and selecting custom spellcheck dictionaries on Windows and Linux. Thanks [@JoeJoeflyn](https://github.com/JoeJoeflyn)! [#234](https://github.com/bholmesdev/hubble.md/pull/234)
-- macOS users can now install Hubble via Homebrew with `brew tap PARAM-ship/hubble && brew install --cask hubble-md`. Thanks [@PARAM-ship](https://github.com/PARAM-ship)! [#174](https://github.com/bholmesdev/hubble.md/issues/174)
+- macOS users can now install Hubble via Homebrew with `brew tap PARAM-ship/hubble && brew install --cask hubble-md`. Thanks [@paramcodes](https://github.com/paramcodes)! [#264](https://github.com/bholmesdev/hubble.md/pull/264)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 ### Added
 
 - Add a spellcheck option to Settings. Allows for enabling / disabling, and selecting custom spellcheck dictionaries on Windows and Linux. Thanks [@JoeJoeflyn](https://github.com/JoeJoeflyn)! [#234](https://github.com/bholmesdev/hubble.md/pull/234)
+- macOS users can now install Hubble via Homebrew with `brew tap PARAM-ship/hubble && brew install --cask hubble-md`. Thanks [@PARAM-ship](https://github.com/PARAM-ship)! [#174](https://github.com/bholmesdev/hubble.md/issues/174)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,24 @@ Hubble ships as a desktop app. Install the latest build from the [releases page]
 
 macOS, Windows, and Linux are supported. macOS builds are signed and notarized; Windows and Linux builds are unsigned, so your OS may warn before the first launch.
 
+### Homebrew (macOS)
+
+For macOS users, you can also install Hubble via Homebrew:
+
+```sh
+brew tap PARAM-ship/hubble
+brew install --cask hubble-md
+```
+
+To update an existing installation:
+
+```sh
+brew update
+brew upgrade --cask hubble-md
+```
+
+The Homebrew tap is maintained by the community and automatically updates when new Hubble.md releases are published.
+
 ## Compile from source
 
 Want to build Hubble directly? First, install the prerequisites:


### PR DESCRIPTION
## Summary
- Adds Homebrew installation instructions to README.md for macOS users
- Documents the community-maintained Homebrew tap at PARAM-ship/homebrew-hubble
- Includes installation and update commands
- Adds changelog entry under [Unreleased]

This addresses issue #174 by providing an easy Homebrew installation method for macOS users who prefer package managers over manual downloads.

## Test plan
- Verified the README.md changes include clear installation instructions
- Verified the CHANGELOG.md entry follows the project's format
- Tested the branch locally to ensure no unintended changes
- The changes are documentation-only, so no functional testing required

Generated with [Devin](https://devin.ai)