### PR TITLE
Add tabs to the desktop editor (#240)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 
 ### Added
 
+- Open several notes at once as tabs. Each tab keeps its own back and forward history and its own scroll position, and `Cmd/Ctrl+W` closes a tab before closing the window.
 - Add a spellcheck option to Settings. Allows for enabling / disabling, and selecting custom spellcheck dictionaries on Windows and Linux. Thanks [@JoeJoeflyn](https://github.com/JoeJoeflyn)! [#234](https://github.com/bholmesdev/hubble.md/pull/234)
 
 ### Changed
 
 ### Fixed
 
+- Typing and immediately opening another note no longer loses the last few characters. The open note is now saved before navigating rather than as the editor closes.
 - Clicking elsewhere in a note now closes the formatting menu and clears its old text highlight. [#256](https://github.com/bholmesdev/hubble.md/pull/256)
 - Pinned notes remain visible after restarting or updating the desktop app. [#254](https://github.com/bholmesdev/hubble.md/pull/254)
 - Pressing Enter in a list item containing an image now creates a new list item instead of dropping out of the list. Thanks [@MonisMS](https://github.com/MonisMS)! [#241](https://github.com/bholmesdev/hubble.md/pull/241)

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -60,6 +60,21 @@ User-facing structured fields attached to a Markdown File. File Properties are d
 
 A Markdown File opened directly from the filesystem, not through a Workspace Folder or Plain Folder. The desktop app can read and edit it with access scoped to the file and nearby assets; nothing syncs.
 
+### Tab
+
+A note the user has open in the desktop editor, shown as one entry in the tab strip above the document.
+
+A Tab records **where** a note is, not what it holds: its path and its own back/forward trail. The open document itself stays singular — one [[Markdown File]] is loaded at a time, in one editor, with one file watcher. Activating a Tab saves the current note and loads the Tab's note from disk, the same thing clicking a sidebar row already does. Background Tabs therefore hold no unsaved text, no dirty state, and no conflict state; there is nothing in a Tab to go stale.
+
+Tabs are session state. They are not persisted, so a relaunch restores the last opened note as a single Tab rather than the set that was open.
+_Avoid_: buffer, pane, window.
+
+### Active Tab
+
+The Tab whose note is currently in the editor. Back and forward act on the Active Tab's trail, so each Tab navigates independently.
+
+The [[Markdown File]] on screen is normally the Active Tab's, with one exception: the app changelog takes over the editor without a Tab of its own, so while it is showing no Tab is selected.
+
 ### Asset
 
 A binary file referenced by a Markdown File, such as an image. Asset paths in markdown use the desktop-canonical `<markdown-file-stem>.assets/<hash>.<ext>` convention relative to the Markdown File's folder.

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -156,6 +156,8 @@ let menuState: MenuState = {
 	isSourceMode: false,
 	canGoBack: false,
 	canGoForward: false,
+	hasTabs: false,
+	hasMultipleTabs: false,
 };
 let updateState: DesktopUpdateState = {
 	isSupported: supportsAutoUpdates,
@@ -918,7 +920,22 @@ function buildMenu() {
 					click: () => sendToRenderer("desktop:menu-sync-workspace"),
 				},
 				{ type: "separator" },
-				{ role: "close" },
+				// `CmdOrCtrl+W` has to keep closing the window once the last Tab is
+				// gone, so this item stays enabled and decides at click time.
+				{
+					id: "app.close-tab",
+					label: menuState.hasTabs
+						? getCommand("app.close-tab").label
+						: "Close",
+					accelerator: getCommand("app.close-tab").defaultBinding,
+					click: () => {
+						if (menuState.hasTabs) {
+							sendToRenderer("desktop:menu-close-tab");
+							return;
+						}
+						mainWindow?.close();
+					},
+				},
 			],
 		},
 		{
@@ -950,6 +967,13 @@ function buildMenu() {
 				),
 				commandMenuItem("app.go-forward", () =>
 					sendToRenderer("desktop:menu-go-forward"),
+				),
+				{ type: "separator" },
+				commandMenuItem("app.previous-tab", () =>
+					sendToRenderer("desktop:menu-previous-tab"),
+				),
+				commandMenuItem("app.next-tab", () =>
+					sendToRenderer("desktop:menu-next-tab"),
 				),
 				{ type: "separator" },
 				{
@@ -1948,6 +1972,8 @@ function registerIpc() {
 			isSourceMode: state.isSourceMode === true,
 			canGoBack: state.canGoBack === true,
 			canGoForward: state.canGoForward === true,
+			hasTabs: state.hasTabs === true,
+			hasMultipleTabs: state.hasMultipleTabs === true,
 		};
 		buildMenu();
 	});

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -156,6 +156,10 @@ const desktopApi = {
 		subscribe("desktop:menu-toggle-terminal", callback),
 	onMenuGoBack: (callback) => subscribe("desktop:menu-go-back", callback),
 	onMenuGoForward: (callback) => subscribe("desktop:menu-go-forward", callback),
+	onMenuCloseTab: (callback) => subscribe("desktop:menu-close-tab", callback),
+	onMenuNextTab: (callback) => subscribe("desktop:menu-next-tab", callback),
+	onMenuPreviousTab: (callback) =>
+		subscribe("desktop:menu-previous-tab", callback),
 	onMenuToggleSourceMode: (callback) =>
 		subscribe("desktop:menu-toggle-source-mode", callback),
 	onUndoDelete: (callback) => subscribe("desktop:undo-delete", callback),

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -27,6 +27,7 @@ import {
 	recordRecentCommand,
 } from "./commands/recentCommands";
 import { buildAppCommands } from "./commands/useAppCommands";
+import { DocumentTabs } from "./components/DocumentTabs";
 import { HtmlAppEmptyState } from "./components/HtmlAppEmptyState";
 import { SettingsDialog, SettingsSection } from "./components/SettingsDialog";
 import { type DesktopSidebarFocus, Sidebar } from "./components/Sidebar";
@@ -69,9 +70,12 @@ import {
 import { isCompactWindow, useCompactWindow } from "./lib/layout";
 import { resolveRelativeLinkPath } from "./lib/relativeLinkPath";
 import { isDefaultLanguage, languageName } from "./lib/spellcheckLanguages";
+import { useScrollMemory } from "./lib/useScrollMemory";
 import { resolveWikiPath } from "./lib/wikiPath";
 import { SIDEBAR_NAV_SELECTOR } from "./selectors";
 import {
+	activateAdjacentTab,
+	closeActiveTab,
 	createWorkspaceWithSidebar,
 	editorDocumentId,
 	forceKeepLocalEdits,
@@ -81,6 +85,7 @@ import {
 	handleExternalFileChange,
 	loadPath,
 	openChangelog,
+	openTabForPath,
 	openWorkspace,
 	openWorkspaceWithSidebar,
 	reconcileWorkspacePath,
@@ -109,6 +114,7 @@ import {
 	codeFileOpenModeStore,
 	lastSeenVersionStore,
 	sidebarOpenStore,
+	tabsStore,
 	terminalPositionStore,
 	themePreferenceStore,
 	uiStore,
@@ -209,11 +215,13 @@ function App() {
 	const workspacePath = useStoreValue(workspacePathStore);
 	const sidebarOpen = useStoreValue(sidebarOpenStore);
 	const terminalPosition = useStoreValue(terminalPositionStore);
+	const tabs = useStoreValue(tabsStore);
 	const hasWorkspace = workspacePath !== null;
 	const { canGoBack: menuCanGoBack, canGoForward: menuCanGoForward } =
 		useHistoryNav();
 	const [scrollContainerEl, setScrollContainerEl] =
 		useState<HTMLDivElement | null>(null);
+	useScrollMemory(state.currentPath, scrollContainerEl);
 	const [settingsOpen, setSettingsOpen] = useState(false);
 	const [copyAsMarkdownRequest, setCopyAsMarkdownRequest] = useState(0);
 	const [updateState, setUpdateState] = useState<DesktopUpdateState | null>(
@@ -447,6 +455,8 @@ function App() {
 			isSourceMode: state.viewMode === "source",
 			canGoBack: menuCanGoBack,
 			canGoForward: menuCanGoForward,
+			hasTabs: tabs.order.length > 0,
+			hasMultipleTabs: tabs.order.length > 1,
 		});
 	}, [
 		hasWorkspace,
@@ -454,6 +464,7 @@ function App() {
 		menuCanGoForward,
 		state.currentPath,
 		state.viewMode,
+		tabs.order.length,
 	]);
 
 	useEffect(() => {
@@ -579,6 +590,9 @@ function App() {
 			desktopApi.onMenuToggleTerminal(() => toggleTerminal()),
 			desktopApi.onMenuGoBack(() => void goBack()),
 			desktopApi.onMenuGoForward(() => void goForward()),
+			desktopApi.onMenuCloseTab(() => void closeActiveTab()),
+			desktopApi.onMenuNextTab(() => void activateAdjacentTab(1)),
+			desktopApi.onMenuPreviousTab(() => void activateAdjacentTab(-1)),
 			desktopApi.onMenuToggleSourceMode(() => {
 				const current = viewerStore.get();
 				if (
@@ -793,45 +807,48 @@ function App() {
 					aria-live="polite"
 					onFocusCapture={closeSidebarOverlay}
 				>
-					<div className="flex-1 min-h-0 min-w-0 relative">
-						{state.status === "loading" && <p>Loading…</p>}
-						{state.status === "error" && (
-							<p>{state.error ?? "Failed to open file."}</p>
-						)}
-						{state.status !== "loading" &&
-							state.status !== "error" &&
-							!state.currentPath && (
-								<div className="flex h-full items-center justify-center p-6">
-									{hasWorkspace ? (
-										<Button onClick={() => void openFilePicker()}>
-											Open file
-										</Button>
-									) : (
-										<WelcomeScreen
-											onCreateFolder={() => void createWorkspaceWithSidebar()}
-											onOpenFolder={() => void openWorkspaceWithSidebar()}
+					<div className="flex-1 min-h-0 min-w-0 flex flex-col">
+						<DocumentTabs />
+						<div className="flex-1 min-h-0 min-w-0 relative">
+							{state.status === "loading" && <p>Loading…</p>}
+							{state.status === "error" && (
+								<p>{state.error ?? "Failed to open file."}</p>
+							)}
+							{state.status !== "loading" &&
+								state.status !== "error" &&
+								!state.currentPath && (
+									<div className="flex h-full items-center justify-center p-6">
+										{hasWorkspace ? (
+											<Button onClick={() => void openFilePicker()}>
+												Open file
+											</Button>
+										) : (
+											<WelcomeScreen
+												onCreateFolder={() => void createWorkspaceWithSidebar()}
+												onOpenFolder={() => void openWorkspaceWithSidebar()}
+											/>
+										)}
+									</div>
+								)}
+							{state.status === "ready" && state.currentPath && (
+								<div className="flex h-full min-h-0 flex-col">
+									{state.externalChange.kind === "conflict" && (
+										<ExternalChangeBanner
+											onKeepMyEdits={() => void forceKeepLocalEdits()}
+											onReloadFromDisk={reloadFromDiskConflict}
 										/>
 									)}
+									<DocumentViewer
+										path={state.currentPath}
+										content={state.content}
+										copyAsMarkdownRequest={copyAsMarkdownRequest}
+										viewMode={state.viewMode}
+										spellcheckStatus={spellcheckStatus}
+										onScrollContainerChange={setScrollContainerEl}
+									/>
 								</div>
 							)}
-						{state.status === "ready" && state.currentPath && (
-							<div className="flex h-full min-h-0 flex-col">
-								{state.externalChange.kind === "conflict" && (
-									<ExternalChangeBanner
-										onKeepMyEdits={() => void forceKeepLocalEdits()}
-										onReloadFromDisk={reloadFromDiskConflict}
-									/>
-								)}
-								<DocumentViewer
-									path={state.currentPath}
-									content={state.content}
-									copyAsMarkdownRequest={copyAsMarkdownRequest}
-									viewMode={state.viewMode}
-									spellcheckStatus={spellcheckStatus}
-									onScrollContainerChange={setScrollContainerEl}
-								/>
-							</div>
-						)}
+						</div>
 					</div>
 					<TerminalPanel />
 				</section>
@@ -840,7 +857,7 @@ function App() {
 				open={searchOpen}
 				onOpenChange={changeSearchOpen}
 				files={paletteFiles}
-				onSelectFile={(path) => void loadPath(path)}
+				onSelectFile={(path) => void openTabForPath(path)}
 				searchContents={searchFileContents}
 				commands={paletteCommands}
 				recentCommandIds={recentCommandIds}

--- a/apps/desktop/src/commands/useAppCommands.ts
+++ b/apps/desktop/src/commands/useAppCommands.ts
@@ -21,6 +21,10 @@ import {
 	supportsSourceToggle,
 } from "../lib/filePath";
 import {
+	activateAdjacentTab,
+	closeActiveTab,
+	closeAllTabs,
+	closeOtherTabs,
 	createFolderInFolder,
 	deleteMarkdownFile,
 	goBack,
@@ -37,6 +41,7 @@ import {
 	toggleTerminal,
 } from "../store/actions";
 import { canGoBack, canGoForward } from "../store/history";
+import { tabsStore } from "../store/state";
 
 const CONTRIBUTING_URL =
 	"https://github.com/bholmesdev/hubble.md/blob/main/CONTRIBUTING.md";
@@ -69,6 +74,8 @@ function toRegistryContext(context: AppCommandContext): RegistryContext {
 		isSourceMode: context.isSourceMode,
 		canGoBack: canGoBack(),
 		canGoForward: canGoForward(),
+		hasTabs: tabsStore.get().order.length > 0,
+		hasMultipleTabs: tabsStore.get().order.length > 1,
 	};
 }
 
@@ -204,6 +211,37 @@ function defineCommands(
 		),
 
 		// Navigate
+		fromRegistry(
+			"app.close-tab",
+			"Navigate",
+			["tab", "close"],
+			closeActiveTab,
+			// The window-close role owns this accelerator; the native menu decides
+			// between closing a tab and closing the window.
+			{ globalShortcut: false },
+		),
+		paletteOnly({
+			id: "app.close-other-tabs",
+			label: "Close Other Tabs",
+			group: "Navigate",
+			keywords: ["tab", "close", "clean"],
+			isEnabled: () => tabsStore.get().order.length > 1,
+			run: closeOtherTabs,
+		}),
+		paletteOnly({
+			id: "app.close-all-tabs",
+			label: "Close All Tabs",
+			group: "Navigate",
+			keywords: ["tab", "close", "clean"],
+			isEnabled: () => tabsStore.get().order.length > 0,
+			run: closeAllTabs,
+		}),
+		fromRegistry("app.next-tab", "Navigate", ["tab", "switch"], () =>
+			activateAdjacentTab(1),
+		),
+		fromRegistry("app.previous-tab", "Navigate", ["tab", "switch"], () =>
+			activateAdjacentTab(-1),
+		),
 		fromRegistry("app.go-back", "Navigate", ["history", "previous"], goBack),
 		fromRegistry("app.go-forward", "Navigate", ["history", "next"], goForward),
 		fromRegistry(

--- a/apps/desktop/src/components/DocumentTabs.tsx
+++ b/apps/desktop/src/components/DocumentTabs.tsx
@@ -1,0 +1,33 @@
+import { TabStrip, type TabStripItem } from "@hubble.md/ui";
+import { useStoreValue } from "@simplestack/store/react";
+import { isChangelogPath } from "../lib/changelogNote";
+import { activateTab, closeTab } from "../store/actions";
+import { currentPathStore, tabsStore } from "../store/state";
+import { tabLabels } from "../store/tabs";
+
+/**
+ * Supplies the Tab strip from the store, keeping `packages/ui` free of any
+ * store coupling.
+ */
+export function DocumentTabs() {
+	const tabs = useStoreValue(tabsStore);
+	// The changelog takes over the editor without a Tab of its own, so it is
+	// the one time the Active Tab is not what the user is reading. Showing it
+	// as selected would point at a note that is not on screen.
+	const onChangelog = useStoreValue(currentPathStore, isChangelogPath);
+	const labels = tabLabels(tabs);
+	const items: TabStripItem[] = tabs.order.map((id) => ({
+		id,
+		label: labels[id] ?? "",
+		title: tabs.byId[id]?.path ?? "",
+	}));
+
+	return (
+		<TabStrip
+			tabs={items}
+			activeTabId={onChangelog ? null : tabs.activeTabId}
+			onActivate={(id) => void activateTab(id)}
+			onClose={(id) => void closeTab(id)}
+		/>
+	);
+}

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -17,9 +17,9 @@ import {
 	deleteFolder,
 	deleteMarkdownFile,
 	deleteSidebarItems,
-	loadPath,
 	moveSidebarItems,
 	openPathInDefaultApp,
+	openTabForPath,
 	openWorkspace,
 	renameFolder,
 	renameMarkdownFile,
@@ -113,7 +113,9 @@ export function Sidebar({
 			onCollapse={collapseSidebar}
 			onSortModeChange={setSortMode}
 			onSelectFile={(path) => {
-				void loadPath(path);
+				// Picking a note from the sidebar is an explicit open, so it gets its
+				// own Tab. Following a link inside a note stays in the current one.
+				void openTabForPath(path);
 				if (compact) collapseSidebar();
 			}}
 			onOpenFileInDefaultApp={(path) => void openPathInDefaultApp(path)}

--- a/apps/desktop/src/desktopApi/types.ts
+++ b/apps/desktop/src/desktopApi/types.ts
@@ -100,6 +100,8 @@ export type MenuState = {
 	isSourceMode: boolean;
 	canGoBack: boolean;
 	canGoForward: boolean;
+	hasTabs: boolean;
+	hasMultipleTabs: boolean;
 };
 
 export type DesktopUpdateStatus =
@@ -237,6 +239,9 @@ export type DesktopApi = {
 	onMenuToggleTerminal(callback: () => void): Unsubscribe;
 	onMenuGoBack(callback: () => void): Unsubscribe;
 	onMenuGoForward(callback: () => void): Unsubscribe;
+	onMenuCloseTab(callback: () => void): Unsubscribe;
+	onMenuNextTab(callback: () => void): Unsubscribe;
+	onMenuPreviousTab(callback: () => void): Unsubscribe;
 	onMenuToggleSourceMode(callback: () => void): Unsubscribe;
 	onUndoDelete(callback: () => void): Unsubscribe;
 	onWindowFocus(callback: () => void): Unsubscribe;

--- a/apps/desktop/src/lib/scrollMemory.test.ts
+++ b/apps/desktop/src/lib/scrollMemory.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	captureScroll,
+	forgetScrollPositions,
+	recallScroll,
+	rememberScroll,
+	rewriteScrollMemory,
+	setScrollContainer,
+} from "./scrollMemory";
+
+describe("scroll memory", () => {
+	beforeEach(() => forgetScrollPositions());
+
+	it("recalls a position per path", () => {
+		rememberScroll("/w/a.md", 120);
+		rememberScroll("/w/b.md", 40);
+
+		expect(recallScroll("/w/a.md")).toBe(120);
+		expect(recallScroll("/w/b.md")).toBe(40);
+		expect(recallScroll("/w/never-opened.md")).toBeUndefined();
+	});
+
+	it("follows notes through a rename, using the caller's rule", () => {
+		rememberScroll("/w/draft.md", 300);
+		rememberScroll("/w/other.md", 80);
+
+		rewriteScrollMemory((path) =>
+			path === "/w/draft.md" ? "/w/final.md" : path,
+		);
+
+		expect(recallScroll("/w/final.md")).toBe(300);
+		expect(recallScroll("/w/draft.md")).toBeUndefined();
+		expect(recallScroll("/w/other.md")).toBe(80);
+	});
+
+	it("follows a whole folder when the caller rewrites prefixes", () => {
+		rememberScroll("/w/old/a.md", 10);
+		rememberScroll("/w/old/deep/b.md", 20);
+		rememberScroll("/w/keep.md", 30);
+
+		rewriteScrollMemory((path) =>
+			path.startsWith("/w/old/") ? path.replace("/w/old/", "/w/new/") : path,
+		);
+
+		expect(recallScroll("/w/new/a.md")).toBe(10);
+		expect(recallScroll("/w/new/deep/b.md")).toBe(20);
+		expect(recallScroll("/w/keep.md")).toBe(30);
+	});
+
+	it("drops the least recently touched note past the cap", () => {
+		for (let i = 0; i < 50; i++) rememberScroll(`/w/${i}.md`, i);
+		// Touching the oldest entry again should save it from the next eviction.
+		rememberScroll("/w/0.md", 999);
+		rememberScroll("/w/overflow.md", 1);
+
+		expect(recallScroll("/w/0.md")).toBe(999);
+		expect(recallScroll("/w/1.md")).toBeUndefined();
+		expect(recallScroll("/w/overflow.md")).toBe(1);
+	});
+
+	it("captures the live container position when leaving a note", () => {
+		setScrollContainer({ scrollTop: 175 } as HTMLElement);
+
+		captureScroll("/w/leaving.md");
+
+		expect(recallScroll("/w/leaving.md")).toBe(175);
+	});
+
+	it("ignores a capture with no container or no path", () => {
+		setScrollContainer(null);
+		captureScroll("/w/detached.md");
+		expect(recallScroll("/w/detached.md")).toBeUndefined();
+
+		setScrollContainer({ scrollTop: 10 } as HTMLElement);
+		captureScroll(null);
+		expect(recallScroll("")).toBeUndefined();
+	});
+
+	it("forgets everything when the open folder changes", () => {
+		rememberScroll("/w/a.md", 10);
+
+		forgetScrollPositions();
+
+		expect(recallScroll("/w/a.md")).toBeUndefined();
+	});
+});

--- a/apps/desktop/src/lib/scrollMemory.ts
+++ b/apps/desktop/src/lib/scrollMemory.ts
@@ -1,0 +1,65 @@
+/**
+ * Where the user was in each note, so reopening one lands where they left it.
+ *
+ * Keyed by path rather than by Tab on purpose: scroll outlives the Tab that
+ * showed it, so closing and reopening a note keeps the position, and a note
+ * open in one Tab keeps it when another Tab is the one that closes.
+ *
+ * The position is read as navigation leaves a note, not from a scroll
+ * listener. One scroll container serves every note, and swapping its content
+ * drops `scrollTop` to zero — a listener hears that as the user scrolling to
+ * the top.
+ */
+
+/** Enough for a working set of notes; older entries are the ones worth losing. */
+const MAX_REMEMBERED = 50;
+
+const positions = new Map<string, number>();
+
+let container: HTMLElement | null = null;
+
+/** The live editor viewport, registered by the view that owns it. */
+export function setScrollContainer(element: HTMLElement | null) {
+	container = element;
+}
+
+export function rememberScroll(path: string, top: number) {
+	if (!path) return;
+	// Re-inserting moves the entry to the end, which makes the first key the
+	// least recently touched one to drop.
+	positions.delete(path);
+	positions.set(path, top);
+	if (positions.size > MAX_REMEMBERED) {
+		const oldest = positions.keys().next().value;
+		if (oldest !== undefined) positions.delete(oldest);
+	}
+}
+
+/** Records where `path` is sitting right now, before navigation moves off it. */
+export function captureScroll(path: string | null) {
+	if (!path || !container) return;
+	rememberScroll(path, container.scrollTop);
+}
+
+export function recallScroll(path: string) {
+	return positions.get(path);
+}
+
+/**
+ * Moves remembered positions with the files they belong to. Takes the same
+ * rewrite its caller hands `rewriteHistory`, so a rename, a folder rename, a
+ * move, and an auto-title all keep their positions by the rule they already
+ * use rather than by one this module guesses at.
+ */
+export function rewriteScrollMemory(rewrite: (path: string) => string) {
+	const moved = [...positions].map(
+		([path, top]) => [rewrite(path), top] as const,
+	);
+	positions.clear();
+	for (const [path, top] of moved) positions.set(path, top);
+}
+
+/** Called when the open folder changes, since those paths are gone from view. */
+export function forgetScrollPositions() {
+	positions.clear();
+}

--- a/apps/desktop/src/lib/useScrollMemory.ts
+++ b/apps/desktop/src/lib/useScrollMemory.ts
@@ -1,0 +1,39 @@
+import { useEffect } from "react";
+import { recallScroll, setScrollContainer } from "./scrollMemory";
+
+/** Roughly a second at 60fps, after which the note is not going to grow. */
+const RESTORE_FRAMES = 60;
+
+/**
+ * Puts a reopened note back where the user left it, and keeps the module's
+ * reference to the live scroll container current.
+ *
+ * Restoring has to outlast the editor filling in: the container serves every
+ * note and still holds the last one's content for a frame or two, so
+ * `scrollTop` is set again each frame until it sticks.
+ */
+export function useScrollMemory(
+	path: string | null,
+	container: HTMLElement | null,
+) {
+	useEffect(() => {
+		setScrollContainer(container);
+		if (!path || !container) return;
+
+		const target = recallScroll(path);
+		if (target === undefined || target <= 0) return;
+
+		let attempts = 0;
+		let frame = 0;
+		const apply = () => {
+			container.scrollTop = target;
+			attempts += 1;
+			if (container.scrollTop < target && attempts < RESTORE_FRAMES) {
+				frame = requestAnimationFrame(apply);
+			}
+		};
+		frame = requestAnimationFrame(apply);
+
+		return () => cancelAnimationFrame(frame);
+	}, [path, container]);
+}

--- a/apps/desktop/src/store/actions.test.ts
+++ b/apps/desktop/src/store/actions.test.ts
@@ -2382,8 +2382,8 @@ describe("desktop loadPath", () => {
 		const firstTabId = appStore.get().tabs.activeTabId;
 		expect(canGoBack()).toBe(true);
 
-		// Stand in for the second tab that step 4's actions will create: the
-		// trail follows the Active Tab, so a fresh tab starts with no history.
+		// The trail follows the Active Tab, so a fresh Tab starts with no
+		// history.
 		appStore.set((current) => ({
 			...current,
 			tabs: {

--- a/apps/desktop/src/store/actions.test.ts
+++ b/apps/desktop/src/store/actions.test.ts
@@ -2314,13 +2314,14 @@ describe("desktop loadPath", () => {
 		expect(canGoForward()).toBe(false);
 	});
 
-	it("keeps navigation history separate per workspace", async () => {
+	it("forgets navigation history when another workspace is opened", async () => {
 		const api = createDesktopApi();
 		api.pathExists.mockResolvedValue(true);
 		api.readFileText.mockImplementation(
 			async (path: string) => `content:${path}`,
 		);
-		const { appStore, canGoBack, loadPath } = await loadStoreActions(api);
+		const { appStore, canGoBack, loadPath, openWorkspace } =
+			await loadStoreActions(api);
 
 		appStore.set((current) => ({
 			...current,
@@ -2330,12 +2331,112 @@ describe("desktop loadPath", () => {
 		await loadPath("/workspace-a/b.md");
 		expect(canGoBack()).toBe(true);
 
-		appStore.set((current) => ({
-			...current,
-			workspace: { ...current.workspace, workspacePath: "/workspace-b" },
-		}));
+		await openWorkspace("/workspace-b");
 
 		expect(canGoBack()).toBe(false);
+	});
+
+	it("forgets the trails of tabs that are no longer open", async () => {
+		const api = createDesktopApi();
+		api.pathExists.mockResolvedValue(true);
+		api.readFileText.mockImplementation(
+			async (path: string) => `content:${path}`,
+		);
+		const { appStore, closeTab, historyStore, loadPath, openTabForPath } =
+			await loadStoreActions(api);
+
+		await loadPath("/workspace/a.md");
+		const first = appStore.get().tabs.activeTabId;
+		await openTabForPath("/workspace/b.md");
+		const second = appStore.get().tabs.activeTabId;
+		if (!first || !second) throw new Error("expected two tabs");
+		expect(Object.keys(historyStore.get().byTab).sort()).toEqual(
+			[first, second].sort(),
+		);
+
+		// A stack orphaned by any route out is unreachable, so the next
+		// navigation reconciles it away rather than each route remembering.
+		historyStore.set((state) => ({
+			...state,
+			byTab: {
+				...state.byTab,
+				"tab-orphaned": { entries: ["/gone.md"], index: 0 },
+			},
+		}));
+		await closeTab(second);
+		await loadPath("/workspace/c.md");
+
+		expect(Object.keys(historyStore.get().byTab)).toEqual([first]);
+	});
+
+	it("keeps navigation history separate per tab", async () => {
+		const api = createDesktopApi();
+		api.pathExists.mockResolvedValue(true);
+		api.readFileText.mockImplementation(
+			async (path: string) => `content:${path}`,
+		);
+		const { appStore, canGoBack, loadPath } = await loadStoreActions(api);
+
+		await loadPath("/workspace/a.md");
+		await loadPath("/workspace/b.md");
+		const firstTabId = appStore.get().tabs.activeTabId;
+		expect(canGoBack()).toBe(true);
+
+		// Stand in for the second tab that step 4's actions will create: the
+		// trail follows the Active Tab, so a fresh tab starts with no history.
+		appStore.set((current) => ({
+			...current,
+			tabs: {
+				order: [...current.tabs.order, "tab-second"],
+				activeTabId: "tab-second",
+				byId: {
+					...current.tabs.byId,
+					"tab-second": { path: "/workspace/c.md" },
+				},
+			},
+		}));
+		expect(canGoBack()).toBe(false);
+
+		appStore.set((current) => ({
+			...current,
+			tabs: { ...current.tabs, activeTabId: firstTabId },
+		}));
+		expect(canGoBack()).toBe(true);
+	});
+
+	it("saves dirty content before opening another file", async () => {
+		const api = createDesktopApi();
+		api.pathExists.mockResolvedValue(true);
+		api.readFileText.mockImplementation(
+			async (path: string) => `content:${path}`,
+		);
+		const { loadPath, updateEditorContent } = await loadStoreActions(api);
+
+		await loadPath("/workspace/a.md");
+		updateEditorContent("/workspace/a.md", "dirty");
+		// The editor's own debounced flush runs after the store has moved on, so
+		// the save has to happen here or the edit is dropped.
+		await loadPath("/workspace/b.md");
+
+		expect(api.writeFileText).toHaveBeenCalledWith("/workspace/a.md", "dirty");
+	});
+
+	it("does not write the current file back when reopening the same path", async () => {
+		const api = createDesktopApi();
+		api.pathExists.mockResolvedValue(true);
+		api.readFileText.mockImplementation(
+			async (path: string) => `content:${path}`,
+		);
+		const { loadPath, updateEditorContent } = await loadStoreActions(api);
+
+		await loadPath("/workspace/a.md");
+		updateEditorContent("/workspace/a.md", "dirty");
+		api.writeFileText.mockClear();
+		// The active-file watcher reloads the open path when a read fails. Saving
+		// first would restore a file that just disappeared.
+		await loadPath("/workspace/a.md");
+
+		expect(api.writeFileText).not.toHaveBeenCalled();
 	});
 
 	it("saves dirty content before navigating history", async () => {
@@ -2377,6 +2478,58 @@ describe("desktop loadPath", () => {
 
 		await goBack();
 
+		expect(viewerStore.get().currentPath).toBe("/workspace/b.md");
+	});
+
+	it("blocks opening another note while the current one has a disk conflict", async () => {
+		const api = createDesktopApi();
+		api.pathExists.mockResolvedValue(true);
+		api.readFileText.mockImplementation(
+			async (path: string) => `content:${path}`,
+		);
+		const { appStore, loadPath, viewerStore } = await loadStoreActions(api);
+
+		await loadPath("/workspace/a.md");
+		appStore.set((current) => ({
+			...current,
+			document: {
+				...current.document,
+				externalChange: { kind: "conflict", diskContent: "disk" },
+			},
+		}));
+
+		// The banner asking which copy wins cannot be answered from another
+		// note, so a sidebar click has to refuse the same way Back does.
+		await loadPath("/workspace/b.md");
+
+		expect(viewerStore.get().currentPath).toBe("/workspace/a.md");
+		expect(viewerStore.get().externalChange.kind).toBe("conflict");
+	});
+
+	it("blocks closing a tab while its note has a disk conflict", async () => {
+		const api = createDesktopApi();
+		api.pathExists.mockResolvedValue(true);
+		api.readFileText.mockImplementation(
+			async (path: string) => `content:${path}`,
+		);
+		const { appStore, closeTab, loadPath, openTabForPath, viewerStore } =
+			await loadStoreActions(api);
+
+		await loadPath("/workspace/a.md");
+		await openTabForPath("/workspace/b.md");
+		const conflicted = appStore.get().tabs.activeTabId;
+		if (!conflicted) throw new Error("expected a tab");
+		appStore.set((current) => ({
+			...current,
+			document: {
+				...current.document,
+				externalChange: { kind: "conflict", diskContent: "disk" },
+			},
+		}));
+
+		await closeTab(conflicted);
+
+		expect(appStore.get().tabs.order).toContain(conflicted);
 		expect(viewerStore.get().currentPath).toBe("/workspace/b.md");
 	});
 
@@ -2572,5 +2725,384 @@ describe("desktop pinned notes", () => {
 			version: 1,
 			pinnedNotes: [],
 		});
+	});
+});
+
+describe("desktop tabs", () => {
+	it("opens a tab for the loaded file", async () => {
+		const api = createDesktopApi();
+		api.pathExists.mockResolvedValue(true);
+		api.readFileText.mockResolvedValue("content");
+		const { appStore, loadPath } = await loadStoreActions(api);
+
+		await loadPath("/workspace/a.md");
+
+		const { order, activeTabId, byId } = appStore.get().tabs;
+		expect(order).toHaveLength(1);
+		expect(activeTabId).toBe(order[0]);
+		expect(byId[order[0]].path).toBe("/workspace/a.md");
+	});
+
+	it("reuses the active tab when opening another file", async () => {
+		const api = createDesktopApi();
+		api.pathExists.mockResolvedValue(true);
+		api.readFileText.mockResolvedValue("content");
+		const { appStore, loadPath } = await loadStoreActions(api);
+
+		await loadPath("/workspace/a.md");
+		const firstId = appStore.get().tabs.activeTabId;
+		await loadPath("/workspace/b.md");
+
+		const { order, activeTabId, byId } = appStore.get().tabs;
+		expect(order).toEqual([firstId]);
+		expect(activeTabId).toBe(firstId);
+		expect(byId[order[0]].path).toBe("/workspace/b.md");
+	});
+
+	it("keeps the tab pointing at the open document when a load fails", async () => {
+		const api = createDesktopApi();
+		api.pathExists.mockResolvedValue(true);
+		api.readFileText.mockImplementation(async (path: string) => {
+			if (path === "/workspace/missing.md") throw new Error("ENOENT");
+			return "content";
+		});
+		const { appStore, loadPath, viewerStore } = await loadStoreActions(api);
+
+		await loadPath("/workspace/a.md");
+		await loadPath("/workspace/missing.md");
+
+		const { order, byId } = appStore.get().tabs;
+		expect(order).toHaveLength(1);
+		expect(byId[order[0]].path).toBe("/workspace/a.md");
+		expect(viewerStore.get().currentPath).toBe("/workspace/a.md");
+	});
+
+	it("closes tabs when the viewer is cleared", async () => {
+		const api = createDesktopApi();
+		api.pathExists.mockResolvedValue(true);
+		api.readFileText.mockResolvedValue("content");
+		const { appStore, clearViewer, loadPath } = await loadStoreActions(api);
+
+		await loadPath("/workspace/a.md");
+		clearViewer();
+
+		expect(appStore.get().tabs.order).toEqual([]);
+		expect(appStore.get().tabs.activeTabId).toBeNull();
+	});
+
+	it("does not persist tabs across a relaunch", async () => {
+		const api = createDesktopApi();
+		api.pathExists.mockResolvedValue(true);
+		api.readFileText.mockResolvedValue("content");
+		const { STORAGE_KEY } = await import("./persistence");
+		const { appStore, loadPath } = await loadStoreActions(api);
+
+		await loadPath("/workspace/a.md");
+		expect(appStore.get().tabs.order).toHaveLength(1);
+
+		const [, written] = vi.mocked(localStorage.setItem).mock.lastCall ?? [];
+		expect(vi.mocked(localStorage.setItem).mock.lastCall?.[0]).toBe(
+			STORAGE_KEY,
+		);
+		expect(JSON.parse(written ?? "{}")).not.toHaveProperty("tabs");
+
+		const relaunched = await loadStoreActions(createDesktopApi(), written);
+
+		expect(relaunched.appStore.get().tabs.order).toEqual([]);
+	});
+
+	it("opens a second tab beside the active one", async () => {
+		const api = createDesktopApi();
+		api.pathExists.mockResolvedValue(true);
+		api.readFileText.mockResolvedValue("content");
+		const { appStore, loadPath, openTabForPath, viewerStore } =
+			await loadStoreActions(api);
+
+		await loadPath("/workspace/a.md");
+		const first = appStore.get().tabs.activeTabId;
+		await openTabForPath("/workspace/b.md");
+
+		const { order, activeTabId, byId } = appStore.get().tabs;
+		expect(order).toHaveLength(2);
+		expect(order[0]).toBe(first);
+		expect(activeTabId).toBe(order[1]);
+		expect(byId[order[0]].path).toBe("/workspace/a.md");
+		expect(byId[order[1]].path).toBe("/workspace/b.md");
+		expect(viewerStore.get().currentPath).toBe("/workspace/b.md");
+	});
+
+	it("focuses the open tab instead of opening the same note twice", async () => {
+		const api = createDesktopApi();
+		api.pathExists.mockResolvedValue(true);
+		api.readFileText.mockResolvedValue("content");
+		const { appStore, loadPath, openTabForPath } = await loadStoreActions(api);
+
+		await loadPath("/workspace/a.md");
+		const first = appStore.get().tabs.activeTabId;
+		await openTabForPath("/workspace/b.md");
+		// Two tabs on one note would give it two autosave timers.
+		await openTabForPath("/workspace/a.md");
+
+		expect(appStore.get().tabs.order).toHaveLength(2);
+		expect(appStore.get().tabs.activeTabId).toBe(first);
+	});
+
+	it("activating a tab reloads its note without extending the trail", async () => {
+		const api = createDesktopApi();
+		api.pathExists.mockResolvedValue(true);
+		api.readFileText.mockImplementation(
+			async (path: string) => `content:${path}`,
+		);
+		const { activateTab, appStore, canGoBack, loadPath, openTabForPath } =
+			await loadStoreActions(api);
+
+		await loadPath("/workspace/a.md");
+		const first = appStore.get().tabs.activeTabId;
+		if (!first) throw new Error("expected a tab");
+		await openTabForPath("/workspace/b.md");
+		expect(canGoBack()).toBe(false);
+
+		await activateTab(first);
+
+		expect(appStore.get().document.currentPath).toBe("/workspace/a.md");
+		// The first tab only ever visited one note, so its trail stays flat.
+		expect(canGoBack()).toBe(false);
+	});
+
+	it("closing the active tab moves to the next one and opens it", async () => {
+		const api = createDesktopApi();
+		api.pathExists.mockResolvedValue(true);
+		api.readFileText.mockImplementation(
+			async (path: string) => `content:${path}`,
+		);
+		const { appStore, closeTab, loadPath, openTabForPath, viewerStore } =
+			await loadStoreActions(api);
+
+		await loadPath("/workspace/a.md");
+		const first = appStore.get().tabs.activeTabId;
+		await openTabForPath("/workspace/b.md");
+		const second = appStore.get().tabs.activeTabId;
+		if (!first || !second) throw new Error("expected two tabs");
+
+		await closeTab(second);
+
+		expect(appStore.get().tabs.order).toEqual([first]);
+		expect(appStore.get().tabs.activeTabId).toBe(first);
+		expect(viewerStore.get().currentPath).toBe("/workspace/a.md");
+	});
+
+	it("closing the last tab empties the editor", async () => {
+		const api = createDesktopApi();
+		api.pathExists.mockResolvedValue(true);
+		api.readFileText.mockResolvedValue("content");
+		const { appStore, closeTab, loadPath, viewerStore } =
+			await loadStoreActions(api);
+
+		await loadPath("/workspace/a.md");
+		const only = appStore.get().tabs.activeTabId;
+		if (!only) throw new Error("expected a tab");
+
+		await closeTab(only);
+
+		expect(appStore.get().tabs.order).toEqual([]);
+		expect(appStore.get().tabs.activeTabId).toBeNull();
+		expect(viewerStore.get().currentPath).toBeNull();
+	});
+
+	it("rewrites a background tab when its file is renamed", async () => {
+		const api = createDesktopApi();
+		api.pathExists.mockResolvedValue(true);
+		api.readFileText.mockImplementation(
+			async (path: string) => `content:${path}`,
+		);
+		api.listDirectory.mockResolvedValue({ files: [], folders: [] });
+		const { appStore, loadPath, openTabForPath, renameMarkdownFile } =
+			await loadStoreActions(api);
+
+		appStore.set((current) => ({
+			...current,
+			workspace: { ...current.workspace, workspacePath: "/workspace" },
+		}));
+		await loadPath("/workspace/a.md");
+		const background = appStore.get().tabs.activeTabId;
+		await openTabForPath("/workspace/b.md");
+
+		// Renaming a note nobody is looking at still has to move its tab.
+		await renameMarkdownFile("/workspace/a.md", "renamed");
+
+		if (!background) throw new Error("expected a tab");
+		expect(appStore.get().tabs.byId[background].path).toBe(
+			"/workspace/renamed.md",
+		);
+	});
+
+	it("closes a background tab when its file is deleted, and reopens it on undo", async () => {
+		const api = createDesktopApi();
+		api.pathExists.mockResolvedValue(true);
+		api.readFileText.mockImplementation(
+			async (path: string) => `content:${path}`,
+		);
+		api.listDirectory.mockResolvedValue({ files: [], folders: [] });
+		const toast = Object.assign(
+			vi.fn(() => "delete-undo"),
+			{
+				dismiss: vi.fn(),
+				success: vi.fn(),
+				error: vi.fn(),
+			},
+		);
+		vi.doMock("sonner", () => ({ toast }));
+		const {
+			appStore,
+			deleteSidebarItems,
+			loadPath,
+			openTabForPath,
+			undoDelete,
+		} = await loadStoreActions(api);
+
+		appStore.set((current) => ({
+			...current,
+			workspace: { ...current.workspace, workspacePath: "/workspace" },
+		}));
+		await loadPath("/workspace/a.md");
+		const background = appStore.get().tabs.activeTabId;
+		await openTabForPath("/workspace/b.md");
+		const visible = appStore.get().tabs.activeTabId;
+
+		await deleteSidebarItems([{ kind: "file", path: "/workspace/a.md" }]);
+
+		expect(appStore.get().tabs.order).toEqual([visible]);
+
+		await undoDelete();
+
+		// Undo puts the closed tab back where it was, ahead of the visible one.
+		expect(appStore.get().tabs.order).toEqual([background, visible]);
+		vi.doUnmock("sonner");
+	});
+
+	it("leaves no document behind when tabs are closed back to back", async () => {
+		const api = createDesktopApi();
+		api.pathExists.mockResolvedValue(true);
+		api.readFileText.mockImplementation(
+			async (path: string) => `content:${path}`,
+		);
+		const { appStore, closeTab, loadPath, openTabForPath, viewerStore } =
+			await loadStoreActions(api);
+
+		await loadPath("/workspace/a.md");
+		await openTabForPath("/workspace/b.md");
+		await openTabForPath("/workspace/c.md");
+		const open = [...appStore.get().tabs.order];
+		expect(open).toHaveLength(3);
+
+		// Closing without awaiting each one is what a user does with a fast
+		// double click. Every close must see the strip the one before it left.
+		await Promise.all(open.map((id) => closeTab(id)));
+
+		expect(appStore.get().tabs.order).toEqual([]);
+		expect(appStore.get().tabs.activeTabId).toBeNull();
+		// The editor must not still be holding a note that has no tab.
+		expect(viewerStore.get().currentPath).toBeNull();
+	});
+
+	it("does not reload the note already in front", async () => {
+		const api = createDesktopApi();
+		api.pathExists.mockResolvedValue(true);
+		api.readFileText.mockImplementation(
+			async (path: string) => `content:${path}`,
+		);
+		const { activateTab, appStore, loadPath } = await loadStoreActions(api);
+
+		await loadPath("/workspace/a.md");
+		const only = appStore.get().tabs.activeTabId;
+		if (!only) throw new Error("expected a tab");
+		api.readFileText.mockClear();
+
+		await activateTab(only);
+
+		// Re-reading would reset undo and view mode for a click that changed
+		// nothing.
+		expect(api.readFileText).not.toHaveBeenCalled();
+	});
+
+	it("reloads the active tab when the changelog is covering it", async () => {
+		const api = createDesktopApi();
+		api.pathExists.mockResolvedValue(true);
+		api.readFileText.mockImplementation(
+			async (path: string) => `content:${path}`,
+		);
+		const { activateTab, appStore, loadPath, openChangelog, viewerStore } =
+			await loadStoreActions(api);
+
+		await loadPath("/workspace/a.md");
+		const only = appStore.get().tabs.activeTabId;
+		if (!only) throw new Error("expected a tab");
+		expect(await openChangelog()).toBe(true);
+		expect(viewerStore.get().currentPath).not.toBe("/workspace/a.md");
+
+		// The changelog has no tab of its own, so its tab stayed active while
+		// its note was off screen. Activating it must bring the note back.
+		await activateTab(only);
+
+		expect(viewerStore.get().currentPath).toBe("/workspace/a.md");
+	});
+
+	it("closes the other tabs without disturbing the one in front", async () => {
+		const api = createDesktopApi();
+		api.pathExists.mockResolvedValue(true);
+		api.readFileText.mockImplementation(
+			async (path: string) => `content:${path}`,
+		);
+		const { appStore, closeOtherTabs, loadPath, openTabForPath, viewerStore } =
+			await loadStoreActions(api);
+
+		await loadPath("/workspace/a.md");
+		await openTabForPath("/workspace/b.md");
+		await openTabForPath("/workspace/c.md");
+		const kept = appStore.get().tabs.activeTabId;
+
+		await closeOtherTabs();
+
+		expect(appStore.get().tabs.order).toEqual([kept]);
+		expect(viewerStore.get().currentPath).toBe("/workspace/c.md");
+	});
+
+	it("closes every tab and empties the editor", async () => {
+		const api = createDesktopApi();
+		api.pathExists.mockResolvedValue(true);
+		api.readFileText.mockImplementation(
+			async (path: string) => `content:${path}`,
+		);
+		const { appStore, closeAllTabs, loadPath, openTabForPath, viewerStore } =
+			await loadStoreActions(api);
+
+		await loadPath("/workspace/a.md");
+		await openTabForPath("/workspace/b.md");
+
+		await closeAllTabs();
+
+		expect(appStore.get().tabs.order).toEqual([]);
+		expect(viewerStore.get().currentPath).toBeNull();
+	});
+
+	it("steps between tabs and wraps at either end", async () => {
+		const api = createDesktopApi();
+		api.pathExists.mockResolvedValue(true);
+		api.readFileText.mockImplementation(
+			async (path: string) => `content:${path}`,
+		);
+		const { activateAdjacentTab, appStore, loadPath, openTabForPath } =
+			await loadStoreActions(api);
+
+		await loadPath("/workspace/a.md");
+		const first = appStore.get().tabs.activeTabId;
+		await openTabForPath("/workspace/b.md");
+		const second = appStore.get().tabs.activeTabId;
+
+		// Forward from the last tab comes back round to the first.
+		await activateAdjacentTab(1);
+		expect(appStore.get().tabs.activeTabId).toBe(first);
+		await activateAdjacentTab(-1);
+		expect(appStore.get().tabs.activeTabId).toBe(second);
 	});
 });

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -36,6 +36,11 @@ import {
 	rewriteMovedLinks,
 } from "../lib/markdownLinkRewrite";
 import {
+	captureScroll,
+	forgetScrollPositions,
+	rewriteScrollMemory,
+} from "../lib/scrollMemory";
+import {
 	setThemePreference as applyThemePreference,
 	initTheme,
 	type ThemePreference,
@@ -45,8 +50,10 @@ import {
 	activeHistory,
 	canGoBack,
 	canGoForward,
+	dropHistory,
 	normalizeStack,
 	pushHistory,
+	resetHistory,
 	rewriteHistory,
 	setHistory,
 } from "./history";
@@ -72,6 +79,7 @@ import {
 	type SortMode,
 	sidebarOpenStore,
 	switcherOpenStore,
+	tabsStore,
 	themePreferenceStore,
 	uiStore,
 	type ViewMode,
@@ -79,6 +87,15 @@ import {
 	withOpenedDoc,
 	workspaceStore,
 } from "./state";
+import {
+	emptyTabs,
+	findTabByPath,
+	nextActiveTabId,
+	type TabId,
+	type TabTarget,
+	withClosedTab,
+	withRewrittenTabPaths,
+} from "./tabs";
 import { createTitleManager } from "./titleManagement";
 import { applyWorkspaceDelta } from "./workspaceDelta";
 
@@ -498,6 +515,8 @@ type LoadPathOptions = {
 	missing?: "toast" | "silent";
 	/** `false` keeps code files in Hubble regardless of the default-app preference. */
 	launchExternal?: boolean;
+	/** Defaults to the Active Tab, so callers that predate tabs are unchanged. */
+	tab?: TabTarget;
 };
 
 export function getPendingRenameTarget(path: string) {
@@ -611,7 +630,13 @@ export function clearPendingTerminalCommand() {
 export function clearViewer() {
 	const path = viewerStore.get().currentPath;
 	if (path) titleManager.stop(path);
-	viewerStore.set((state) => emptyDoc(state.lastOpenedPath));
+	// Every Tab goes, so every trail goes with it.
+	resetHistory();
+	appStore.set((state) => ({
+		...state,
+		tabs: emptyTabs(),
+		document: emptyDoc(state.document.lastOpenedPath),
+	}));
 }
 
 /** Opens a workspace and reveals the sidebar. */
@@ -662,16 +687,26 @@ export async function openWorkspace(path?: string) {
 		await expireDeleteUndo();
 	}
 
-	workspaceStore.set((state) => {
-		const filtered = state.recentWorkspaces.filter((p) => p !== nextPath);
+	// Tabs belong to the open folder: their notes live in it, and their trails
+	// record paths inside it. Opening another folder starts a fresh set.
+	appStore.set((state) => {
+		const filtered = state.workspace.recentWorkspaces.filter(
+			(p) => p !== nextPath,
+		);
 		return {
 			...state,
-			workspacePath: nextPath,
-			recentWorkspaces: [nextPath, ...filtered].slice(0, MAX_RECENT),
-			files: [],
-			pinnedNotes: [],
+			tabs: emptyTabs(),
+			workspace: {
+				...state.workspace,
+				workspacePath: nextPath,
+				recentWorkspaces: [nextPath, ...filtered].slice(0, MAX_RECENT),
+				files: [],
+				pinnedNotes: [],
+			},
 		};
 	});
+	resetHistory();
+	forgetScrollPositions();
 	switcherOpenStore.set(false);
 	await Promise.all([refreshFileList(nextPath), loadPinnedNotes(nextPath)]);
 
@@ -822,6 +857,41 @@ export function savePathContent(
 	);
 }
 
+/**
+ * Steps off the open document: records where the user was, writes their edits,
+ * and reports whether leaving is allowed. Every route out of a note goes
+ * through here, so opening a note, closing its Tab, and moving through history
+ * all leave it the same way.
+ *
+ * Saving here rather than letting the editor's unmount flush do it is what
+ * makes leaving reliable. That flush runs after the store has already moved to
+ * the next path, so `savePathContentNow` sees a path that is no longer current
+ * and drops the write.
+ *
+ * Returns false when the note is in conflict, since the banner asking whether
+ * the disk copy or the open copy wins cannot be answered from another note.
+ */
+async function leaveCurrentDocument(nextPath?: string): Promise<boolean> {
+	const { currentPath, content } = viewerStore.get();
+	if (!currentPath) return true;
+	// Reopening the same path is not leaving it, and skipping that case
+	// matters: the active-file watcher reloads the current path when a read
+	// fails, and saving first would write a file that just disappeared back
+	// to disk.
+	if (nextPath && pathEquals(currentPath, nextPath)) return true;
+	// The editor's scroll container is shared between notes and resets as soon
+	// as the next one renders, so where the user was has to be read now.
+	captureScroll(currentPath);
+	await savePathContent(currentPath, content);
+	if (viewerStore.get().externalChange.kind !== "conflict") return true;
+	// Refusing without saying so reads as a dead click, and the banner offering
+	// the choice can be off screen behind the sidebar.
+	toast.error("This note changed on disk", {
+		description: "Choose which version to keep before leaving it.",
+	});
+	return false;
+}
+
 const deletionActions = createDeleteActions({
 	saveBeforeDelete: (path, content) =>
 		saves.run(path, () =>
@@ -882,6 +952,9 @@ export async function renameMarkdownFile(path: string, nextName: string) {
 		if (movedAssetFolder) movedFiles.push(movedAssetFolder);
 		await updateMovedLinks(movedFiles, filesBeforeRename);
 		rewriteHistory(path, nextPath);
+		rewriteScrollMemory((scrolled) =>
+			scrolled === path ? nextPath : scrolled,
+		);
 		appStore.set((state) => ({
 			...state,
 			workspace: {
@@ -901,6 +974,9 @@ export async function renameMarkdownFile(path: string, nextName: string) {
 					),
 				),
 			},
+			tabs: withRewrittenTabPaths(state.tabs, (tabPath) =>
+				tabPath === path ? nextPath : tabPath,
+			),
 			document: {
 				...state.document,
 				currentPath:
@@ -1011,6 +1087,9 @@ export async function renameFolder(
 		await desktopApi.renameFile(path, nextPath);
 		await deleteEmptySourceAncestors(path, nextPath, workspacePath);
 		rewriteHistory(path, nextPath, true);
+		rewriteScrollMemory((scrolled) =>
+			replacePathPrefix(scrolled, path, nextPath),
+		);
 		appStore.set((state) => ({
 			...state,
 			workspace: {
@@ -1035,6 +1114,9 @@ export async function renameFolder(
 					),
 				),
 			},
+			tabs: withRewrittenTabPaths(state.tabs, (tabPath) =>
+				replacePathPrefix(tabPath, path, nextPath),
+			),
 			document: {
 				...state.document,
 				currentPath: state.document.currentPath
@@ -1122,6 +1204,9 @@ export async function moveSidebarItem(
 				? await moveAssociatedAssetFolder(sourcePath, nextPath)
 				: null;
 		rewriteHistory(sourcePath, nextPath, isFolder);
+		rewriteScrollMemory((scrolled) =>
+			replacePathPrefix(scrolled, sourcePath, nextPath),
+		);
 		appStore.set((state) => ({
 			...state,
 			workspace: {
@@ -1142,6 +1227,9 @@ export async function moveSidebarItem(
 					),
 				),
 			},
+			tabs: withRewrittenTabPaths(state.tabs, (tabPath) =>
+				replacePathPrefix(tabPath, sourcePath, nextPath),
+			),
 			document: {
 				...state.document,
 				currentPath: state.document.currentPath
@@ -1275,6 +1363,8 @@ const { run: loadInternalPath, invalidate: invalidateLoadPath } = takeLatest(
 		const historyMode = options?.history ?? "push";
 		const missingMode = options?.missing ?? "toast";
 		const fileKind = fileKindForPath(path);
+		if (!(await leaveCurrentDocument(path))) return;
+		if (isStale()) return;
 		const timer = window.setTimeout(() => {
 			if (isStale()) return;
 			viewerStore.set((state) => ({
@@ -1296,7 +1386,9 @@ const { run: loadInternalPath, invalidate: invalidateLoadPath } = takeLatest(
 			if (currentPath && !pathEquals(currentPath, path)) {
 				titleManager.stop(currentPath);
 			}
-			appStore.set((state) => withOpenedDoc(state, path, content));
+			appStore.set((state) =>
+				withOpenedDoc(state, path, content, options?.tab),
+			);
 			if (historyMode === "push") pushHistory(path);
 		} catch (err) {
 			if (isStale()) return;
@@ -1311,6 +1403,10 @@ const { run: loadInternalPath, invalidate: invalidateLoadPath } = takeLatest(
 						: state,
 				);
 			} else {
+				// The file is gone rather than unreadable, so only the Tab holding
+				// it closes. Other Tabs point at files that are still there.
+				const gone = findTabByPath(tabsStore.get(), path);
+				if (gone) dropHistory(gone);
 				appStore.set((state) => ({
 					...state,
 					workspace: {
@@ -1321,12 +1417,24 @@ const { run: loadInternalPath, invalidate: invalidateLoadPath } = takeLatest(
 							),
 						),
 					},
+					tabs: gone ? withClosedTab(state.tabs, gone) : state.tabs,
 					document: emptyDoc(
 						state.document.lastOpenedPath === path
 							? null
 							: state.document.lastOpenedPath,
 					),
 				}));
+				// Falling back to a neighbouring Tab has to wait for this run to
+				// finish, or `takeLatest` cancels the load it starts.
+				const fallback = tabsStore.get().activeTabId;
+				const next = fallback ? tabsStore.get().byId[fallback]?.path : null;
+				if (next) {
+					void loadPath(next, {
+						history: "none",
+						launchExternal: false,
+						tab: fallback ?? undefined,
+					});
+				}
 			}
 		} finally {
 			window.clearTimeout(timer);
@@ -1357,6 +1465,112 @@ export async function loadPath(path: string, options?: LoadPathOptions) {
 }
 
 /**
+ * Opens `path` in its own Tab, focusing the Tab already showing it rather than
+ * opening a second one. Two Tabs on one note would give it two autosave timers
+ * writing the same file.
+ */
+export async function openTabForPath(path: string) {
+	const open = findTabByPath(tabsStore.get(), path);
+	if (open) {
+		await activateTab(open);
+		return;
+	}
+	await loadPath(path, { tab: "new" });
+}
+
+/**
+ * Shows the note a Tab is holding. Activation re-reads from disk the way a
+ * sidebar click does, so it neither pushes onto that Tab's trail nor launches
+ * an external app for a code file — `navigateHistory` takes the same care.
+ */
+export async function activateTab(id: TabId) {
+	const tabs = tabsStore.get();
+	const tab = tabs.byId[id];
+	if (!tab) return;
+	// Clicking the Tab already in front would re-read from disk and throw away
+	// undo for nothing. Switching notes costs undo; clicking where you already
+	// are should not.
+	//
+	// The check looks at the note on screen, not just the Active Tab, because
+	// the changelog covers the editor without a Tab of its own: its Tab stays
+	// active while its note is hidden, and activating it has to reload.
+	const showing = viewerStore.get().currentPath;
+	if (tabs.activeTabId === id && pathEquals(showing ?? "", tab.path)) return;
+	await loadPath(tab.path, {
+		history: "none",
+		launchExternal: false,
+		tab: id,
+	});
+}
+
+/**
+ * Closes a Tab and its back/forward trail, moving to the neighbour it leaves
+ * behind. Closing the last Tab empties the editor rather than picking a note.
+ */
+export async function closeTab(id: TabId) {
+	const tabs = tabsStore.get();
+	if (!tabs.byId[id]) return;
+	const wasActive = tabs.activeTabId === id;
+	const next = wasActive ? nextActiveTabId(tabs, id) : null;
+
+	if (wasActive && !(await leaveCurrentDocument())) return;
+	dropHistory(id);
+	appStore.set((state) => ({ ...state, tabs: withClosedTab(state.tabs, id) }));
+
+	if (!wasActive) return;
+	const nextPath = next ? tabsStore.get().byId[next]?.path : null;
+	if (nextPath && next) {
+		await loadPath(nextPath, {
+			history: "none",
+			launchExternal: false,
+			tab: next,
+		});
+		return;
+	}
+	appStore.set((state) => ({
+		...state,
+		document: emptyDoc(state.document.lastOpenedPath),
+	}));
+}
+
+/**
+ * Closes every Tab but the one in front. Opening a note from the sidebar gives
+ * it a Tab, so browsing leaves a row of them behind; this is the way back to
+ * one note without clicking every cross.
+ */
+export async function closeOtherTabs() {
+	const { order, activeTabId } = tabsStore.get();
+	if (!activeTabId) return;
+	for (const id of order) {
+		if (id !== activeTabId) await closeTab(id);
+	}
+}
+
+/** Closes every Tab, emptying the editor. */
+export async function closeAllTabs() {
+	// Background Tabs go first, or closing the front one would load a
+	// neighbour that is about to close anyway.
+	await closeOtherTabs();
+	await closeActiveTab();
+}
+
+/** Closes whichever Tab is in front. No-op when none is. */
+export async function closeActiveTab() {
+	const active = tabsStore.get().activeTabId;
+	if (active) await closeTab(active);
+}
+
+/** Steps to the Tab `delta` places away, wrapping at either end. */
+export async function activateAdjacentTab(delta: number) {
+	const { order, activeTabId } = tabsStore.get();
+	if (order.length < 2 || !activeTabId) return;
+	const at = order.indexOf(activeTabId);
+	if (at < 0) return;
+	const next = order[(at + delta + order.length) % order.length];
+	await activateTab(next);
+}
+
+/**
  * Opens the app changelog as an ephemeral note. It never touches disk or
  * history: `lastOpenedPath` and the workspace's `lastOpenedPaths` keep the
  * real note so relaunch restores it, and the stack index stays put so back
@@ -1365,10 +1579,7 @@ export async function loadPath(path: string, options?: LoadPathOptions) {
 export async function openChangelog(): Promise<boolean> {
 	const current = viewerStore.get();
 	if (isChangelogPath(current.currentPath)) return true;
-	if (current.currentPath) {
-		await savePathContent(current.currentPath, current.content);
-		if (viewerStore.get().externalChange.kind === "conflict") return false;
-	}
+	if (!(await leaveCurrentDocument())) return false;
 	// An in-flight loadPath must not resolve over the changelog.
 	invalidateLoadPath();
 	viewerStore.set((state) => ({
@@ -1396,10 +1607,7 @@ async function navigateHistory(delta: -1 | 1) {
 	// Block concurrent history ops for the whole leave (save + load).
 	historyStore.set((state) => ({ ...state, isNavigating: true }));
 	try {
-		if (current.currentPath) {
-			await savePathContent(current.currentPath, current.content);
-			if (viewerStore.get().externalChange.kind === "conflict") return;
-		}
+		if (!(await leaveCurrentDocument())) return;
 
 		let working = activeHistory();
 		let nextIndex = working.index + (fromChangelog ? 0 : delta);

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -1508,12 +1508,19 @@ export async function activateTab(id: TabId) {
  * behind. Closing the last Tab empties the editor rather than picking a note.
  */
 export async function closeTab(id: TabId) {
+	if (!tabsStore.get().byId[id]) return;
+	if (tabsStore.get().activeTabId === id && !(await leaveCurrentDocument()))
+		return;
+
+	// Read the Tabs after leaving, not before: saving the outgoing note is a
+	// round trip to disk, and a delete landing while it is in flight closes
+	// Tabs underneath us. Deciding on the stale snapshot would then load a
+	// neighbour that is itself gone.
 	const tabs = tabsStore.get();
 	if (!tabs.byId[id]) return;
 	const wasActive = tabs.activeTabId === id;
 	const next = wasActive ? nextActiveTabId(tabs, id) : null;
 
-	if (wasActive && !(await leaveCurrentDocument())) return;
 	dropHistory(id);
 	appStore.set((state) => ({ ...state, tabs: withClosedTab(state.tabs, id) }));
 

--- a/apps/desktop/src/store/deleteActions.ts
+++ b/apps/desktop/src/store/deleteActions.ts
@@ -8,9 +8,12 @@ import {
 	appStore,
 	emptyDoc,
 	historyStore,
+	tabsStore,
 	viewerStore,
 	workspaceStore,
 } from "./state";
+
+import { findTabByPath, type TabId, withoutTabsMatching } from "./tabs";
 
 const UNDO_MS = 5000;
 
@@ -22,6 +25,10 @@ type PendingDelete = {
 	removedLastOpened: Record<string, string>;
 	historyBefore: ReturnType<typeof historyStore.get>;
 	historyAfter: ReturnType<typeof historyStore.get>;
+	// Snapshotting the whole slice restores closed Tabs at their old positions,
+	// the same trick the history stacks above use.
+	tabsBefore: ReturnType<typeof tabsStore.get>;
+	tabsAfter: ReturnType<typeof tabsStore.get>;
 	pinRemovalSaved: Promise<void>;
 	toastId: string | number | null;
 	claimed: boolean;
@@ -34,7 +41,7 @@ type DeleteDeps = {
 	refreshFileList: () => Promise<void>;
 	loadPath: (
 		path: string,
-		options: { history: "none"; launchExternal: false },
+		options: { history: "none"; launchExternal: false; tab?: TabId },
 	) => Promise<void>;
 	syncPins: () => Promise<void>;
 	stopTitleRenames: (path: string) => void;
@@ -127,11 +134,26 @@ export function createDeleteActions(deps: DeleteDeps) {
 			if (historyStore.get() === deletion.historyAfter) {
 				historyStore.set(deletion.historyBefore);
 			}
+			// Only restore Tabs the user has not rearranged since; otherwise the
+			// undo would throw away newer work to reinstate a stale strip.
+			if (tabsStore.get() === deletion.tabsAfter) {
+				appStore.set((state) => ({ ...state, tabs: deletion.tabsBefore }));
+			}
 			await deps.refreshFiles(deletion.workspacePath);
-			if (deletion.reopenPath && viewerStore.get().currentPath === null) {
+			const restoredTab = deletion.reopenPath
+				? findTabByPath(tabsStore.get(), deletion.reopenPath)
+				: null;
+			// Reopen when the editor is empty, or when restoring put the deleted
+			// note's Tab back in front. Anywhere else the user has moved on.
+			if (
+				deletion.reopenPath &&
+				(viewerStore.get().currentPath === null ||
+					(restoredTab !== null && tabsStore.get().activeTabId === restoredTab))
+			) {
 				await deps.loadPath(deletion.reopenPath, {
 					history: "none",
 					launchExternal: false,
+					tab: restoredTab ?? undefined,
 				});
 			}
 			await deps.syncPins();
@@ -210,16 +232,18 @@ export function createDeleteActions(deps: DeleteDeps) {
 				deletedPath(path),
 			),
 		);
+		// Background Tabs can be showing deleted files too, so their trails are
+		// pruned whether or not the visible note was one of them.
+		for (const item of items) {
+			if (item.kind === "file") pruneHistory(item.path);
+			else pruneHistory(item.folderId, true);
+		}
 		if (deletedCurrent) {
 			if (viewerBefore.currentPath)
 				deps.stopTitleRenames(viewerBefore.currentPath);
 			clearHistory();
-		} else {
-			for (const item of items) {
-				if (item.kind === "file") pruneHistory(item.path);
-				else pruneHistory(item.folderId, true);
-			}
 		}
+		const tabsBefore = tabsStore.get();
 		appStore.set((state) => ({
 			...state,
 			workspace: {
@@ -237,6 +261,7 @@ export function createDeleteActions(deps: DeleteDeps) {
 					),
 				),
 			},
+			tabs: withoutTabsMatching(state.tabs, deletedPath),
 			document: deletedCurrent
 				? emptyDoc(
 						state.document.lastOpenedPath &&
@@ -253,6 +278,21 @@ export function createDeleteActions(deps: DeleteDeps) {
 								: state.document.lastOpenedPath,
 					},
 		}));
+		// Deleting the visible note leaves whichever Tab survived it focused, so
+		// the editor follows rather than sitting empty behind a live Tab strip.
+		if (deletedCurrent) {
+			const survivor = tabsStore.get().activeTabId;
+			const survivorPath = survivor
+				? tabsStore.get().byId[survivor]?.path
+				: null;
+			if (survivor && survivorPath) {
+				await deps.loadPath(survivorPath, {
+					history: "none",
+					launchExternal: false,
+					tab: survivor,
+				});
+			}
+		}
 		const pinRemovalSaved = deps.syncPins();
 		const deletion: PendingDelete = {
 			token,
@@ -262,6 +302,8 @@ export function createDeleteActions(deps: DeleteDeps) {
 			removedLastOpened,
 			historyBefore,
 			historyAfter: historyStore.get(),
+			tabsBefore,
+			tabsAfter: tabsStore.get(),
 			pinRemovalSaved,
 			toastId: null,
 			claimed: false,
@@ -321,6 +363,7 @@ export function createDeleteActions(deps: DeleteDeps) {
 						),
 					),
 				},
+				tabs: withoutTabsMatching(state.tabs, (tabPath) => tabPath === path),
 				document:
 					state.document.currentPath === path
 						? emptyDoc(
@@ -368,6 +411,9 @@ export function createDeleteActions(deps: DeleteDeps) {
 						),
 					),
 				},
+				tabs: withoutTabsMatching(state.tabs, (tabPath) =>
+					pathInFolder(tabPath, path),
+				),
 				document:
 					state.document.currentPath &&
 					pathInFolder(state.document.currentPath, path)

--- a/apps/desktop/src/store/history.ts
+++ b/apps/desktop/src/store/history.ts
@@ -1,28 +1,27 @@
 import { isChangelogPath } from "../lib/changelogNote";
 import { pathInFolder, replacePathPrefix } from "../lib/filePath";
 import {
+	activeTabIdStore,
 	currentPathStore,
 	type HistoryStack,
 	type HistoryState,
 	historyStore,
 	MAX_HISTORY,
-	workspaceStore,
+	tabsStore,
 } from "./state";
+import type { TabId } from "./tabs";
 
 /**
- * Per-workspace back/forward stacks over opened file paths.
+ * Per-tab back/forward stacks over opened file paths.
  *
  * This module owns reads and writes of `historyStore`. Navigation itself
  * (save current doc, load target) lives in actions.ts to avoid an import
  * cycle with `loadPath`.
+ *
+ * Keying by tab rather than by open folder is what lets each tab hold its own
+ * trail. It also removes the need for a sentinel key: every open note belongs
+ * to a tab, including a Loose File opened with no workspace.
  */
-
-/** Stack key for files opened with no workspace. */
-const LOOSE_HISTORY_KEY = "__none__";
-
-function historyKey(workspacePath = workspaceStore.get().workspacePath) {
-	return workspacePath ?? LOOSE_HISTORY_KEY;
-}
 
 /** Clamps a persisted or edited stack so `index` always points at an entry. */
 export function normalizeStack(stack?: HistoryStack): HistoryStack {
@@ -35,22 +34,52 @@ export function normalizeStack(stack?: HistoryStack): HistoryStack {
 	};
 }
 
-function stackFor(history: HistoryState, workspacePath: string | null) {
-	return normalizeStack(history.byWorkspace[historyKey(workspacePath)]);
+function stackFor(history: HistoryState, tabId: TabId | null | undefined) {
+	return normalizeStack(tabId ? history.byTab[tabId] : undefined);
 }
 
-/** The current workspace's stack. */
+/** The Active Tab's stack. */
 export function activeHistory() {
-	return stackFor(historyStore.get(), workspaceStore.get().workspacePath);
+	return stackFor(historyStore.get(), activeTabIdStore.get());
 }
 
-/** Replaces the current workspace's stack. */
+/**
+ * Replaces the Active Tab's stack, and drops the stacks of Tabs that have
+ * closed.
+ *
+ * Tabs go away from several places — closing one, deleting its file, clearing
+ * the viewer, switching folders — and a stack left behind by any of them can
+ * never be reached again. Sweeping them here, on the one write path, means no
+ * removal site has to remember, and a missed one cleans up on the next
+ * navigation.
+ */
 export function setHistory(stack: HistoryStack) {
-	const key = historyKey();
+	const tabId = activeTabIdStore.get();
+	if (!tabId) return;
+	const open = new Set(tabsStore.get().order);
 	historyStore.set((state) => ({
 		...state,
-		byWorkspace: { ...state.byWorkspace, [key]: stack },
+		byTab: {
+			...Object.fromEntries(
+				Object.entries(state.byTab).filter(([id]) => open.has(id)),
+			),
+			[tabId]: stack,
+		},
 	}));
+}
+
+/** Forgets a closed tab's stack. */
+export function dropHistory(tabId: TabId) {
+	historyStore.set((state) => {
+		if (!(tabId in state.byTab)) return state;
+		const { [tabId]: _dropped, ...byTab } = state.byTab;
+		return { ...state, byTab };
+	});
+}
+
+/** Forgets every stack, for when the whole tab set is replaced. */
+export function resetHistory() {
+	historyStore.set((state) => ({ ...state, byTab: {} }));
 }
 
 /**
@@ -66,17 +95,17 @@ export function pushHistory(path: string) {
 	setHistory({ entries, index: entries.length - 1 });
 }
 
-/** Empties the current workspace's stack. */
+/** Empties the Active Tab's stack. */
 export function clearHistory() {
 	setHistory({ entries: [], index: -1 });
 }
 
-/** Applies `update` to every workspace's stack, normalizing around it. */
+/** Applies `update` to every tab's stack, normalizing around it. */
 function mapHistory(update: (stack: HistoryStack) => HistoryStack) {
 	historyStore.set((state) => ({
 		...state,
-		byWorkspace: Object.fromEntries(
-			Object.entries(state.byWorkspace).map(([key, stack]) => [
+		byTab: Object.fromEntries(
+			Object.entries(state.byTab).map(([key, stack]) => [
 				key,
 				normalizeStack(update(normalizeStack(stack))),
 			]),
@@ -87,8 +116,8 @@ function mapHistory(update: (stack: HistoryStack) => HistoryStack) {
 /**
  * Points history at a file's new location after a rename or move so back and
  * forward keep working. With `isFolder`, rewrites the path prefix of every
- * entry inside the folder. Runs across all workspaces because a rename can
- * touch paths recorded under another workspace's stack.
+ * entry inside the folder. Runs across all tabs because a renamed path can
+ * appear in any tab's trail, not only the one showing it.
  */
 export function rewriteHistory(
 	fromPath: string,
@@ -129,10 +158,10 @@ export function pruneHistory(path: string, isFolder = false) {
 
 export function canGoBack(
 	history = historyStore.get(),
-	workspacePath = workspaceStore.get().workspacePath,
+	tabId = activeTabIdStore.get(),
 	onChangelog = isChangelogPath(currentPathStore.get()),
 ) {
-	const stack = stackFor(history, workspacePath);
+	const stack = stackFor(history, tabId);
 	// The changelog note is never pushed, so back means "return to the current
 	// entry" and stays enabled whenever one exists.
 	if (onChangelog) return stack.index >= 0;
@@ -141,10 +170,10 @@ export function canGoBack(
 
 export function canGoForward(
 	history = historyStore.get(),
-	workspacePath = workspaceStore.get().workspacePath,
+	tabId = activeTabIdStore.get(),
 	onChangelog = isChangelogPath(currentPathStore.get()),
 ) {
 	if (onChangelog) return false;
-	const { index, entries } = stackFor(history, workspacePath);
+	const { index, entries } = stackFor(history, tabId);
 	return index >= 0 && index < entries.length - 1;
 }

--- a/apps/desktop/src/store/hooks.ts
+++ b/apps/desktop/src/store/hooks.ts
@@ -1,20 +1,20 @@
 import { useStoreValue } from "@simplestack/store/react";
 import { isChangelogPath } from "../lib/changelogNote";
 import { canGoBack, canGoForward } from "./history";
-import { currentPathStore, historyStore, workspacePathStore } from "./state";
+import { activeTabIdStore, currentPathStore, historyStore } from "./state";
 
 // Back/forward enablement depends on two stores: the history stacks and the
-// workspace that picks the active stack. Boolean selectors re-render callers
+// Active Tab that picks the active stack. Boolean selectors re-render callers
 // only when enablement actually flips.
 export function useHistoryNav() {
-	const workspacePath = useStoreValue(workspacePathStore);
+	const activeTabId = useStoreValue(activeTabIdStore);
 	const onChangelog = useStoreValue(currentPathStore, isChangelogPath);
 	return {
 		canGoBack: useStoreValue(historyStore, (history) =>
-			canGoBack(history, workspacePath, onChangelog),
+			canGoBack(history, activeTabId, onChangelog),
 		),
 		canGoForward: useStoreValue(historyStore, (history) =>
-			canGoForward(history, workspacePath, onChangelog),
+			canGoForward(history, activeTabId, onChangelog),
 		),
 	};
 }

--- a/apps/desktop/src/store/persistence.ts
+++ b/apps/desktop/src/store/persistence.ts
@@ -6,6 +6,7 @@ import {
 	type FolderEntry,
 	type SortMode,
 } from "./state";
+import { emptyTabs, type TabsState } from "./tabs";
 
 type WorkspaceState = {
 	workspacePath: string | null;
@@ -41,6 +42,7 @@ export type CodeFileOpenMode = "hubble" | "default-app";
 export type DesktopState = {
 	workspace: WorkspaceState;
 	document: DocumentState;
+	tabs: TabsState;
 	ui: UiState;
 	settings: SettingsState;
 };
@@ -104,6 +106,9 @@ export function getInitialState(): DesktopState {
 	return {
 		workspace: hydrateWorkspace(p?.workspace),
 		document: emptyDoc(p?.document?.lastOpenedPath ?? null),
+		// Tabs are session state, like the back/forward stacks. Launch restores
+		// the last opened note, which opens a single Tab through the usual path.
+		tabs: emptyTabs(),
 		ui: {
 			sidebarOpen: p?.ui?.sidebarOpen ?? false,
 			isSwitcherOpen: false,

--- a/apps/desktop/src/store/state.ts
+++ b/apps/desktop/src/store/state.ts
@@ -9,6 +9,7 @@ import {
 	STORAGE_KEY,
 	serialize,
 } from "./persistence";
+import { type TabId, type TabTarget, withOpenedTab } from "./tabs";
 
 export type SortMode = "alpha" | "recent";
 
@@ -52,7 +53,7 @@ export type HistoryStack = {
 };
 
 export type HistoryState = {
-	byWorkspace: Record<string, HistoryStack>;
+	byTab: Record<TabId, HistoryStack>;
 	isNavigating: boolean;
 };
 
@@ -128,6 +129,7 @@ export function withOpenedDoc(
 	state: DesktopState,
 	path: string,
 	content: string,
+	tab?: TabTarget,
 ): DesktopState {
 	const workspacePath = state.workspace.workspacePath;
 	const workspace =
@@ -144,6 +146,7 @@ export function withOpenedDoc(
 	return {
 		...state,
 		workspace,
+		tabs: withOpenedTab(state.tabs, path, tab),
 		document: {
 			...state.document,
 			currentPath: path,
@@ -161,7 +164,7 @@ export const appStore = store<DesktopState>(getInitialState(), {
 });
 
 export const historyStore = store<HistoryState>({
-	byWorkspace: {},
+	byTab: {},
 	isNavigating: false,
 });
 
@@ -177,6 +180,8 @@ export const titleGenerationPreviewStore = store<{
 export const workspaceStore = appStore.select("workspace");
 export const viewerStore = appStore.select("document");
 export const uiStore = appStore.select("ui");
+export const tabsStore = appStore.select("tabs");
+export const activeTabIdStore = tabsStore.select("activeTabId");
 
 export const workspacePathStore = workspaceStore.select("workspacePath");
 export const recentWorkspacesStore = workspaceStore.select("recentWorkspaces");

--- a/apps/desktop/src/store/tabs.test.ts
+++ b/apps/desktop/src/store/tabs.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import {
+	emptyTabs,
+	nextActiveTabId,
+	type TabsState,
+	tabLabels,
+	withClosedTab,
+	withOpenedTab,
+	withoutTabsMatching,
+	withRewrittenTabPaths,
+} from "./tabs";
+
+/** Fixed ids keep assertions readable; only `withOpenedTab` mints real ones. */
+function strip(paths: Record<string, string>, activeTabId: string | null) {
+	return {
+		order: Object.keys(paths),
+		activeTabId,
+		byId: Object.fromEntries(
+			Object.entries(paths).map(([id, path]) => [id, { path }]),
+		),
+	} satisfies TabsState;
+}
+
+describe("opening tabs", () => {
+	it("replaces what the active tab shows by default", () => {
+		const before = strip({ a: "/w/one.md" }, "a");
+
+		const after = withOpenedTab(before, "/w/two.md");
+
+		expect(after.order).toEqual(["a"]);
+		expect(after.byId.a.path).toBe("/w/two.md");
+	});
+
+	it("opens a new tab directly right of the active one", () => {
+		const before = strip({ a: "/w/one.md", b: "/w/two.md" }, "a");
+
+		const after = withOpenedTab(before, "/w/three.md", "new");
+
+		expect(after.order).toHaveLength(3);
+		expect(after.order[1]).toBe(after.activeTabId);
+		expect(after.order[2]).toBe("b");
+	});
+
+	it("mints a tab when the strip is empty or the target has closed", () => {
+		expect(withOpenedTab(emptyTabs(), "/w/one.md").order).toHaveLength(1);
+
+		const after = withOpenedTab(
+			strip({ a: "/w/one.md" }, "a"),
+			"/w/two.md",
+			"gone",
+		);
+
+		// A stale target falls back to the active tab rather than vanishing.
+		expect(after.order).toEqual(["a"]);
+		expect(after.byId.a.path).toBe("/w/two.md");
+	});
+});
+
+describe("closing tabs", () => {
+	const three = strip({ a: "/w/a.md", b: "/w/b.md", c: "/w/c.md" }, "b");
+
+	it("focuses the right neighbour, falling back to the left", () => {
+		expect(nextActiveTabId(three, "b")).toBe("c");
+		expect(nextActiveTabId(three, "c")).toBe("b");
+		expect(nextActiveTabId(strip({ b: "/w/b.md" }, "b"), "b")).toBeNull();
+	});
+
+	it("removes the tab and moves focus off it", () => {
+		const after = withClosedTab(three, "b");
+
+		expect(after.order).toEqual(["a", "c"]);
+		expect(after.activeTabId).toBe("c");
+		expect(after.byId).not.toHaveProperty("b");
+	});
+
+	it("leaves focus alone when a background tab closes", () => {
+		expect(withClosedTab(three, "a").activeTabId).toBe("b");
+	});
+
+	it("ignores a tab that is already gone", () => {
+		expect(withClosedTab(three, "missing")).toBe(three);
+	});
+
+	it("closes every tab a predicate matches, keeping focus valid", () => {
+		const after = withoutTabsMatching(three, (path) => path !== "/w/a.md");
+
+		expect(after.order).toEqual(["a"]);
+		expect(after.activeTabId).toBe("a");
+	});
+});
+
+describe("rewriting tab paths", () => {
+	it("moves every tab through the caller's rewrite", () => {
+		const before = strip({ a: "/w/old/x.md", b: "/w/keep.md" }, "a");
+
+		const after = withRewrittenTabPaths(before, (path) =>
+			path.startsWith("/w/old/") ? path.replace("/w/old/", "/w/new/") : path,
+		);
+
+		expect(after.byId.a.path).toBe("/w/new/x.md");
+		expect(after.byId.b.path).toBe("/w/keep.md");
+		expect(after.order).toEqual(before.order);
+	});
+});
+
+describe("tab labels", () => {
+	it("qualifies a name only when another open tab shares it", () => {
+		expect(
+			tabLabels(
+				strip(
+					{
+						a: "/w/notes/index.md",
+						b: "/w/archive/index.md",
+						c: "/w/plan.md",
+					},
+					"a",
+				),
+			),
+		).toEqual({ a: "notes/index", b: "archive/index", c: "plan" });
+	});
+
+	it("drops the extension, since every note carries one", () => {
+		expect(tabLabels(strip({ a: "/w/plan.md" }, "a"))).toEqual({ a: "plan" });
+	});
+});

--- a/apps/desktop/src/store/tabs.ts
+++ b/apps/desktop/src/store/tabs.ts
@@ -1,0 +1,143 @@
+import { basename, dirname, fileStem, pathEquals } from "../lib/filePath";
+
+/**
+ * An open note in the tab strip. A Tab records where a note is, not what it
+ * holds: the open document itself stays in `DocumentState`, and activating a
+ * Tab re-reads it from disk the same way opening a note from the sidebar does.
+ */
+export type Tab = { path: string };
+
+export type TabId = string;
+
+export type TabsState = {
+	order: TabId[];
+	activeTabId: TabId | null;
+	byId: Record<TabId, Tab>;
+};
+
+/**
+ * Which Tab a load lands in. Omitted means the Active Tab, so navigation that
+ * predates tabs keeps replacing what is on screen rather than piling up Tabs
+ * behind the user.
+ */
+export type TabTarget = TabId | "new";
+
+export const emptyTabs = (): TabsState => ({
+	order: [],
+	activeTabId: null,
+	byId: {},
+});
+
+// Ids are opaque because a note's path is not its identity: auto-titling
+// renames a new note moments after it is created, and rename and move rewrite
+// paths under an open Tab.
+let lastTabId = 0;
+
+function mintTabId(): TabId {
+	lastTabId += 1;
+	return `tab-${lastTabId}`;
+}
+
+/** The Tab showing `path`, or null when no open Tab does. */
+export function findTabByPath(tabs: TabsState, path: string): TabId | null {
+	return (
+		tabs.order.find((id) => pathEquals(tabs.byId[id]?.path ?? "", path)) ?? null
+	);
+}
+
+/**
+ * Opens `path` in `target`, minting a Tab when there is none to reuse. The new
+ * Tab lands directly right of the Active one, so opening from a Tab keeps its
+ * result next to where it was asked for.
+ */
+export function withOpenedTab(
+	tabs: TabsState,
+	path: string,
+	target?: TabTarget,
+): TabsState {
+	if (target !== "new") {
+		const id = target && tabs.byId[target] ? target : tabs.activeTabId;
+		if (id && tabs.byId[id]) {
+			return {
+				...tabs,
+				activeTabId: id,
+				byId: { ...tabs.byId, [id]: { path } },
+			};
+		}
+	}
+	const id = mintTabId();
+	const activeAt = tabs.activeTabId ? tabs.order.indexOf(tabs.activeTabId) : -1;
+	const order = [...tabs.order];
+	order.splice(activeAt < 0 ? order.length : activeAt + 1, 0, id);
+	return { order, activeTabId: id, byId: { ...tabs.byId, [id]: { path } } };
+}
+
+/**
+ * The Tab to focus once `id` closes: its right neighbour, falling back to its
+ * left. Null when `id` was the only Tab open.
+ */
+export function nextActiveTabId(tabs: TabsState, id: TabId): TabId | null {
+	const at = tabs.order.indexOf(id);
+	if (at < 0) return tabs.activeTabId;
+	return tabs.order[at + 1] ?? tabs.order[at - 1] ?? null;
+}
+
+export function withClosedTab(tabs: TabsState, id: TabId): TabsState {
+	if (!tabs.byId[id]) return tabs;
+	const { [id]: _closed, ...byId } = tabs.byId;
+	return {
+		order: tabs.order.filter((other) => other !== id),
+		activeTabId:
+			tabs.activeTabId === id ? nextActiveTabId(tabs, id) : tabs.activeTabId,
+		byId,
+	};
+}
+
+/**
+ * Moves every Tab's path through `rewrite`. Rename, folder rename, and move
+ * each decide what counts as a match differently, so the caller supplies the
+ * rewrite it already uses elsewhere and this only walks the Tabs.
+ */
+export function withRewrittenTabPaths(
+	tabs: TabsState,
+	rewrite: (path: string) => string,
+): TabsState {
+	return {
+		...tabs,
+		byId: Object.fromEntries(
+			Object.entries(tabs.byId).map(([id, tab]) => [
+				id,
+				{ ...tab, path: rewrite(tab.path) },
+			]),
+		),
+	};
+}
+
+/** Closes every Tab whose path `isGone` accepts. */
+export function withoutTabsMatching(
+	tabs: TabsState,
+	isGone: (path: string) => boolean,
+): TabsState {
+	return tabs.order
+		.filter((id) => isGone(tabs.byId[id]?.path ?? ""))
+		.reduce(withClosedTab, tabs);
+}
+
+/**
+ * Tab labels: the note's name, qualified with its folder when another open Tab
+ * shares that name. Two notes called `index` in different folders are the case
+ * that makes an unqualified strip unreadable.
+ */
+export function tabLabels(tabs: TabsState): Record<TabId, string> {
+	const stems = tabs.order.map((id) => fileStem(tabs.byId[id]?.path ?? ""));
+	return Object.fromEntries(
+		tabs.order.map((id, at) => {
+			const stem = stems[at];
+			const shared = stems.some(
+				(other, index) => index !== at && other === stem,
+			);
+			const folder = dirname(tabs.byId[id]?.path ?? "");
+			return [id, shared && folder ? `${basename(folder)}/${stem}` : stem];
+		}),
+	);
+}

--- a/apps/desktop/src/store/titleManagement.ts
+++ b/apps/desktop/src/store/titleManagement.ts
@@ -6,6 +6,7 @@ import {
 	type MovedFile,
 	rewriteMovedLinks,
 } from "../lib/markdownLinkRewrite";
+import { rewriteScrollMemory } from "../lib/scrollMemory";
 import { generatedTitleStem } from "../lib/titleGeneration";
 import { rewriteHistory } from "./history";
 import {
@@ -15,6 +16,7 @@ import {
 	viewerStore,
 	workspaceStore,
 } from "./state";
+import { withRewrittenTabPaths } from "./tabs";
 
 const TITLE_RENAME_DELAY_MS = 500;
 const existingPathErrorPattern = /\bEEXIST\b|\balready exists\b/i;
@@ -278,6 +280,9 @@ export function createTitleManager(deps: TitleManagerDeps) {
 			previewPath: nextPath,
 		});
 		rewriteHistory(previousPath, nextPath);
+		rewriteScrollMemory((scrolled) =>
+			pathEquals(scrolled, previousPath) ? nextPath : scrolled,
+		);
 		appStore.set((state) => ({
 			...state,
 			workspace: {
@@ -299,6 +304,9 @@ export function createTitleManager(deps: TitleManagerDeps) {
 					),
 				),
 			},
+			tabs: withRewrittenTabPaths(state.tabs, (tabPath) =>
+				pathEquals(tabPath, previousPath) ? nextPath : tabPath,
+			),
 			document: {
 				...state.document,
 				currentPath: pathEquals(state.document.currentPath ?? "", previousPath)

--- a/packages/editor/src/commandRegistry.ts
+++ b/packages/editor/src/commandRegistry.ts
@@ -6,6 +6,8 @@ export type CommandContext = {
 	isSourceMode?: boolean;
 	canGoBack?: boolean;
 	canGoForward?: boolean;
+	hasTabs?: boolean;
+	hasMultipleTabs?: boolean;
 };
 
 export type CommandDefinition = {
@@ -66,6 +68,23 @@ export const commandRegistry = {
 		defaultBinding: "CmdOrCtrl+]",
 		label: "Go Forward",
 		isEnabled: (context) => context.canGoForward === true,
+	},
+	// `CmdOrCtrl+W` also carries Electron's window-close role. The menu item
+	// closes a Tab when there is one and falls back to closing the window.
+	"app.close-tab": {
+		defaultBinding: "CmdOrCtrl+W",
+		label: "Close Tab",
+		isEnabled: (context) => context.hasTabs === true,
+	},
+	"app.next-tab": {
+		defaultBinding: "CmdOrCtrl+Alt+]",
+		label: "Next Tab",
+		isEnabled: (context) => context.hasMultipleTabs === true,
+	},
+	"app.previous-tab": {
+		defaultBinding: "CmdOrCtrl+Alt+[",
+		label: "Previous Tab",
+		isEnabled: (context) => context.hasMultipleTabs === true,
 	},
 	"app.toggle-terminal": {
 		defaultBinding: "CmdOrCtrl+J",

--- a/packages/ui/src/components/TabStrip.test.tsx
+++ b/packages/ui/src/components/TabStrip.test.tsx
@@ -93,6 +93,22 @@ describe("TabStrip", () => {
 		).toEqual([-1, -1]);
 	});
 
+	it("stays reachable while the changelog covers the editor", () => {
+		// Nothing is selected then, and a strip with no tab stop would be the
+		// one place the keyboard cannot get back to a note.
+		const { onActivate } = renderStrip({ activeTabId: null });
+
+		expect(tabs().map((tab) => tab.tabIndex)).toEqual([0, -1]);
+
+		act(() => {
+			tabs()[0].dispatchEvent(
+				new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+			);
+		});
+
+		expect(onActivate).toHaveBeenCalledWith("b");
+	});
+
 	it("moves between notes with the arrow keys and wraps", () => {
 		const { onActivate } = renderStrip();
 

--- a/packages/ui/src/components/TabStrip.test.tsx
+++ b/packages/ui/src/components/TabStrip.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactNode } from "react";
+// @ts-expect-error This package does not ship @types/react-dom; the test only
+// needs createRoot's render/unmount surface.
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TabStrip, type TabStripProps } from "./TabStrip";
+
+type Root = {
+	render(children: ReactNode): void;
+	unmount(): void;
+};
+
+const roots: Root[] = [];
+
+(
+	globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+afterEach(() => {
+	act(() => {
+		for (const root of roots) root.unmount();
+	});
+	roots.length = 0;
+	document.body.replaceChildren();
+	vi.restoreAllMocks();
+});
+
+function renderStrip(props: Partial<TabStripProps> = {}) {
+	const onActivate = vi.fn();
+	const onClose = vi.fn();
+	const container = document.createElement("div");
+	document.body.appendChild(container);
+	const root = createRoot(container) as Root;
+	roots.push(root);
+	act(() =>
+		root.render(
+			<TabStrip
+				tabs={[
+					{ id: "a", label: "plan", title: "/w/plan.md" },
+					{ id: "b", label: "notes", title: "/w/notes.md" },
+				]}
+				activeTabId="a"
+				onActivate={onActivate}
+				onClose={onClose}
+				{...props}
+			/>,
+		),
+	);
+	return { onActivate, onClose };
+}
+
+const tabs = () => [...document.querySelectorAll<HTMLElement>("[role=tab]")];
+
+describe("TabStrip", () => {
+	it("shows from the first note, so the editor never shifts", () => {
+		renderStrip({ tabs: [{ id: "a", label: "plan", title: "/w/plan.md" }] });
+
+		expect(document.querySelector("[role=tablist]")).not.toBeNull();
+		expect(tabs()).toHaveLength(1);
+	});
+
+	it("renders nothing when no note is open", () => {
+		renderStrip({ tabs: [], activeTabId: null });
+
+		expect(document.querySelector("[role=tablist]")).toBeNull();
+	});
+
+	it("marks the active tab and reports activation", () => {
+		const { onActivate } = renderStrip();
+
+		expect(tabs().map((tab) => tab.getAttribute("aria-selected"))).toEqual([
+			"true",
+			"false",
+		]);
+
+		act(() => tabs()[1].click());
+
+		expect(onActivate).toHaveBeenCalledWith("b");
+	});
+
+	it("costs one tab stop, not one per note", () => {
+		renderStrip();
+
+		expect(tabs().map((tab) => tab.tabIndex)).toEqual([0, -1]);
+		// The close buttons are reachable by mouse and by Delete, but they must
+		// not sit between the strip and the editor in the tab order.
+		expect(
+			[...document.querySelectorAll<HTMLElement>("[aria-label^='Close ']")].map(
+				(button) => button.tabIndex,
+			),
+		).toEqual([-1, -1]);
+	});
+
+	it("moves between notes with the arrow keys and wraps", () => {
+		const { onActivate } = renderStrip();
+
+		const press = (key: string) =>
+			act(() => {
+				tabs()[0].dispatchEvent(
+					new KeyboardEvent("keydown", { key, bubbles: true }),
+				);
+			});
+
+		press("ArrowRight");
+		expect(onActivate).toHaveBeenLastCalledWith("b");
+		press("ArrowLeft");
+		expect(onActivate).toHaveBeenLastCalledWith("b");
+		press("End");
+		expect(onActivate).toHaveBeenLastCalledWith("b");
+		press("Home");
+		expect(onActivate).toHaveBeenLastCalledWith("a");
+	});
+
+	it("closes the open note on Delete", () => {
+		const { onClose } = renderStrip();
+
+		act(() => {
+			tabs()[0].dispatchEvent(
+				new KeyboardEvent("keydown", { key: "Delete", bubbles: true }),
+			);
+		});
+
+		expect(onClose).toHaveBeenCalledWith("a");
+	});
+
+	it("closes from the button and from a middle click", () => {
+		const { onClose, onActivate } = renderStrip();
+
+		const close = document.querySelector<HTMLElement>(
+			"[aria-label='Close notes']",
+		);
+		act(() => close?.click());
+		expect(onClose).toHaveBeenCalledWith("b");
+
+		act(() => {
+			tabs()[0].dispatchEvent(
+				new MouseEvent("auxclick", { bubbles: true, button: 1 }),
+			);
+		});
+		expect(onClose).toHaveBeenLastCalledWith("a");
+		// Middle-clicking closes without also switching to the tab.
+		expect(onActivate).not.toHaveBeenCalled();
+	});
+});

--- a/packages/ui/src/components/TabStrip.tsx
+++ b/packages/ui/src/components/TabStrip.tsx
@@ -1,4 +1,8 @@
-import { type KeyboardEvent as ReactKeyboardEvent, useRef } from "react";
+import {
+	type KeyboardEvent as ReactKeyboardEvent,
+	useEffect,
+	useRef,
+} from "react";
 import MingcuteCloseLine from "~icons/mingcute/close-line";
 import { cn } from "../lib/utils";
 
@@ -33,6 +37,24 @@ export function TabStrip({
 }: TabStripProps) {
 	const stripRef = useRef<HTMLDivElement | null>(null);
 
+	// Where focus lands when the strip is reached by Tab, and where the arrow
+	// keys count from. It falls back to the first note so that the strip is
+	// still reachable while the changelog covers the editor, which is the one
+	// time no note is selected and the one time the user most needs a way back.
+	const anchor = Math.max(
+		0,
+		tabs.findIndex((tab) => tab.id === activeTabId),
+	);
+
+	// Behavior 18: a note activated off-screen has to be brought into view,
+	// which horizontal overflow alone does not do.
+	useEffect(() => {
+		const selected = stripRef.current?.querySelector<HTMLElement>(
+			'[aria-selected="true"]',
+		);
+		selected?.scrollIntoView?.({ block: "nearest", inline: "nearest" });
+	}, [activeTabId]);
+
 	const focusTabAt = (index: number) => {
 		const buttons =
 			stripRef.current?.querySelectorAll<HTMLElement>('[role="tab"]');
@@ -40,13 +62,11 @@ export function TabStrip({
 	};
 
 	const onKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
-		const at = tabs.findIndex((tab) => tab.id === activeTabId);
-		if (at < 0) return;
 		const target =
 			event.key === "ArrowLeft"
-				? (at - 1 + tabs.length) % tabs.length
+				? (anchor - 1 + tabs.length) % tabs.length
 				: event.key === "ArrowRight"
-					? (at + 1) % tabs.length
+					? (anchor + 1) % tabs.length
 					: event.key === "Home"
 						? 0
 						: event.key === "End"
@@ -62,7 +82,7 @@ export function TabStrip({
 		// deliberately outside the tab order.
 		if (event.key === "Delete" || event.key === "Backspace") {
 			event.preventDefault();
-			onClose(tabs[at].id);
+			onClose(tabs[anchor].id);
 		}
 	};
 
@@ -75,7 +95,7 @@ export function TabStrip({
 			onKeyDown={onKeyDown}
 			className="flex shrink-0 items-stretch gap-px overflow-x-auto border-border border-b bg-background"
 		>
-			{tabs.map((tab) => {
+			{tabs.map((tab, index) => {
 				const active = tab.id === activeTabId;
 				return (
 					<div
@@ -89,9 +109,9 @@ export function TabStrip({
 							type="button"
 							role="tab"
 							aria-selected={active}
-							// Roving focus: only the open note is a tab stop, so the strip
-							// costs one Tab press rather than one per note.
-							tabIndex={active ? 0 : -1}
+							// Roving focus: one note is the tab stop, so the strip costs
+							// one Tab press rather than one per note.
+							tabIndex={index === anchor ? 0 : -1}
 							title={tab.title}
 							onClick={() => onActivate(tab.id)}
 							// Middle-click closes, matching every other tabbed editor.

--- a/packages/ui/src/components/TabStrip.tsx
+++ b/packages/ui/src/components/TabStrip.tsx
@@ -20,6 +20,9 @@ export type TabStripProps = {
 	onClose: (id: string) => void;
 };
 
+const tabAt = (strip: HTMLElement | null, index: number) =>
+	strip?.querySelectorAll<HTMLElement>('[role="tab"]')[index];
+
 /**
  * The row of open notes above the editor. It shows from the first note
  * onwards: arriving only at the second would shove the editor down mid-click,
@@ -49,16 +52,14 @@ export function TabStrip({
 	// Behavior 18: a note activated off-screen has to be brought into view,
 	// which horizontal overflow alone does not do.
 	useEffect(() => {
-		const selected = stripRef.current?.querySelector<HTMLElement>(
-			'[aria-selected="true"]',
-		);
-		selected?.scrollIntoView?.({ block: "nearest", inline: "nearest" });
-	}, [activeTabId]);
+		tabAt(stripRef.current, anchor)?.scrollIntoView?.({
+			block: "nearest",
+			inline: "nearest",
+		});
+	}, [anchor]);
 
 	const focusTabAt = (index: number) => {
-		const buttons =
-			stripRef.current?.querySelectorAll<HTMLElement>('[role="tab"]');
-		buttons?.[index]?.focus();
+		tabAt(stripRef.current, index)?.focus();
 	};
 
 	const onKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {

--- a/packages/ui/src/components/TabStrip.tsx
+++ b/packages/ui/src/components/TabStrip.tsx
@@ -1,0 +1,127 @@
+import { type KeyboardEvent as ReactKeyboardEvent, useRef } from "react";
+import MingcuteCloseLine from "~icons/mingcute/close-line";
+import { cn } from "../lib/utils";
+
+export type TabStripItem = {
+	id: string;
+	label: string;
+	/** Shown on hover, where the full path disambiguates two similar labels. */
+	title: string;
+};
+
+export type TabStripProps = {
+	tabs: TabStripItem[];
+	activeTabId: string | null;
+	onActivate: (id: string) => void;
+	onClose: (id: string) => void;
+};
+
+/**
+ * The row of open notes above the editor. It shows from the first note
+ * onwards: arriving only at the second would shove the editor down mid-click,
+ * which reads as a glitch rather than as a note opening.
+ *
+ * The strip is one stop in the page's tab order, not one per note. Arrow keys
+ * move between notes from there, which is what `role="tablist"` promises and
+ * what keeps a dozen open notes from burying the editor behind Tab presses.
+ */
+export function TabStrip({
+	tabs,
+	activeTabId,
+	onActivate,
+	onClose,
+}: TabStripProps) {
+	const stripRef = useRef<HTMLDivElement | null>(null);
+
+	const focusTabAt = (index: number) => {
+		const buttons =
+			stripRef.current?.querySelectorAll<HTMLElement>('[role="tab"]');
+		buttons?.[index]?.focus();
+	};
+
+	const onKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+		const at = tabs.findIndex((tab) => tab.id === activeTabId);
+		if (at < 0) return;
+		const target =
+			event.key === "ArrowLeft"
+				? (at - 1 + tabs.length) % tabs.length
+				: event.key === "ArrowRight"
+					? (at + 1) % tabs.length
+					: event.key === "Home"
+						? 0
+						: event.key === "End"
+							? tabs.length - 1
+							: null;
+		if (target !== null) {
+			event.preventDefault();
+			onActivate(tabs[target].id);
+			focusTabAt(target);
+			return;
+		}
+		// Closing from the keyboard without having to reach the button, which is
+		// deliberately outside the tab order.
+		if (event.key === "Delete" || event.key === "Backspace") {
+			event.preventDefault();
+			onClose(tabs[at].id);
+		}
+	};
+
+	if (tabs.length === 0) return null;
+	return (
+		<div
+			ref={stripRef}
+			role="tablist"
+			aria-label="Open notes"
+			onKeyDown={onKeyDown}
+			className="flex shrink-0 items-stretch gap-px overflow-x-auto border-border border-b bg-background"
+		>
+			{tabs.map((tab) => {
+				const active = tab.id === activeTabId;
+				return (
+					<div
+						key={tab.id}
+						className={cn(
+							"group flex min-w-0 items-center gap-1 border-transparent border-b-2 pr-1 pl-3",
+							active ? "border-foreground bg-accent/40" : "hover:bg-accent/20",
+						)}
+					>
+						<button
+							type="button"
+							role="tab"
+							aria-selected={active}
+							// Roving focus: only the open note is a tab stop, so the strip
+							// costs one Tab press rather than one per note.
+							tabIndex={active ? 0 : -1}
+							title={tab.title}
+							onClick={() => onActivate(tab.id)}
+							// Middle-click closes, matching every other tabbed editor.
+							onAuxClick={(event) => {
+								if (event.button !== 1) return;
+								event.preventDefault();
+								onClose(tab.id);
+							}}
+							className={cn(
+								"max-w-48 truncate py-1.5 text-sm",
+								active ? "text-foreground" : "text-muted-foreground",
+							)}
+						>
+							{tab.label}
+						</button>
+						<button
+							type="button"
+							tabIndex={-1}
+							aria-label={`Close ${tab.label}`}
+							onClick={() => onClose(tab.id)}
+							className={cn(
+								"rounded p-0.5 text-muted-foreground opacity-0 hover:bg-accent hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100",
+								active && "opacity-100",
+							)}
+						>
+							<MingcuteCloseLine className="size-3.5" />
+						</button>
+					</div>
+				);
+			})}
+		</div>
+	);
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -18,6 +18,11 @@ export {
 	type SidebarMoveItemInput,
 	type SidebarSortMode,
 } from "./components/Sidebar";
+export {
+	TabStrip,
+	type TabStripItem,
+	type TabStripProps,
+} from "./components/TabStrip";
 export { NewNoteButton, Toolbar } from "./components/Toolbar";
 export { WorkspaceSwitcherMenu } from "./components/WorkspaceSwitcherMenu";
 export {

--- a/specs/gh-240/PRODUCT.md
+++ b/specs/gh-240/PRODUCT.md
@@ -1,0 +1,95 @@
+# Multiple notes open at once as tabs
+
+## Summary
+
+Desktop users can keep several Markdown Files open at once as a row of tabs above the editor, and switch between them with a click, `CmdOrCtrl+1`–`9`, or `CmdOrCtrl+Alt+[` / `]`. One tab is visible at a time; there is no split view. Each tab keeps its own back/forward trail. Tabs are a working set for the current session, not a saved layout.
+
+## Problem
+
+Hubble shows one Markdown File at a time. A user running several agent conversations at once — each about a different note — can only see one of those notes, and loses track of which terminal session belongs to which note. The terminal panel already has session tabs; the notes do not.
+
+Back/forward does not solve this. History is a linear trail that truncates the moment the user branches off it, so returning to "the other two notes I am working on" means re-finding them in the sidebar and destroying the forward trail. `CmdOrCtrl+P` finds a file but does not keep it. Neither is a place to leave something.
+
+Running two copies of the app over one folder is not a workaround: two instances writing the same files risks clobbering while the sync engine is in progress.
+
+## Goals
+
+1. Keep several Markdown Files open and switch between them in one click, without re-finding them in the sidebar.
+2. Give each tab its own back/forward trail, so following a link in one tab does not disturb another.
+3. Make the open set visible at a glance, so the user can tell which notes are in play.
+4. Leave single-note use unchanged. A user who never opens a second tab should not notice this feature exists.
+
+## Non-goals
+
+1. **No split view and no second window.** One note is visible at a time. Both shapes were raised on the issue; the reporter confirmed tabs are what is wanted.
+2. **No dirty indicator on the tab.** Hubble autosaves, so "unsaved" is not a state a background tab can be in. See Design Context.
+3. **No terminal session bound to a tab.** Terminal sessions are scoped to the open folder, live outside the app store, and cannot have their note path changed once running. Tracked separately.
+4. **Tabs do not survive relaunch.** Consistent with ADR-0008 and with the back/forward trail, which is also session-only. Relaunch restores the last opened Markdown File as a single tab, exactly as today.
+5. **No preserved undo history across a tab switch.** Undo lives in the editor instance, not in app state, so it resets exactly as it does when navigating today. Scroll position *is* preserved — see Design Context.
+6. **No two tabs on the same Markdown File.** Opening a file that is already open focuses its tab.
+7. No drag-to-reorder, no pinned tabs, no preview tabs, no tab groups.
+
+## Design Context
+
+**Switching tabs is navigation.** A tab records a path; activating it runs the same save-and-load Hubble already performs when the user clicks a note in the sidebar. This keeps one open document, one file watcher, and one editor — the shape ADR-0008 describes, where the sidebar index is ephemeral and the app keeps a single direct watcher on the currently open file. Giving each tab its own live buffer would mean a watcher per open tab, which is the unbounded watcher graph ADR-0008 rejects.
+
+**This is the direction comparable editors have converged on.** Obsidian — Electron, Markdown files on disk, tabs — moved from a live view per tab to a deferred placeholder that materializes on activation in v1.7.2, and exposes it as `WorkspaceLeaf.isDeferred` / `loadIfDeferred()`. On external changes, no mainstream editor watches every open file: VS Code runs one recursive workspace watcher plus per-file watchers only for files outside the workspace, jEdit and IntelliJ revalidate when a tab regains focus. A live buffer per tab is also actively hazardous for an autosaving app, because two tabs on one file become two buffers writing to one path on a timer, last write winning silently — which is why opening an already-open file focuses its tab instead.
+
+**Scroll position is kept, undo is not.** Editors treat these as different layers: scroll and cursor are view state keyed by file and cached independently of any tab (VS Code holds a capped cache of them and restores on reopen), while undo belongs to the editor instance. Hubble can afford the first cheaply — remember the scroll offset per path on leaving, restore it on arriving — and cannot afford the second without an editor mounted per tab.
+
+**Autosave makes a dirty indicator meaningless.** There is no Save command; edits are written shortly after typing stops. A background tab is therefore never unsaved, and a dot on the active tab would be visible for a fraction of a second. The one durable state worth surfacing — an external change conflicting with local edits — already has a banner, and under this design can only ever apply to the visible tab.
+
+**This depends on a save fix.** Leaving a note today relies on the editor flushing its pending edit as it unmounts, and that flush is discarded because the open path has already changed by the time it runs. Tabs make leaving a note a routine, one-click action, so the fix lands first: saving becomes an explicit step in navigation rather than a side effect of unmounting.
+
+**Vocabulary.** `CONTEXT.md` gains **Tab** and **Active Tab**; the codebase has no term for an open note today.
+
+## Behavior
+
+### Opening
+
+1. With a Workspace Folder or Plain Folder open, the tab strip appears above the editor whenever more than one Markdown File is open.
+2. Opening a file — sidebar, wiki link, relative link, `CmdOrCtrl+P`, file picker, or creating a new file — replaces the Active Tab, exactly as today.
+3. `CmdOrCtrl+T` opens the current file in a new tab. `CmdOrCtrl`-click or middle-click on a sidebar row or a link opens that target in a new tab without activating it.
+4. Opening a Markdown File that is already open in another tab activates that tab instead of opening a second one.
+5. A new tab is inserted after the Active Tab and becomes active, unless it was opened in the background.
+
+### Switching
+
+6. Clicking a tab activates it. `CmdOrCtrl+1`–`8` select by position; `CmdOrCtrl+9` selects the last tab regardless of count. `CmdOrCtrl+Alt+[` / `]` step to the previous and next tab, wrapping at each end.
+7. Activating a tab saves the outgoing Markdown File first. If that file has an unresolved disk conflict the switch does not run and the conflict banner stays, matching how back/forward already behaves.
+8. Each tab has its own back/forward trail. Back and Forward act on the Active Tab only, and their enablement reflects that tab.
+9. Switching tabs re-reads the file from disk. Scroll position is restored to where the user left that file. Undo history and the rich/source toggle reset, exactly as they do when navigating today.
+
+### Closing
+
+10. `CmdOrCtrl+W` closes the Active Tab; middle-click or the close control closes a specific tab. Closing discards that tab's back/forward trail.
+11. Closing the Active Tab activates its right-hand neighbour, or its left-hand neighbour if it was last.
+12. Closing the final tab leaves the empty state shown when no file is open. `CmdOrCtrl+W` with no tabs open closes the window, as today.
+
+### Files changing underneath
+
+13. Renaming or moving a Markdown File open in any tab updates that tab in place; the tab's back/forward trail is rewritten as it already is today.
+14. Deleting a Markdown File closes every tab showing it. Undoing that delete reopens it as a single tab.
+15. Opening a different folder closes all tabs and opens that folder's last-opened Markdown File, as today.
+16. The changelog note ("What's new") is not a file on disk and does not get a tab. It takes over the editor with the tab strip unchanged, and activating any tab leaves it — matching how it already replaces the open note today.
+
+### Presentation
+
+17. A tab shows the file name without its extension. When two open tabs would show the same name, both also show enough of the parent folder to tell them apart.
+18. When tabs exceed the available width the strip scrolls horizontally, and the Active Tab is always scrolled into view.
+19. The tab strip is hidden entirely when only one Markdown File is open, so single-note use is visually unchanged.
+
+## UX Validation
+
+1. Open a folder with several Markdown Files. Confirm no tab strip is visible with one file open.
+2. `CmdOrCtrl`-click a second file in the sidebar. Confirm a strip appears with two tabs and the first stays active. Open a third, then switch between all three by clicking and with `CmdOrCtrl+1`–`3`.
+3. Type into tab 2 continuously and immediately click tab 1. Switch back and confirm every character survived.
+4. Scroll halfway down a long note in tab 1, switch to tab 2, and switch back. Confirm the scroll position is where it was left.
+5. In tab 1 follow a wiki link, then switch to tab 2 and follow a different link. Confirm Back in each tab returns along that tab's own trail, and that Back enablement changes as tabs change.
+6. Edit a note in tab 2, change the same file outside Hubble, return to tab 2, and confirm the conflict banner appears and switching away is refused until it is resolved.
+7. Rename a file open in a background tab from the sidebar. Confirm that tab's label updates and activating it opens the renamed file.
+8. Delete a file open in a background tab. Confirm the tab closes, then undo the delete and confirm it reopens.
+9. Open two files with the same name from different folders. Confirm both tabs show enough path to distinguish them.
+10. Open enough tabs to overflow the strip. Confirm it scrolls and the Active Tab stays visible.
+11. Close tabs with `CmdOrCtrl+W` until none remain. Confirm the empty state, then that a further `CmdOrCtrl+W` closes the window.
+12. Switch to a different folder with several tabs open, then switch back. Confirm tabs reset to that folder's last-opened file.

--- a/specs/gh-240/PRODUCT.md
+++ b/specs/gh-240/PRODUCT.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Desktop users can keep several Markdown Files open at once as a row of tabs above the editor, and switch between them with a click, `CmdOrCtrl+1`–`9`, or `CmdOrCtrl+Alt+[` / `]`. One tab is visible at a time; there is no split view. Each tab keeps its own back/forward trail. Tabs are a working set for the current session, not a saved layout.
+Desktop users can keep several Markdown Files open at once as a row of tabs above the editor, and switch between them with a click, the arrow keys, or `CmdOrCtrl+Alt+[` / `]`. One tab is visible at a time; there is no split view. Each tab keeps its own back/forward trail. Tabs are a working set for the current session, not a saved layout.
 
 ## Problem
 
@@ -17,7 +17,7 @@ Running two copies of the app over one folder is not a workaround: two instances
 1. Keep several Markdown Files open and switch between them in one click, without re-finding them in the sidebar.
 2. Give each tab its own back/forward trail, so following a link in one tab does not disturb another.
 3. Make the open set visible at a glance, so the user can tell which notes are in play.
-4. Leave single-note use unchanged. A user who never opens a second tab should not notice this feature exists.
+4. Cost a user who never opens a second note nothing but one row: no change to how notes load, save, or navigate, and no extra step to reach the editor by keyboard.
 
 ## Non-goals
 
@@ -28,6 +28,7 @@ Running two copies of the app over one folder is not a workaround: two instances
 5. **No preserved undo history across a tab switch.** Undo lives in the editor instance, not in app state, so it resets exactly as it does when navigating today. Scroll position *is* preserved — see Design Context.
 6. **No two tabs on the same Markdown File.** Opening a file that is already open focuses its tab.
 7. No drag-to-reorder, no pinned tabs, no preview tabs, no tab groups.
+8. **No opening a tab in the background, and no select-by-position shortcut.** `CmdOrCtrl+T`, `CmdOrCtrl`-click, and `CmdOrCtrl+1`–`9` are all worth having and none of them is load-bearing: opening a note already gives it a tab, and stepping with `CmdOrCtrl+Alt+[` / `]` reaches every tab. They are left out to keep the first version to one row and three commands.
 
 ## Design Context
 
@@ -47,22 +48,22 @@ Running two copies of the app over one folder is not a workaround: two instances
 
 ### Opening
 
-1. With a Workspace Folder or Plain Folder open, the tab strip appears above the editor whenever more than one Markdown File is open.
-2. Opening a file — sidebar, wiki link, relative link, `CmdOrCtrl+P`, file picker, or creating a new file — replaces the Active Tab, exactly as today.
-3. `CmdOrCtrl+T` opens the current file in a new tab. `CmdOrCtrl`-click or middle-click on a sidebar row or a link opens that target in a new tab without activating it.
+1. With a Workspace Folder or Plain Folder open, the tab strip appears above the editor as soon as one Markdown File is open, and stays for every note after it.
+2. Choosing a file deliberately gives it a tab: the sidebar, `CmdOrCtrl+P`, the file picker, and creating a new file. The tab becomes active.
+3. Following a wiki link or a relative link stays in the Active Tab and extends that tab's trail. Reading through linked notes is one train of thought, not a pile of tabs; Back is the way out of it.
 4. Opening a Markdown File that is already open in another tab activates that tab instead of opening a second one.
-5. A new tab is inserted after the Active Tab and becomes active, unless it was opened in the background.
+5. A new tab is inserted after the Active Tab.
 
 ### Switching
 
-6. Clicking a tab activates it. `CmdOrCtrl+1`–`8` select by position; `CmdOrCtrl+9` selects the last tab regardless of count. `CmdOrCtrl+Alt+[` / `]` step to the previous and next tab, wrapping at each end.
+6. Clicking a tab activates it. `CmdOrCtrl+Alt+[` / `]` step to the previous and next tab, wrapping at each end. The strip is one stop in the page's tab order rather than one per note; from there the arrow keys move along it, and `Home` and `End` reach its ends.
 7. Activating a tab saves the outgoing Markdown File first. If that file has an unresolved disk conflict the switch does not run and the conflict banner stays, matching how back/forward already behaves.
 8. Each tab has its own back/forward trail. Back and Forward act on the Active Tab only, and their enablement reflects that tab.
 9. Switching tabs re-reads the file from disk. Scroll position is restored to where the user left that file. Undo history and the rich/source toggle reset, exactly as they do when navigating today.
 
 ### Closing
 
-10. `CmdOrCtrl+W` closes the Active Tab; middle-click or the close control closes a specific tab. Closing discards that tab's back/forward trail.
+10. `CmdOrCtrl+W` closes the Active Tab; middle-click, the close control, or `Delete` from the keyboard closes a specific tab. Closing discards that tab's back/forward trail.
 11. Closing the Active Tab activates its right-hand neighbour, or its left-hand neighbour if it was last.
 12. Closing the final tab leaves the empty state shown when no file is open. `CmdOrCtrl+W` with no tabs open closes the window, as today.
 
@@ -77,12 +78,12 @@ Running two copies of the app over one folder is not a workaround: two instances
 
 17. A tab shows the file name without its extension. When two open tabs would show the same name, both also show enough of the parent folder to tell them apart.
 18. When tabs exceed the available width the strip scrolls horizontally, and the Active Tab is always scrolled into view.
-19. The tab strip is hidden entirely when only one Markdown File is open, so single-note use is visually unchanged.
+19. The strip is hidden only when no Markdown File is open. It does not appear on the second note: arriving then would shove the editor down under the pointer mid-click, which reads as a glitch rather than as a note opening.
 
 ## UX Validation
 
-1. Open a folder with several Markdown Files. Confirm no tab strip is visible with one file open.
-2. `CmdOrCtrl`-click a second file in the sidebar. Confirm a strip appears with two tabs and the first stays active. Open a third, then switch between all three by clicking and with `CmdOrCtrl+1`–`3`.
+1. Open a folder with several Markdown Files. Confirm the strip appears with the first file and shows one tab.
+2. Click a second file in the sidebar. Confirm a second tab appears after the first and is active. Open a third, then switch between all three by clicking and with `CmdOrCtrl+Alt+[` / `]`. Confirm one `Tab` press from the editor reaches the strip, and that the arrow keys move along it from there.
 3. Type into tab 2 continuously and immediately click tab 1. Switch back and confirm every character survived.
 4. Scroll halfway down a long note in tab 1, switch to tab 2, and switch back. Confirm the scroll position is where it was left.
 5. In tab 1 follow a wiki link, then switch to tab 2 and follow a different link. Confirm Back in each tab returns along that tab's own trail, and that Back enablement changes as tabs change.

--- a/specs/gh-240/TECH.md
+++ b/specs/gh-240/TECH.md
@@ -1,0 +1,125 @@
+# Multiple notes open at once as tabs — technical plan
+
+## Context
+
+Issue: https://github.com/bholmesdev/hubble.md/issues/240
+
+Product spec: `specs/gh-240/PRODUCT.md`
+
+Current commit researched: `c4235c9eeae77958d966d2fe7c44ce91e5a89aca`
+
+Desktop holds exactly one open document: `DocumentState` in `apps/desktop/src/store/state.ts`, reached through `viewerStore` and `currentPathStore`, and read from roughly 200 call sites across 17 files. Navigation is already centralized on `loadPath` / `loadInternalPath` in `apps/desktop/src/store/actions.ts`; back/forward stacks are keyed per open folder in `apps/desktop/src/store/history.ts`; one non-recursive watcher follows the open file in `apps/desktop/src/App.tsx`. `packages/ui` is prop-driven and has no store coupling.
+
+**Prerequisite.** Leaving a note relies on the editor flushing its debounced save as it unmounts (`packages/ui/src/editor/EditorView.tsx`). That flush is discarded: `loadInternalPath` writes the new path into the store before React unmounts the editor, so `savePathContentNow` sees `current.currentPath !== path` and returns. Typing without a pause and then clicking another note loses the burst. Verified in the running app — a control run that pauses before navigating saves, an otherwise identical run that does not pause loses the text, reproducibly. Filed separately; tabs make leaving a note a routine action, so the fix lands first and this plan builds on it.
+
+## Decision: no per-tab document buffers
+
+Two shapes were considered and rejected before this one. Both give every tab a live `DocumentState` — either by mirroring the active buffer into a map, or by replacing `document` with a map plus a hand-written store facade over the active entry — and so give every tab live content, a live conflict state, and a live dirty flag.
+
+They were rejected because:
+
+- The single-document assumption is load-bearing in reads, not only in writes. `savePathContentNow`, `updateMovedLinks`, and the auto-title liveness checks in `apps/desktop/src/store/titleManagement.ts` all mean "the only document" today and would quietly come to mean "the focused document" — dropping saves for a backgrounded tab, corrupting a background draft during a folder rename, and permanently stopping auto-titling for a note the user switched away from. All three keep compiling.
+- Background buffers go stale unless each is watched. The open-file watcher is singular by design (`desktop:watch-path` in `apps/desktop/electron/main.ts`, commented "Only the active file uses this watcher"), and chokidar watching a file watches that file, so N tabs means N `fs.watch` handles. A real cost, though a bounded one — this is weaker than ADR-0008's case against the sidebar's unbounded recursive graph, and is listed as a cost rather than a blocker.
+- They churn the roughly 110 `viewerStore` references and 19 `document:` seeding sites in `apps/desktop/src/store/actions.test.ts`.
+
+Hubble autosaves, so once the prerequisite fix makes leaving a note reliably flush, **a background tab has no state to hold beyond its path**. A tab becomes a remembered path plus a back/forward trail, activating a tab is the save-and-load Hubble already performs, and `DocumentState` is untouched.
+
+This is also where comparable editors have ended up. Obsidian moved from a live view per tab to a deferred placeholder materialized on activation in v1.7.2 (`WorkspaceLeaf.isDeferred` / `loadIfDeferred()`). No mainstream editor watches every open file — VS Code pairs one recursive workspace watcher with per-file watchers only for files outside the workspace, and jEdit and IntelliJ revalidate on tab focus instead. For an autosaving editor specifically, a buffer per tab is hazardous rather than merely costly: two tabs on one path become two buffers writing to that path on a timer.
+
+Tradeoff accepted: activating a tab re-reads from disk and resets undo and view mode. Undo would not survive under the rejected shapes either — it lives in Tiptap, not in `DocumentState`, so preserving it needs an editor mounted per tab under any design. Scroll position is kept, but as view state keyed by path rather than as part of a tab (see Approach).
+
+## Approach
+
+### Tab state
+
+Add one slice to `DesktopState`:
+
+```ts
+tabs: { order: TabId[]; activeTabId: TabId | null; byId: Record<TabId, { path: string }> }
+```
+
+`TabId` is a generated opaque id, not the path. `editorDocumentId` already establishes that a note's path is not its identity, and auto-titling renames a new note within half a second of creation. Ids are minted from a module counter so tests stay deterministic under `vi.resetModules()`.
+
+Not added to `Persisted` or `serialize()` in `apps/desktop/src/store/persistence.ts`. `document.lastOpenedPath` keeps its current meaning and still restores a single tab on launch.
+
+### `loadInternalPath` as the chokepoint
+
+Extract the save-and-abort preamble `navigateHistory` already performs into `leaveCurrentDocument()`: save the open file from store content, and report back if a conflict is present or is discovered by that save. Call it at the top of `loadInternalPath` so every entry point gets it — sidebar clicks, wiki links, `CmdOrCtrl+P`, and tab activation alike. `navigateHistory` and `openChangelog` then call the shared helper instead of duplicating it.
+
+This is what makes the design safe: saving becomes an explicit step in navigation rather than a side effect of unmounting an editor.
+
+Extend `loadPath` options with a target tab. The default is the Active Tab, so existing callers are unchanged; an explicit option mints a new one. Write the tab slice inside `loadInternalPath` beside `withOpenedDoc`, and **only on the success path** — the toast branch deliberately stays on the current document, so writing the tab earlier would leave the strip pointing at a file that failed to open. The silent-missing branch closes the target tab instead.
+
+Two details that bite here. Tab activation must pass `launchExternal: false`, as `navigateHistory` already does: without it, activating a tab holding a code file launches an external app and never switches. And `openChangelog` never goes through `loadInternalPath` at all — it writes `currentPath` directly — so it is deliberately excluded from the tab model: the changelog takes over the editor without a tab, and activating any tab leaves it. That is the one place `activeTabId` and `document.currentPath` are allowed to differ, so clicking the already-active tab must reload rather than no-op.
+
+### History re-keyed from open folder to tab
+
+`historyStore.byWorkspace` becomes `byTab`. This is small and it ships with tabs rather than after them: `byWorkspace` appears in only two places outside `history.ts`, every `canGoBack` / `canGoForward` call site passes zero arguments and so is unaffected by the parameter's meaning changing, and `mapHistory` already sweeps every key blindly, so rename and delete rewriting stays correct unchanged. `historyKey()` and `LOOSE_HISTORY_KEY` delete outright — a tab always has an id, so the loose-file sentinel has nothing to represent. The only edit outside `history.ts` is `useHistoryNav` in `store/hooks.ts`, which subscribes to the active tab id instead of the workspace path. Closing a tab deletes its stack.
+
+Deferring this would not be a smaller first change, it would be a broken one: every activation pushes onto the single trail, so Back in one tab would load a file opened in another, and enablement would be identical across tabs and never change on switch — contradicting Behavior 8.
+
+`isNavigating` stays a single global boolean. With one `DocumentState` there is only ever one navigation in flight; making it per tab would permit a race that the global flag currently prevents.
+
+History also stays in its own `historyStore` rather than moving onto the tab record. Folding it into `appStore` would look tidier for lifecycle, but delete-undo snapshots and restores `historyStore` wholesale, and that cheap snapshot would have to be reworked into the `appStore` undo path.
+
+Behaviour change worth noting: back/forward trails no longer survive an open-folder switch, because tabs reset with the folder.
+
+### Rewriting tabs with existing file operations
+
+Rename, move, and delete already rewrite `workspace.lastOpenedPaths` and `document.currentPath` inside one `appStore.set`. Each gains the same treatment for `tabs.byId`: `renameMarkdownFile`, `renameFolder`, and `moveSidebarItem` in `actions.ts`, plus `publishRename` in `titleManagement.ts`, which rewrites paths for auto-titled notes and is the one most easily missed. Note these four do not share a path comparison — exact equality, `replacePathPrefix`, and `pathEquals` respectively — so each takes the rewrite function it already uses rather than a single shared helper.
+
+Delete closes matching tabs rather than rewriting them, across the three paths in `apps/desktop/src/store/deleteActions.ts`. Undo needs to restore them: `reopenPath` is recorded only when the deleted file was the visible one, so it cannot reopen a background tab. The pending deletion snapshots the whole `tabs` slice before and after, and restores the before if nothing has rearranged the strip since — the same shape as the history snapshot beside it, which restores positions exactly without tracking them.
+
+### Scroll position as view state
+
+Scroll is kept in a small module-level cache keyed by path — written when leaving a document, read when one is opened — not stored on the tab. Keyed by path rather than by tab, it also survives closing and reopening a file, and it stays correct if a tab is closed while the file remains open elsewhere. Capped, and dropped on workspace switch. This is the layer split editors settle on: view state outlives both the tab and the editor instance, while undo belongs to the editor.
+
+### UI and menu
+
+Pure tab logic — the state shape and the functions over it — lives in `apps/desktop/src/store/tabs.ts`, which `state.ts` imports rather than the reverse. Keeping it out of `state.ts` is what lets it be tested without standing up the store.
+
+The tab strip is a prop-driven component in `packages/ui`, keeping that package free of store coupling, with a thin container in `apps/desktop` supplying order, labels, and the active id. It mounts above the editor inside the document column rather than in `Toolbar`, which is a fixed-height three-cluster row carrying a window drag region. Label disambiguation and next-active-tab-on-close are pure functions, unit-tested directly.
+
+Commands go in `packages/editor/src/commandRegistry.ts`, with palette entries in `useAppCommands.ts` and native menu items in `apps/desktop/electron/main.ts`. `CmdOrCtrl+W` currently maps to the window `close` role in the File menu and needs to close a tab first, falling back to closing the window when none are open. `MenuState` gains tab enablement. No manual memos — CI runs `pnpm check:react-compiler`.
+
+## What does not change
+
+- `DocumentState`, `viewerStore`, `currentPathStore`, and every existing read and write of them.
+- One open document, one editor instance, one file watcher on the open file.
+- `packages/ui` store purity; `apps/www` and `apps/web`.
+- `Persisted` / `serialize()` — no tab state on disk, so no schema migration.
+- The 19 `document:` seeding sites in `actions.test.ts`, and every existing assertion in it.
+
+## E2E test plan
+
+Desktop, on the running app (`apps/desktop/.claude/skills/test-desktop-app`), following `specs/gh-240/PRODUCT.md` § UX Validation. The load-bearing ones:
+
+1. Type continuously in one tab, switch immediately, switch back — no lost text. This is the prerequisite fix, and the regression most worth guarding.
+2. Build a link trail in two tabs independently; confirm Back follows each tab's own trail and enablement tracks the Active Tab.
+3. Conflict a file, then attempt to switch away — refused, banner stays.
+4. Rename, move, and delete a file open in a background tab; undo the delete.
+5. Switch open folders with several tabs open, and back again.
+
+Unit and integration:
+
+- Pure helpers: next active tab after close, label disambiguation, tab rewrite and prune.
+- `actions.test.ts`: `leaveCurrentDocument` saves before load and aborts on conflict; `loadPath` tab targeting; per-tab history isolation; rename rewrites a background tab; delete closes matching tabs; opening an already-open path focuses its tab.
+- Tab strip component under the existing `// @vitest-environment happy-dom` and `createRoot` + `act` precedent.
+
+Commands: `pnpm check` while iterating, `pnpm --filter @hubble.md/desktop test`, `pnpm check:react-compiler` after React changes, `pnpm build:desktop` before review.
+
+## Risks
+
+- **Tab switch costs a disk read** and can reach the delayed loading state on slow volumes. Same cost as a sidebar click today; accepted rather than mitigated.
+- **Undo history and view mode reset on switch.** The most likely user complaint. Not fixable without an editor mounted per tab, which is a separate change; called out as a non-goal rather than left to be discovered.
+- **`CmdOrCtrl+W` overriding the window close role** is easy to get wrong on macOS. Covered by UX Validation step 10.
+- **Auto-titling still stops when the user leaves a new note** inside its rename window. Unchanged from today, but tabs make leaving more frequent. Worth a follow-up rather than widening this change.
+
+## Follow-ups
+
+- Bind a terminal session to a tab — the original motivation. Needs a main-process change to retarget a running session.
+- Persist the open tab set across relaunch.
+- Preserve undo history across a tab switch, which needs an editor mounted per tab.
+- Preview tabs: one replaceable slot per strip, promoted on edit, so browsing does not accumulate tabs.
+- Drag to reorder tabs.
+- Keep auto-titling alive after navigating away from a new note.


### PR DESCRIPTION
  ## Description

  Refs #240.Opening as a **draft**: the issue is still labelled `needs-discussion` and @bholmesdev hasn't weighed in, so this is here to look at rather than to merge. @nyashkn confirmed the shape on the issue: save-then-load per switch, no per-document buffers, dirty dot dropped, undo and view-mode reset accepted.

  Several notes can be open at once as tabs, one visible at a time, each with its own back/forward trail and scroll position.

  A tab records **where** a note is, not what it holds: its path and its trail. The open document stays singular, with one file loaded, one editor and one watcher. Activating a tab saves the current note and loads the tab's note, which is what clicking a sidebar row already did.

  Per-tab document buffers were considered and rejected. The single-document assumption is load-bearing in reads, not only writes. `savePathContentNow`, the auto-title liveness check in `titleManagement.ts`, and `updateMovedLinks` would all quietly come to mean "the focused document" while still compiling.

  Opening a note explicitly, from the sidebar or `Cmd/Ctrl+P`, gives it a tab or focuses the one already showing it. Following a wiki link stays in the current tab, which is what its trail is for.

  New module `apps/desktop/src/store/tabs.ts` holds the tab state shape and the pure functions over it. `state.ts` imports from it rather than the reverse, so the logic is testable without standing up the store.

  ### Two behaviour changes outside tabs, worth flagging

  **Leaving a note now saves it first.** This fixes a standing bug: typing without pausing and immediately opening another note dropped the last edit, because the editor's unmount flush ran after the store had moved on.

  **Leaving a note with a disk conflict is refused, with a toast.** Back already refused, but a sidebar click didn't. Now every exit goes through one place. It matters more once the note is saved on the way out, since saving a conflicted note would overwrite the disk copy.

  ### Not included

  Terminal-per-tab is agreed as a separate PR, so this issue stays open after this lands. Also out of scope: split view, preview tabs, drag to reorder, persisting tabs across relaunch, and preserving undo across a switch.

  ### Changelog

  Entry added under `[Unreleased]`, `Added`:

  > Open several notes at once as tabs. Each tab keeps its own back and forward history and its own scroll position, and `Cmd/Ctrl+W` closes a tab before closing the window.

  ## Type of Change

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Documentation update

  ## Testing

  - [x] Existing tests pass
  - [x] Added new tests for changes
  - [x] Tested manually (describe below)

- [x] Tested manually (describe below)

`pnpm build:desktop` clean. 247 desktop tests, 152 ui, 115 editor. React Compiler audit: 0 failed.

Store-level tests cover tab targeting, per-tab history isolation, rename rewriting a background tab, delete closing tabs and undo restoring them, and conflict refusal on each exit path. The pure helpers in `tabs.ts` and the scroll memory are tested directly, without standing up the store. `TabStrip` has component tests under the existing happy-dom precedent, including keyboard navigation.

**Manual Testing Details:**

Driven against the running Electron app: the strip appears with the first note, sidebar opens accumulate tabs, reopening a note focuses its tab instead of duplicating it, arrow keys move between notes, the strip costs one tab stop rather than one per note, clicking the open tab is a no-op, following a link stays in the same tab, and closing one tab leaves the rest.

## Checklist

- [x] I discussed this change in a GitHub issue before submitting this PR
- [x] I have run the linter, formatter, and tests to ensure my code is ready for review