### PR TITLE
Add folder-aware Markdown templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 
 ### Added
 
+- Reuse folder-aware Markdown templates from the `/template` menu, set defaults for new notes, and save existing notes as templates with their images and links intact. [#269](https://github.com/bholmesdev/hubble.md/pull/269)
+
 ### Changed
 
 ### Fixed

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -47,6 +47,10 @@ import {
 } from "../src/lib/searchContent";
 import type { ThemePreference } from "../src/theme";
 import { DeleteUndo } from "./deleteUndo";
+import {
+	materializeTemplateBundle,
+	rollbackMaterializedAssets,
+} from "./materializeTemplate";
 import { TelemetryManager } from "./telemetry";
 import { setupTerminalIpc } from "./terminal";
 import {
@@ -125,6 +129,8 @@ const telemetry = new TelemetryManager({
 	version: app.getVersion(),
 	userAgent: () => session.defaultSession.getUserAgent(),
 });
+
+const materializedTemplateAssets = new Map<string, string[]>();
 
 if (isDev && process.env.HUBBLE_DESKTOP_ENABLE_CDP === "1") {
 	app.commandLine.appendSwitch("remote-debugging-address", "127.0.0.1");
@@ -1419,6 +1425,51 @@ function registerIpc() {
 			// accidentally shorten UTF-8 content while crossing string encoders.
 			// See https://github.com/bholmesdev/hubble.md/issues/126 for the repro.
 			await fs.writeFile(resolved, Uint8Array.from(bytes));
+		},
+	);
+
+	ipcMain.handle("desktop:materialize-template", async (_event, input) => {
+		if (
+			!input ||
+			typeof input.sourcePath !== "string" ||
+			typeof input.targetPath !== "string" ||
+			typeof input.content !== "string" ||
+			(input.mode !== "create" && input.mode !== "existing")
+		) {
+			throw new Error("Invalid template materialization request");
+		}
+		const sourcePath = assertGranted(input.sourcePath);
+		const targetPath = resolvePath(input.targetPath);
+		assertGranted(path.dirname(targetPath));
+		if (input.mode === "existing") assertGranted(targetPath);
+		const result = await materializeTemplateBundle({
+			...input,
+			sourcePath,
+			targetPath,
+		});
+		for (const createdPath of result.createdPaths) grantFile(createdPath);
+		if (input.mode === "create") {
+			grantFile(targetPath);
+			return { content: result.content };
+		}
+		if (result.createdPaths.length === 0) return { content: result.content };
+		const cleanupToken = randomUUID();
+		materializedTemplateAssets.set(cleanupToken, result.createdPaths);
+		setTimeout(
+			() => materializedTemplateAssets.delete(cleanupToken),
+			5 * 60 * 1000,
+		);
+		return { content: result.content, cleanupToken };
+	});
+
+	ipcMain.handle(
+		"desktop:rollback-template-materialization",
+		async (_event, { cleanupToken }) => {
+			if (typeof cleanupToken !== "string") return;
+			const createdPaths = materializedTemplateAssets.get(cleanupToken);
+			if (!createdPaths) return;
+			materializedTemplateAssets.delete(cleanupToken);
+			await rollbackMaterializedAssets(createdPaths);
 		},
 	);
 

--- a/apps/desktop/electron/materializeTemplate.test.ts
+++ b/apps/desktop/electron/materializeTemplate.test.ts
@@ -1,0 +1,133 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	materializeTemplateBundle,
+	rollbackMaterializedAssets,
+} from "./materializeTemplate";
+
+const roots: string[] = [];
+
+async function makeRoot() {
+	const root = await fs.mkdtemp(
+		path.join(os.tmpdir(), "hubble-template-test-"),
+	);
+	roots.push(root);
+	return root;
+}
+
+afterEach(async () => {
+	await Promise.all(
+		roots.splice(0).map((root) => fs.rm(root, { recursive: true })),
+	);
+});
+
+describe("materializeTemplateBundle", () => {
+	it("creates Markdown and a recursively copied Asset bundle", async () => {
+		const root = await makeRoot();
+		const source = path.join(root, "templates", "journal.md");
+		const target = path.join(root, "notes", "new-file.md");
+		await fs.mkdir(path.join(root, "templates", "journal.assets", "nested"), {
+			recursive: true,
+		});
+		await fs.writeFile(
+			path.join(root, "templates", "journal.assets", "nested", "image.png"),
+			"image",
+		);
+
+		await materializeTemplateBundle({
+			sourcePath: source,
+			targetPath: target,
+			content: "![Image](journal.assets/nested/image.png)",
+			mode: "create",
+		});
+
+		expect(await fs.readFile(target, "utf8")).toBe(
+			"![Image](new-file.assets/nested/image.png)",
+		);
+		expect(
+			await fs.readFile(
+				path.join(root, "notes", "new-file.assets", "nested", "image.png"),
+				"utf8",
+			),
+		).toBe("image");
+	});
+
+	it("deduplicates equal files and renames byte collisions", async () => {
+		const root = await makeRoot();
+		const source = path.join(root, "templates", "journal.md");
+		const target = path.join(root, "notes", "existing.md");
+		const sourceAssets = path.join(root, "templates", "journal.assets");
+		const targetAssets = path.join(root, "notes", "existing.assets");
+		await fs.mkdir(sourceAssets, { recursive: true });
+		await fs.mkdir(targetAssets, { recursive: true });
+		await fs.writeFile(path.join(sourceAssets, "same.png"), "same");
+		await fs.writeFile(path.join(sourceAssets, "chart.png"), "new");
+		await fs.writeFile(path.join(targetAssets, "same.png"), "same");
+		await fs.writeFile(path.join(targetAssets, "chart.png"), "old");
+
+		const result = await materializeTemplateBundle({
+			sourcePath: source,
+			targetPath: target,
+			content:
+				"![Same](journal.assets/same.png)\n![Chart](journal.assets/chart.png)",
+			mode: "existing",
+		});
+
+		expect(result.content).toBe(
+			"![Same](existing.assets/same.png)\n![Chart](existing.assets/chart-2.png)",
+		);
+		expect(result.createdPaths).toEqual([
+			path.join(targetAssets, "chart-2.png"),
+		]);
+		expect(
+			await fs.readFile(path.join(targetAssets, "chart.png"), "utf8"),
+		).toBe("old");
+	});
+
+	it("rolls back only files created by an existing-note request", async () => {
+		const root = await makeRoot();
+		const targetAssets = path.join(root, "notes", "existing.assets");
+		await fs.mkdir(targetAssets, { recursive: true });
+		const existing = path.join(targetAssets, "keep.png");
+		const created = path.join(targetAssets, "remove.png");
+		await fs.writeFile(existing, "keep");
+		await fs.writeFile(created, "remove");
+
+		await rollbackMaterializedAssets([created]);
+
+		expect(await fs.readFile(existing, "utf8")).toBe("keep");
+		await expect(fs.readFile(created)).rejects.toMatchObject({
+			code: "ENOENT",
+		});
+	});
+
+	it("leaves no Assets when create publication fails", async () => {
+		const root = await makeRoot();
+		const source = path.join(root, "templates", "journal.md");
+		const target = path.join(root, "notes", "new-file.md");
+		await fs.mkdir(path.join(root, "templates", "journal.assets"), {
+			recursive: true,
+		});
+		await fs.mkdir(path.dirname(target), { recursive: true });
+		await fs.writeFile(
+			path.join(root, "templates", "journal.assets", "a.png"),
+			"a",
+		);
+		await fs.writeFile(target, "occupied");
+
+		await expect(
+			materializeTemplateBundle({
+				sourcePath: source,
+				targetPath: target,
+				content: "![A](journal.assets/a.png)",
+				mode: "create",
+			}),
+		).rejects.toMatchObject({ code: "EEXIST" });
+		await expect(
+			fs.stat(path.join(root, "notes", "new-file.assets")),
+		).rejects.toMatchObject({ code: "ENOENT" });
+		expect(await fs.readFile(target, "utf8")).toBe("occupied");
+	});
+});

--- a/apps/desktop/electron/materializeTemplate.ts
+++ b/apps/desktop/electron/materializeTemplate.ts
@@ -1,0 +1,182 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type {
+	MaterializeTemplateInput,
+	MaterializeTemplateOutput,
+} from "../src/desktopApi/types";
+import { markdownAssetFolderPath } from "../src/lib/filePath";
+import { rebaseCopiedMarkdown } from "../src/lib/markdownLinkRewrite";
+
+type AssetPlan = {
+	bytes: Buffer;
+	fromPath: string;
+	toPath: string;
+	write: boolean;
+};
+
+async function existsAsDirectory(filePath: string) {
+	try {
+		return (await fs.stat(filePath)).isDirectory();
+	} catch {
+		return false;
+	}
+}
+
+async function readFileIfPresent(filePath: string) {
+	try {
+		return await fs.readFile(filePath);
+	} catch (error) {
+		if (
+			error &&
+			typeof error === "object" &&
+			"code" in error &&
+			error.code === "ENOENT"
+		)
+			return null;
+		throw error;
+	}
+}
+
+async function listFiles(root: string, current = root): Promise<string[]> {
+	const entries = await fs.readdir(current, { withFileTypes: true });
+	const files: string[] = [];
+	for (const entry of entries) {
+		const entryPath = path.join(current, entry.name);
+		if (entry.isDirectory()) files.push(...(await listFiles(root, entryPath)));
+		else if (entry.isFile()) files.push(entryPath);
+	}
+	return files;
+}
+
+function collisionPath(filePath: string, index: number) {
+	const extension = path.extname(filePath);
+	const stem = path.basename(filePath, extension);
+	return path.join(path.dirname(filePath), `${stem}-${index}${extension}`);
+}
+
+async function destinationForAsset(candidate: string, bytes: Buffer) {
+	let nextPath = candidate;
+	let index = 2;
+	while (true) {
+		const existing = await readFileIfPresent(nextPath);
+		if (!existing) return { path: nextPath, write: true };
+		if (Buffer.compare(existing, bytes) === 0) {
+			return { path: nextPath, write: false };
+		}
+		nextPath = collisionPath(candidate, index);
+		index += 1;
+	}
+}
+
+async function planAssets(sourcePath: string, targetPath: string) {
+	const sourceAssets = markdownAssetFolderPath(sourcePath);
+	const targetAssets = markdownAssetFolderPath(targetPath);
+	if (
+		!sourceAssets ||
+		!targetAssets ||
+		!(await existsAsDirectory(sourceAssets))
+	) {
+		return [];
+	}
+	const plans: AssetPlan[] = [];
+	for (const fromPath of await listFiles(sourceAssets)) {
+		const bytes = await fs.readFile(fromPath);
+		const candidate = path.join(
+			targetAssets,
+			path.relative(sourceAssets, fromPath),
+		);
+		const destination = await destinationForAsset(candidate, bytes);
+		plans.push({
+			bytes,
+			fromPath,
+			toPath: destination.path,
+			write: destination.write,
+		});
+	}
+	return plans;
+}
+
+async function removeEmptyParents(paths: string[]) {
+	const assetRoots = paths
+		.map((filePath) => {
+			let current = path.dirname(filePath);
+			while (path.basename(current).endsWith(".assets") === false) {
+				const parent = path.dirname(current);
+				if (parent === current) return null;
+				current = parent;
+			}
+			return current;
+		})
+		.filter((root): root is string => root !== null);
+	const directories = new Set(paths.map((filePath) => path.dirname(filePath)));
+	for (const directory of [...directories].sort(
+		(a, b) => b.length - a.length,
+	)) {
+		const assetRoot = assetRoots.find(
+			(root) =>
+				directory === root || directory.startsWith(`${root}${path.sep}`),
+		);
+		if (!assetRoot) continue;
+		let current = directory;
+		while (true) {
+			try {
+				await fs.rmdir(current);
+			} catch {
+				break;
+			}
+			if (current === assetRoot) break;
+			const parent = path.dirname(current);
+			current = parent;
+		}
+	}
+}
+
+export async function rollbackMaterializedAssets(createdPaths: string[]) {
+	for (const createdPath of [...createdPaths].reverse()) {
+		try {
+			await fs.unlink(createdPath);
+		} catch (error) {
+			if (
+				!error ||
+				typeof error !== "object" ||
+				!("code" in error) ||
+				error.code !== "ENOENT"
+			)
+				throw error;
+		}
+	}
+	await removeEmptyParents(createdPaths);
+}
+
+/** Copies a Markdown file's associated Asset bundle and optionally creates it. */
+export async function materializeTemplateBundle(
+	input: MaterializeTemplateInput,
+): Promise<MaterializeTemplateOutput & { createdPaths: string[] }> {
+	const plans = await planAssets(input.sourcePath, input.targetPath);
+	const content = rebaseCopiedMarkdown({
+		content: input.content,
+		fromPath: input.sourcePath,
+		toPath: input.targetPath,
+		copiedAssets: plans.map((plan) => ({
+			fromPath: plan.fromPath,
+			toPath: plan.toPath,
+		})),
+	});
+	const createdPaths: string[] = [];
+	try {
+		for (const plan of plans) {
+			if (!plan.write) continue;
+			await fs.mkdir(path.dirname(plan.toPath), { recursive: true });
+			await fs.writeFile(plan.toPath, plan.bytes, { flag: "wx" });
+			createdPaths.push(plan.toPath);
+		}
+		if (input.mode === "create") {
+			await fs.mkdir(path.dirname(input.targetPath), { recursive: true });
+			await fs.writeFile(input.targetPath, content, { flag: "wx" });
+		}
+		return { content, createdPaths };
+	} catch (error) {
+		await rollbackMaterializedAssets(createdPaths);
+		throw error;
+	}
+}

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -43,6 +43,12 @@ const desktopApi = {
 			bytes,
 		});
 	},
+	materializeTemplate: (input) =>
+		ipcRenderer.invoke("desktop:materialize-template", input),
+	rollbackTemplateMaterialization: (cleanupToken) =>
+		ipcRenderer.invoke("desktop:rollback-template-materialization", {
+			cleanupToken,
+		}),
 	createFolder: (path) => ipcRenderer.invoke("desktop:create-folder", { path }),
 	renameFile: (fromPath, toPath) =>
 		ipcRenderer.invoke("desktop:rename-file", { fromPath, toPath }),

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -6,6 +6,7 @@ import {
 import {
 	Button,
 	classifyHref,
+	type EditorTemplateChoice,
 	EditorView,
 	GlobalSearchPalette,
 	getActiveEditor,
@@ -65,6 +66,7 @@ import {
 } from "./lib/filePath";
 import { isCompactWindow, useCompactWindow } from "./lib/layout";
 import { resolveRelativeLinkPath } from "./lib/relativeLinkPath";
+import { isTemplatePath } from "./lib/templates";
 import { resolveWikiPath } from "./lib/wikiPath";
 import { SIDEBAR_NAV_SELECTOR } from "./selectors";
 import {
@@ -113,6 +115,12 @@ import {
 	workspacePathStore,
 	workspaceStore,
 } from "./store/state";
+import {
+	prepareTemplateApplication,
+	rollbackTemplateMaterialization,
+	templateChoiceStubsForPath,
+	templateChoicesForPath,
+} from "./store/templateActions";
 import { isDarkTheme, subscribeTheme } from "./theme";
 
 // Forces editor refresh when underlying TipTap extensions change
@@ -231,12 +239,16 @@ function App() {
 	);
 	const recentCommandIds = useStoreValue(recentCommandIdsStore);
 	const workspaceFiles = useStoreValue(workspaceStore).files;
+	const templateChoices = state.currentPath
+		? templateChoiceStubsForPath(state.currentPath)
+		: [];
 	const paletteFiles: PaletteFile[] = workspaceFiles
 		.filter((file) => (file.kind ?? fileKindForPath(file.path)) === "document")
 		.map((file) => ({
 			path: file.path,
 			relativePath: relativeWorkspacePath(file.path, workspacePath ?? null),
 			modifiedAt: file.modified_at,
+			isTemplate: isTemplatePath(file.path),
 		}));
 	const lastSeenVersion = useStoreValue(lastSeenVersionStore);
 	const pinnedNotes = useStoreValue(workspaceStore).pinnedNotes;
@@ -789,6 +801,7 @@ function App() {
 									path={state.currentPath}
 									content={state.content}
 									copyAsMarkdownRequest={copyAsMarkdownRequest}
+									templateChoices={templateChoices}
 									viewMode={state.viewMode}
 									onScrollContainerChange={setScrollContainerEl}
 								/>
@@ -910,12 +923,14 @@ function DocumentViewer({
 	path,
 	content,
 	copyAsMarkdownRequest,
+	templateChoices,
 	viewMode,
 	onScrollContainerChange,
 }: {
 	path: string;
 	content: string;
 	copyAsMarkdownRequest: number;
+	templateChoices: EditorTemplateChoice[];
 	viewMode: ViewMode;
 	onScrollContainerChange?: (el: HTMLDivElement | null) => void;
 }) {
@@ -1010,6 +1025,7 @@ function DocumentViewer({
 			documentId={documentId}
 			initialMarkdown={content}
 			copyAsMarkdownRequest={copyAsMarkdownRequest}
+			templateChoices={templateChoices}
 			onScrollContainerChange={onScrollContainerChange}
 		/>
 	);
@@ -1090,12 +1106,14 @@ function MarkdownEditor({
 	documentId,
 	initialMarkdown,
 	copyAsMarkdownRequest,
+	templateChoices,
 	onScrollContainerChange,
 }: {
 	path: string;
 	documentId: string;
 	initialMarkdown: string;
 	copyAsMarkdownRequest: number;
+	templateChoices: EditorTemplateChoice[];
 	onScrollContainerChange?: (el: HTMLDivElement | null) => void;
 }) {
 	const workspace = useStoreValue(workspaceStore);
@@ -1158,6 +1176,14 @@ function MarkdownEditor({
 			onSave={savePathContent}
 			onScrollContainerChange={onScrollContainerChange}
 			copyAsMarkdownRequest={copyAsMarkdownRequest}
+			templateChoices={templateChoices}
+			loadTemplateChoices={() => templateChoicesForPath(path)}
+			prepareTemplateApplication={(choice, context) =>
+				prepareTemplateApplication(choice, context, {
+					openTemplate: (templatePath) => loadPath(templatePath),
+				})
+			}
+			cleanupTemplateApplication={rollbackTemplateMaterialization}
 			onOpenExternalLink={openExternalLink}
 			onOpenWikiLink={(target) =>
 				void loadPath(

--- a/apps/desktop/src/components/Toolbar.tsx
+++ b/apps/desktop/src/components/Toolbar.tsx
@@ -18,6 +18,7 @@ import MingcuteCopy2Line from "~icons/mingcute/copy-2-line";
 import MingcuteExternalLinkLine from "~icons/mingcute/external-link-line";
 import MingcuteFolderOpenLine from "~icons/mingcute/folder-open-line";
 import MingcuteMore2Line from "~icons/mingcute/more-2-line";
+import MingcuteSave2Line from "~icons/mingcute/save-2-line";
 import MingcuteTerminalLine from "~icons/mingcute/terminal-line";
 import { desktopApi } from "../desktopApi";
 import type { AgentClient } from "../desktopApi/types";
@@ -34,12 +35,14 @@ import {
 } from "../lib/filePath";
 import { useCompactWindow } from "../lib/layout";
 import { revealFileLabel } from "../lib/revealFile";
+import { isTemplatePath } from "../lib/templates";
 import {
 	goBack,
 	goForward,
 	openPathInDefaultApp,
 	renameCurrentMarkdownFile,
 	requestChatAboutNote,
+	saveCurrentAsTemplate,
 	setViewerMode,
 	toggleSidebar,
 	toggleTerminal,
@@ -200,6 +203,8 @@ function ActionsMenu({
 }) {
 	const { viewMode } = useStoreValue(viewerStore);
 	const isSourceMode = viewMode === "source";
+	const canSaveAsTemplate =
+		!!path && hasMarkdownExtension(path) && !isTemplatePath(path);
 	const sourceModeLabel = path
 		? isSourceMode
 			? hasHtmlExtension(path)
@@ -311,6 +316,15 @@ function ActionsMenu({
 								<MingcuteCodeLine className="size-3 shrink-0" />
 								<span className="min-w-0 flex-1">{sourceModeLabel}</span>
 								<ShortcutHint commandId="app.toggle-source-mode" />
+							</Menu.Item>
+						)}
+						{canSaveAsTemplate && (
+							<Menu.Item
+								className="flex w-full cursor-pointer items-center gap-2 rounded-sm [padding-block:0.375rem] [padding-inline:0.5rem] text-start text-[11px] outline-hidden select-none data-highlighted:bg-accent"
+								onClick={() => void saveCurrentAsTemplate()}
+							>
+								<MingcuteSave2Line className="size-3 shrink-0" />
+								<span className="min-w-0 flex-1">Save as template</span>
 							</Menu.Item>
 						)}
 						{path && (

--- a/apps/desktop/src/desktopApi/types.ts
+++ b/apps/desktop/src/desktopApi/types.ts
@@ -74,6 +74,18 @@ export type PersistPastedImageOutput = {
 	deduped: boolean;
 };
 
+export type MaterializeTemplateInput = {
+	sourcePath: string;
+	targetPath: string;
+	content: string;
+	mode: "create" | "existing";
+};
+
+export type MaterializeTemplateOutput = {
+	content: string;
+	cleanupToken?: string;
+};
+
 export type OpenPathFromLinkResult =
 	| { kind: "file"; path: string }
 	| { kind: "opened" };
@@ -160,6 +172,10 @@ export type DesktopApi = {
 	persistPastedImage(
 		input: PersistPastedImageInput,
 	): Promise<PersistPastedImageOutput>;
+	materializeTemplate(
+		input: MaterializeTemplateInput,
+	): Promise<MaterializeTemplateOutput>;
+	rollbackTemplateMaterialization(token: string): Promise<void>;
 	deleteFile(path: string, options?: { recursive?: boolean }): Promise<void>;
 	stageDelete(workspacePath: string, paths: string[]): Promise<string>;
 	undoText(): Promise<void>;

--- a/apps/desktop/src/lib/markdownLinkRewrite.test.ts
+++ b/apps/desktop/src/lib/markdownLinkRewrite.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { indexMovedFiles, pathAfterMove } from "./markdownLinkRewrite";
+import {
+	indexMovedFiles,
+	pathAfterMove,
+	rebaseCopiedMarkdown,
+} from "./markdownLinkRewrite";
 
 describe("pathAfterMove", () => {
 	it("matches descendants when moved paths use Windows separators", () => {
@@ -13,5 +17,68 @@ describe("pathAfterMove", () => {
 		expect(
 			pathAfterMove("C:/workspace/note.assets/image.png", movedByOldPath),
 		).toBe("C:/workspace/renamed.assets/image.png");
+	});
+});
+
+describe("rebaseCopiedMarkdown", () => {
+	it("preserves relative Markdown and HTML targets after a copy", () => {
+		const content = [
+			"[Plan](../plans/roadmap.md?view=1#now)",
+			'<a href="../brief.html">Brief</a>',
+			'<img src="template.assets/chart.png">',
+		].join("\n");
+
+		expect(
+			rebaseCopiedMarkdown({
+				content,
+				fromPath: "/workspace/templates/template.md",
+				toPath: "/workspace/notes/meetings/new-file.md",
+				copiedAssets: [
+					{
+						fromPath: "/workspace/templates/template.assets/chart.png",
+						toPath: "/workspace/notes/meetings/new-file.assets/chart-2.png",
+					},
+				],
+			}),
+		).toBe(
+			[
+				"[Plan](../../plans/roadmap.md?view=1#now)",
+				'<a href="../../brief.html">Brief</a>',
+				'<img src="new-file.assets/chart-2.png">',
+			].join("\n"),
+		);
+	});
+
+	it("leaves absolute, external, anchor, and wikilink targets unchanged", () => {
+		const content = [
+			"[Web](https://hubble.md)",
+			"[Root](/shared/file.md)",
+			"[Anchor](#section)",
+			"[[projects/roadmap|Roadmap]]",
+		].join("\n");
+
+		expect(
+			rebaseCopiedMarkdown({
+				content,
+				fromPath: "/workspace/templates/template.md",
+				toPath: "/workspace/notes/new-file.md",
+			}),
+		).toBe(content);
+	});
+
+	it("handles Windows paths and case-insensitive copied asset lookup", () => {
+		expect(
+			rebaseCopiedMarkdown({
+				content: "![Chart](Template.assets/Chart.PNG)",
+				fromPath: "C:\\workspace\\templates\\template.md",
+				toPath: "C:\\workspace\\notes\\new-file.md",
+				copiedAssets: [
+					{
+						fromPath: "C:\\workspace\\templates\\template.assets\\chart.png",
+						toPath: "C:\\workspace\\notes\\new-file.assets\\chart.png",
+					},
+				],
+			}),
+		).toBe("![Chart](new-file.assets/chart.png)");
 	});
 });

--- a/apps/desktop/src/lib/markdownLinkRewrite.ts
+++ b/apps/desktop/src/lib/markdownLinkRewrite.ts
@@ -19,6 +19,11 @@ type MarkdownFile = {
 
 export type MovedFileIndex = Map<string, MovedFile>;
 
+export type CopiedAsset = {
+	fromPath: string;
+	toPath: string;
+};
+
 /** Splits a link destination into its filesystem path and query/hash suffix. */
 function splitLinkDestination(destination: string): {
 	path: string;
@@ -273,4 +278,41 @@ export function rewriteMovedLinks({
 		);
 	}
 	return rewriteWikiLinks(nextContent, workspacePath, movedByOldPath);
+}
+
+/**
+ * Re-bases relative links when Markdown is copied to a different folder.
+ *
+ * Uncopied targets keep pointing to their original absolute location. Asset
+ * targets supplied by the bundle copier point at their copied destination.
+ * Workspace-relative wikilinks need no rewrite because copying their source
+ * does not change their meaning.
+ */
+export function rebaseCopiedMarkdown({
+	content,
+	fromPath,
+	toPath,
+	copiedAssets = [],
+}: {
+	content: string;
+	fromPath: string;
+	toPath: string;
+	copiedAssets?: CopiedAsset[];
+}) {
+	const targetDir = dirname(toPath);
+	if (!targetDir) return content;
+	const copiedBySource = new Map(
+		copiedAssets.map((asset) => [
+			normalizePath(asset.fromPath).toLocaleLowerCase(),
+			normalizePath(asset.toPath),
+		]),
+	);
+	return rewriteLinkDestinations(content, (destination) => {
+		if (!isLocalRelativeDestination(destination)) return destination;
+		const { path, suffix } = splitLinkDestination(destination);
+		const originalTarget = absoluteLinkPath(fromPath, path);
+		const copiedTarget =
+			copiedBySource.get(originalTarget.toLocaleLowerCase()) ?? originalTarget;
+		return `${relativeLinkPath(targetDir, copiedTarget)}${suffix}`;
+	});
 }

--- a/apps/desktop/src/lib/templates.test.ts
+++ b/apps/desktop/src/lib/templates.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import {
+	cascadingTemplateLibraryPaths,
+	discoverTemplateChoices,
+	isTemplateLibraryName,
+	isTemplatePath,
+	owningTemplateLibraryPath,
+	resolveDefaultTemplateChoice,
+	templateOwnerFolderPath,
+} from "./templates";
+
+describe("template path classification", () => {
+	it("recognizes case-insensitive template libraries", () => {
+		expect(isTemplateLibraryName("templates")).toBe(true);
+		expect(isTemplateLibraryName("Templates")).toBe(true);
+		expect(isTemplateLibraryName("template")).toBe(false);
+	});
+
+	it("treats markdown files recursively inside a template library as templates", () => {
+		expect(isTemplatePath("/vault/templates/daily.md")).toBe(true);
+		expect(isTemplatePath("/vault/Templates/nested/daily.markdown")).toBe(true);
+		expect(isTemplatePath("/vault/templates/image.png")).toBe(false);
+		expect(isTemplatePath("/vault/notes/templates.md")).toBe(false);
+	});
+
+	it("finds the nearest owning template library", () => {
+		expect(
+			owningTemplateLibraryPath("/vault/templates/nested/templates/one.md"),
+		).toBe("/vault/templates/nested/templates");
+	});
+});
+
+describe("template library cascade", () => {
+	it("walks from the target owner folder to the workspace root", () => {
+		expect(
+			cascadingTemplateLibraryPaths(
+				templateOwnerFolderPath("/vault/notes/meetings/day.md"),
+				"/vault",
+			),
+		).toEqual([
+			"/vault/notes/meetings/templates",
+			"/vault/notes/templates",
+			"/vault/templates",
+		]);
+	});
+
+	it("uses a template file's library owner while editing templates", () => {
+		expect(templateOwnerFolderPath("/vault/notes/templates/current.md")).toBe(
+			"/vault/notes",
+		);
+	});
+});
+
+describe("discoverTemplateChoices", () => {
+	it("returns nearest-first library-relative choices", () => {
+		const choices = discoverTemplateChoices({
+			workspacePath: "/vault",
+			targetPath: "/vault/notes/meetings/day.md",
+			files: [
+				{ path: "/vault/templates/journal.md" },
+				{ path: "/vault/notes/meetings/templates/main.md" },
+				{ path: "/vault/notes/templates/client/brief.md" },
+				{ path: "/vault/outside.md" },
+				{ path: "/vault/notes/meetings/templates/image.png" },
+			],
+		});
+
+		expect(choices.map((choice) => choice.label)).toEqual([
+			"main",
+			"client/brief",
+			"journal",
+		]);
+		expect(choices.map((choice) => choice.libraryRelativePath)).toEqual([
+			"main.md",
+			"client/brief.md",
+			"journal.md",
+		]);
+	});
+
+	it("keeps same-named templates separate and excludes the current template", () => {
+		const choices = discoverTemplateChoices({
+			workspacePath: "/vault",
+			targetPath: "/vault/notes/templates/main.md",
+			files: [
+				{ path: "/vault/templates/main.md" },
+				{ path: "/vault/notes/templates/main.md" },
+				{ path: "/vault/notes/templates/other.md" },
+			],
+		});
+
+		expect(choices.map((choice) => choice.path)).toEqual([
+			"/vault/notes/templates/other.md",
+			"/vault/templates/main.md",
+		]);
+	});
+
+	it("handles Windows separators and workspace casing", () => {
+		const choices = discoverTemplateChoices({
+			workspacePath: "c:/vault",
+			targetPath: "C:\\Vault\\Notes\\Day.md",
+			files: [
+				{ path: "C:\\Vault\\Templates\\Root.md" },
+				{ path: "C:\\Vault\\Notes\\Templates\\Local.md" },
+			],
+		});
+
+		expect(choices.map((choice) => choice.libraryPath)).toEqual([
+			"C:/Vault/Notes/Templates",
+			"C:/Vault/Templates",
+		]);
+	});
+});
+
+describe("resolveDefaultTemplateChoice", () => {
+	it("chooses the nearest valid default", () => {
+		const choices = discoverTemplateChoices({
+			workspacePath: "/vault",
+			targetPath: "/vault/notes/day.md",
+			files: [
+				{ path: "/vault/templates/a.md" },
+				{ path: "/vault/notes/templates/z.md" },
+			],
+		});
+
+		expect(resolveDefaultTemplateChoice(choices)?.path).toBe(
+			"/vault/notes/templates/z.md",
+		);
+	});
+
+	it("breaks duplicate defaults by case-insensitive relative path, then case", () => {
+		const choices = discoverTemplateChoices({
+			workspacePath: "/vault",
+			targetPath: "/vault/day.md",
+			files: [
+				{ path: "/vault/templates/b.md" },
+				{ path: "/vault/templates/A.md" },
+				{ path: "/vault/templates/a.md" },
+			],
+		});
+
+		expect(resolveDefaultTemplateChoice(choices)?.path).toBe(
+			"/vault/templates/A.md",
+		);
+	});
+});

--- a/apps/desktop/src/lib/templates.ts
+++ b/apps/desktop/src/lib/templates.ts
@@ -1,0 +1,171 @@
+import {
+	dirname,
+	hasMarkdownExtension,
+	joinPath,
+	normalizePath,
+	pathEquals,
+} from "./filePath";
+
+export const TEMPLATE_LIBRARY_NAME = "templates";
+
+export type TemplateFileEntry = {
+	path: string;
+	kind?: string;
+};
+
+export type TemplateChoice = {
+	path: string;
+	libraryPath: string;
+	libraryRelativePath: string;
+	label: string;
+	ownerPath: string | null;
+	libraryRank: number;
+};
+
+function normalizedLower(path: string) {
+	return normalizePath(path).toLocaleLowerCase();
+}
+
+function splitPath(path: string) {
+	const normalized = normalizePath(path);
+	return {
+		absolute: normalized.startsWith("/"),
+		parts: normalized.split("/").filter(Boolean),
+	};
+}
+
+function pathFromParts(parts: string[], absolute: boolean) {
+	if (parts.length === 0) return absolute ? "/" : "";
+	return `${absolute ? "/" : ""}${parts.join("/")}`;
+}
+
+function stripMarkdownExtension(path: string) {
+	return path.replace(/\.(md|markdown|mdown)$/i, "");
+}
+
+function relativePathInFolder(path: string, folderPath: string) {
+	const normalizedPath = normalizePath(path);
+	const normalizedFolder = normalizePath(folderPath).replace(/\/+$/, "");
+	if (pathEquals(normalizedPath, normalizedFolder)) return "";
+	const prefix = `${normalizedFolder}/`;
+	const lowerPath = normalizedPath.toLocaleLowerCase();
+	const lowerPrefix = prefix.toLocaleLowerCase();
+	return lowerPath.startsWith(lowerPrefix)
+		? normalizedPath.slice(prefix.length)
+		: null;
+}
+
+function compareLibraryRelativePath(a: TemplateChoice, b: TemplateChoice) {
+	const lowerA = a.libraryRelativePath.toLocaleLowerCase();
+	const lowerB = b.libraryRelativePath.toLocaleLowerCase();
+	const byInsensitive = lowerA.localeCompare(lowerB);
+	if (byInsensitive !== 0) return byInsensitive;
+	if (a.libraryRelativePath === b.libraryRelativePath) return 0;
+	return a.libraryRelativePath < b.libraryRelativePath ? -1 : 1;
+}
+
+export function isTemplateLibraryName(name: string) {
+	return name.toLocaleLowerCase() === TEMPLATE_LIBRARY_NAME;
+}
+
+export function owningTemplateLibraryPath(path: string) {
+	const { parts, absolute } = splitPath(path);
+	let libraryIndex = -1;
+	for (let index = 0; index < parts.length; index += 1) {
+		if (isTemplateLibraryName(parts[index])) libraryIndex = index;
+	}
+	if (libraryIndex === -1) return null;
+	return pathFromParts(parts.slice(0, libraryIndex + 1), absolute);
+}
+
+export function isTemplatePath(path: string) {
+	return hasMarkdownExtension(path) && owningTemplateLibraryPath(path) !== null;
+}
+
+export function templateOwnerFolderPath(path: string) {
+	const libraryPath = owningTemplateLibraryPath(path);
+	return dirname(libraryPath ?? path);
+}
+
+export function cascadingTemplateLibraryPaths(
+	ownerPath: string | null,
+	workspacePath: string | null,
+) {
+	if (!ownerPath || !workspacePath) return [];
+
+	const root = normalizePath(workspacePath);
+	const libraries: string[] = [];
+	let current: string | null = normalizePath(ownerPath);
+	while (current) {
+		const lowerCurrent = normalizedLower(current);
+		const lowerRoot = normalizedLower(root);
+		if (
+			lowerCurrent === lowerRoot ||
+			lowerCurrent.startsWith(`${lowerRoot}/`)
+		) {
+			libraries.push(joinPath(current, TEMPLATE_LIBRARY_NAME));
+		}
+		if (pathEquals(current, root)) break;
+		const parent = dirname(current);
+		if (!parent || pathEquals(parent, current)) break;
+		current = parent;
+	}
+	return libraries;
+}
+
+export function discoverTemplateChoices({
+	files,
+	targetPath,
+	workspacePath,
+	currentPath = targetPath,
+}: {
+	files: readonly TemplateFileEntry[];
+	targetPath: string;
+	workspacePath: string | null;
+	currentPath?: string | null;
+}) {
+	const ownerPath = templateOwnerFolderPath(targetPath);
+	const libraries = cascadingTemplateLibraryPaths(ownerPath, workspacePath);
+	const libraryRank = new Map(
+		libraries.map((path, index) => [normalizedLower(path), index]),
+	);
+	const choices: TemplateChoice[] = [];
+
+	for (const file of files) {
+		if (currentPath && pathEquals(file.path, currentPath)) continue;
+		if (file.kind && file.kind !== "document") continue;
+		if (!hasMarkdownExtension(file.path)) continue;
+
+		const libraryPath = owningTemplateLibraryPath(file.path);
+		if (!libraryPath) continue;
+		const rank = libraryRank.get(normalizedLower(libraryPath));
+		if (rank === undefined) continue;
+
+		const libraryRelativePath = relativePathInFolder(file.path, libraryPath);
+		if (!libraryRelativePath) continue;
+		choices.push({
+			path: file.path,
+			libraryPath,
+			libraryRelativePath,
+			label: stripMarkdownExtension(libraryRelativePath),
+			ownerPath: dirname(libraryPath),
+			libraryRank: rank,
+		});
+	}
+
+	return choices.sort((a, b) => {
+		const byLibrary =
+			(libraryRank.get(normalizedLower(a.libraryPath)) ?? 0) -
+			(libraryRank.get(normalizedLower(b.libraryPath)) ?? 0);
+		return byLibrary || compareLibraryRelativePath(a, b);
+	});
+}
+
+export function resolveDefaultTemplateChoice(
+	validDefaultChoices: readonly TemplateChoice[],
+) {
+	return [...validDefaultChoices].sort((a, b) => {
+		const byLibrary = a.libraryRank - b.libraryRank;
+		return byLibrary || compareLibraryRelativePath(a, b);
+	})[0];
+}

--- a/apps/desktop/src/store/actions.test.ts
+++ b/apps/desktop/src/store/actions.test.ts
@@ -15,6 +15,8 @@ type MockDesktopApi = {
 	setDeleteUndoAvailable: ReturnType<typeof vi.fn>;
 	undoText: ReturnType<typeof vi.fn>;
 	pathExists: ReturnType<typeof vi.fn>;
+	materializeTemplate: ReturnType<typeof vi.fn>;
+	rollbackTemplateMaterialization: ReturnType<typeof vi.fn>;
 	openPathFromLink: ReturnType<typeof vi.fn>;
 	openPathInDefaultApp: ReturnType<typeof vi.fn>;
 	sidebarDeltaForPath: ReturnType<typeof vi.fn>;
@@ -37,6 +39,8 @@ function createDesktopApi(): MockDesktopApi {
 		setDeleteUndoAvailable: vi.fn(async () => {}),
 		undoText: vi.fn(async () => {}),
 		pathExists: vi.fn(async () => false),
+		materializeTemplate: vi.fn(async (_input) => ({ content: "" })),
+		rollbackTemplateMaterialization: vi.fn(async () => {}),
 		openPathFromLink: vi.fn(async () => ({ kind: "opened" })),
 		openPathInDefaultApp: vi.fn(async () => {}),
 		sidebarDeltaForPath: vi.fn(async () => null),
@@ -1402,6 +1406,137 @@ describe("desktop title generation", () => {
 		await vi.advanceTimersByTimeAsync(500);
 
 		expect(api.renameFile).not.toHaveBeenCalled();
+	});
+});
+
+describe("desktop template actions", () => {
+	beforeEach(() => {
+		vi.unstubAllGlobals();
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("creates blank templates inside template libraries without title generation", async () => {
+		const api = createDesktopApi();
+		const { appStore, createMarkdownFileInFolder, updateEditorContent } =
+			await loadStoreActions(api);
+		appStore.set((state) => ({
+			...state,
+			workspace: { ...state.workspace, workspacePath: "/workspace" },
+		}));
+
+		const path = await createMarkdownFileInFolder("/workspace/Templates");
+		updateEditorContent(
+			"/workspace/Templates/new-template.md",
+			"Template title",
+		);
+		await vi.advanceTimersByTimeAsync(500);
+
+		expect(path).toBe("/workspace/Templates/new-template.md");
+		expect(api.writeFileText).toHaveBeenCalledWith(
+			"/workspace/Templates/new-template.md",
+			"---\ndefault-template: false\n---\n",
+		);
+		expect(api.renameFile).not.toHaveBeenCalled();
+	});
+
+	it("materializes the effective default for new Markdown notes", async () => {
+		const api = createDesktopApi();
+		api.readFileText.mockImplementation(async (path: string) =>
+			path === "/workspace/templates/daily.md"
+				? "---\ndefault-template: true\n---\n# Daily"
+				: path === "/workspace/notes/new-file.md"
+					? "# Daily"
+					: "",
+		);
+		api.materializeTemplate.mockResolvedValue({ content: "# Daily" });
+		const {
+			appStore,
+			createMarkdownFileInFolder,
+			updateEditorContent,
+			viewerStore,
+		} = await loadStoreActions(api);
+		appStore.set((state) => ({
+			...state,
+			workspace: {
+				...state.workspace,
+				workspacePath: "/workspace",
+				files: [{ path: "/workspace/templates/daily.md", modified_at: 1 }],
+			},
+		}));
+
+		const path = await createMarkdownFileInFolder("/workspace/notes");
+		expect(viewerStore.get().content).toBe("# Daily");
+		updateEditorContent(path as string, "# Edited title");
+		await vi.advanceTimersByTimeAsync(500);
+
+		expect(path).toBe("/workspace/notes/new-file.md");
+		expect(api.materializeTemplate).toHaveBeenCalledWith({
+			sourcePath: "/workspace/templates/daily.md",
+			targetPath: "/workspace/notes/new-file.md",
+			content: "# Daily",
+			mode: "create",
+		});
+		expect(api.renameFile).not.toHaveBeenCalled();
+	});
+
+	it("unchecks sibling defaults when a template becomes the default", async () => {
+		const api = createDesktopApi();
+		api.readFileText.mockImplementation(async (path: string) =>
+			path === "/workspace/templates/b.md"
+				? "---\ndefault-template: true\n---\nB"
+				: "A",
+		);
+		const { appStore, updateEditorContent } = await loadStoreActions(api);
+		appStore.set((state) => ({
+			...state,
+			workspace: {
+				...state.workspace,
+				workspacePath: "/workspace",
+				files: [
+					{ path: "/workspace/templates/a.md", modified_at: 1 },
+					{ path: "/workspace/templates/b.md", modified_at: 1 },
+				],
+			},
+			document: {
+				...state.document,
+				currentPath: "/workspace/templates/a.md",
+				content: "---\ndefault-template: false\n---\nA",
+				diskContent: "---\ndefault-template: false\n---\nA",
+			},
+		}));
+
+		updateEditorContent(
+			"/workspace/templates/a.md",
+			"---\ndefault-template: true\n---\nA",
+		);
+		await vi.waitFor(() =>
+			expect(api.writeFileText).toHaveBeenCalledWith(
+				"/workspace/templates/b.md",
+				"---\ndefault-template: false\n---\nB",
+			),
+		);
+	});
+
+	it("does not save invalid front matter as a template", async () => {
+		const api = createDesktopApi();
+		const { appStore, saveCurrentAsTemplate } = await loadStoreActions(api);
+		appStore.set((state) => ({
+			...state,
+			workspace: { ...state.workspace, workspacePath: "/workspace" },
+			document: {
+				...state.document,
+				currentPath: "/workspace/note.md",
+				content: "---\nbroken: [one\n---\nBody",
+				diskContent: "---\nbroken: [one\n---\nBody",
+			},
+		}));
+
+		expect(await saveCurrentAsTemplate()).toBeNull();
+		expect(api.materializeTemplate).not.toHaveBeenCalled();
 	});
 });
 

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -35,6 +35,7 @@ import {
 	pathAfterMove,
 	rewriteMovedLinks,
 } from "../lib/markdownLinkRewrite";
+import { isTemplatePath } from "../lib/templates";
 import {
 	setThemePreference as applyThemePreference,
 	initTheme,
@@ -79,6 +80,12 @@ import {
 	withOpenedDoc,
 	workspaceStore,
 } from "./state";
+import {
+	contentWithDefaultTemplateFalse,
+	materializeNewMarkdownFile,
+	normalizeDefaultTemplateSiblings,
+	templateFileStem,
+} from "./templateActions";
 import { createTitleManager } from "./titleManagement";
 import { applyWorkspaceDelta } from "./workspaceDelta";
 
@@ -686,6 +693,7 @@ export function updateEditorContent(path: string, content: string) {
 	if (current.currentPath !== currentPath || current.content === content)
 		return;
 	void expireDeleteUndo();
+	void normalizeDefaultTemplateSiblings(currentPath, current.content, content);
 
 	viewerStore.set((state) => {
 		if (state.currentPath !== currentPath) return state;
@@ -1202,12 +1210,98 @@ async function createEmptyFileInFolder(
 	}
 }
 
-export function createMarkdownFileInFolder(parentPath: string) {
-	return createEmptyFileInFolder(parentPath, "new-file", ".md");
+export async function createMarkdownFileInFolder(parentPath: string) {
+	const path = uniqueFilePath(parentPath, templateFileStem(parentPath), ".md");
+	try {
+		const { startsBlankTitleSession } = await materializeNewMarkdownFile(
+			parentPath,
+			path,
+		);
+		if (startsBlankTitleSession) {
+			titleManager.start(path);
+		}
+		const modified_at = Math.floor(Date.now() / 1000);
+		workspaceStore.set((state) => ({
+			...state,
+			files: [
+				...state.files,
+				{ path, modified_at, kind: fileKindForPath(path) },
+			],
+		}));
+		await loadPath(path);
+		await refreshFileList();
+		return path;
+	} catch (err) {
+		titleManager.stop(path);
+		const message = handleFileError(err);
+		toast.error("Failed to create file", { description: message });
+		return null;
+	}
 }
 
 export function createHtmlFileInFolder(parentPath: string) {
 	return createEmptyFileInFolder(parentPath, "new-app", ".html");
+}
+
+export async function saveCurrentAsTemplate() {
+	const current = viewerStore.get();
+	const sourcePath = current.currentPath;
+	if (
+		!sourcePath ||
+		!hasMarkdownExtension(sourcePath) ||
+		isTemplatePath(sourcePath)
+	) {
+		return null;
+	}
+	const parentPath = dirname(sourcePath);
+	if (!parentPath) return null;
+	const templatesPath = joinPath(parentPath, "templates");
+	const targetPath = uniqueFilePath(
+		templatesPath,
+		fileStem(sourcePath),
+		extname(sourcePath) || ".md",
+	);
+	let content: string;
+	try {
+		content = contentWithDefaultTemplateFalse(current.content);
+	} catch (err) {
+		toast.error("Invalid note front matter", {
+			description: errorMessage(err),
+		});
+		return null;
+	}
+
+	try {
+		const materialized = await desktopApi.materializeTemplate({
+			sourcePath,
+			targetPath,
+			content,
+			mode: "create",
+		});
+		const nextContent = materialized.content;
+		const modified_at = Math.floor(Date.now() / 1000);
+		workspaceStore.set((state) => ({
+			...state,
+			files: [
+				...state.files,
+				{ path: targetPath, modified_at, kind: fileKindForPath(targetPath) },
+			],
+			folders: state.folders.some((folder) =>
+				pathEquals(folder.path, templatesPath),
+			)
+				? state.folders
+				: [...state.folders, { path: templatesPath, modified_at }],
+		}));
+		appStore.set((state) => withOpenedDoc(state, targetPath, nextContent));
+		pushHistory(targetPath);
+		await refreshFileList();
+		toast.success("Saved as template");
+		return targetPath;
+	} catch (err) {
+		const message = handleFileError(err);
+		toast.error("Failed to save template", { description: message });
+		return null;
+	}
 }
 
 export async function createFolderInFolder(parentPath: string) {

--- a/apps/desktop/src/store/templateActions.ts
+++ b/apps/desktop/src/store/templateActions.ts
@@ -1,0 +1,320 @@
+import {
+	combineMarkdownFrontMatter,
+	DEFAULT_TEMPLATE_PROPERTY_KEY,
+	type FileProperty,
+	mergeTemplateFrontMatter,
+	parseMarkdownFrontMatter,
+	readDefaultTemplateDirective,
+	serializeFrontMatter,
+} from "@hubble.md/editor";
+import { toast } from "sonner";
+import { desktopApi } from "../desktopApi";
+import {
+	basename,
+	joinPath,
+	pathEquals,
+	relativeWorkspacePath,
+} from "../lib/filePath";
+import {
+	discoverTemplateChoices,
+	owningTemplateLibraryPath,
+	resolveDefaultTemplateChoice,
+	type TemplateChoice,
+} from "../lib/templates";
+import { viewerStore, workspaceStore } from "./state";
+
+export type TemplateEditorChoice = {
+	id: string;
+	title: string;
+	description?: string;
+	library?: string;
+	path?: string;
+	isDefault?: boolean;
+	keywords?: string[];
+};
+
+export type TemplateApplicationContext = {
+	targetPath: string;
+	targetMarkdown: string;
+};
+
+export type PreparedTemplateApplication = {
+	body: string;
+	frontMatter: string;
+	cleanupToken?: string;
+};
+
+class ShownTemplateError extends Error {
+	readonly reported = true;
+}
+
+export function templateFileStem(parentPath: string) {
+	return owningTemplateLibraryPath(parentPath) ? "new-template" : "new-file";
+}
+
+export async function materializeNewMarkdownFile(
+	parentPath: string,
+	targetPath: string,
+) {
+	if (owningTemplateLibraryPath(parentPath)) {
+		const content = combineMarkdownFrontMatter("default-template: false", "");
+		await desktopApi.writeFileText(targetPath, content);
+		return { content, startsBlankTitleSession: false };
+	}
+
+	const defaultPath = await resolveDefaultTemplatePath(parentPath);
+	if (!defaultPath) {
+		await desktopApi.writeFileText(targetPath, "");
+		return { content: "", startsBlankTitleSession: true };
+	}
+
+	const templateContent = await desktopApi.readFileText(defaultPath);
+	const preparedContent = stripDefaultTemplateDirective(templateContent);
+	const materialized = await desktopApi.materializeTemplate({
+		sourcePath: defaultPath,
+		targetPath,
+		content: preparedContent,
+		mode: "create",
+	});
+	return { content: materialized.content, startsBlankTitleSession: false };
+}
+
+export async function prepareTemplateApplication(
+	choice: TemplateEditorChoice,
+	context: TemplateApplicationContext,
+	options?: { openTemplate?: (path: string) => void | Promise<void> },
+): Promise<PreparedTemplateApplication> {
+	const templatePath = choice.path;
+	if (!templatePath) throw new Error("Template unavailable");
+	const before = viewerStore.get();
+	if (before.currentPath !== context.targetPath) {
+		throw new Error("Template cancelled");
+	}
+
+	let templateContent: string;
+	try {
+		templateContent = await desktopApi.readFileText(templatePath);
+	} catch (error) {
+		toast.error("Failed to read template", { description: message(error) });
+		throw new ShownTemplateError("Template unavailable");
+	}
+
+	const template = parseMarkdownFrontMatter(templateContent);
+	const merged = mergeTemplateFrontMatter(
+		templateContent,
+		context.targetMarkdown,
+	);
+	if (merged.type === "invalid-template") {
+		toast.error("Invalid template front matter", {
+			description: merged.error,
+			action: options?.openTemplate
+				? {
+						label: "Edit template",
+						onClick: () => void options.openTemplate?.(templatePath),
+					}
+				: undefined,
+		});
+		throw new ShownTemplateError("Template properties are invalid");
+	}
+	if (merged.type === "invalid-target") {
+		toast.error("Invalid note front matter", { description: merged.error });
+		throw new ShownTemplateError("Current note properties are invalid");
+	}
+
+	let materialized: { content: string; cleanupToken?: string };
+	try {
+		materialized = await desktopApi.materializeTemplate({
+			sourcePath: templatePath,
+			targetPath: context.targetPath,
+			content: template.body,
+			mode: "existing",
+		});
+	} catch (error) {
+		toast.error("Failed to apply template", { description: message(error) });
+		throw new ShownTemplateError("Template unavailable");
+	}
+
+	const after = viewerStore.get();
+	if (
+		after.currentPath !== context.targetPath ||
+		after.content !== before.content
+	) {
+		if (materialized.cleanupToken) {
+			await rollbackTemplateMaterialization(materialized.cleanupToken);
+		}
+		throw new Error("Template cancelled");
+	}
+
+	return {
+		body: materialized.content,
+		frontMatter: merged.frontMatter,
+		cleanupToken: materialized.cleanupToken,
+	};
+}
+
+export async function rollbackTemplateMaterialization(token: string) {
+	try {
+		await desktopApi.rollbackTemplateMaterialization(token);
+	} catch (error) {
+		toast.error("Failed to clean up template assets", {
+			description: message(error),
+		});
+	}
+}
+
+export async function normalizeDefaultTemplateSiblings(
+	path: string,
+	previousContent: string,
+	nextContent: string,
+) {
+	if (!isValidDefaultTransition(previousContent, nextContent)) return;
+	const libraryPath = owningTemplateLibraryPath(path);
+	if (!libraryPath) return;
+	const files = workspaceStore
+		.get()
+		.files.filter(
+			(file) =>
+				!pathEquals(file.path, path) &&
+				pathEquals(owningTemplateLibraryPath(file.path) ?? "", libraryPath),
+		);
+	for (const file of files) {
+		try {
+			const content = await desktopApi.readFileText(file.path);
+			const parsed = parseMarkdownFrontMatter(content);
+			if (readDefaultTemplateDirective(parsed) !== true) continue;
+			await desktopApi.writeFileText(
+				file.path,
+				withDefaultTemplateDirective(content, false),
+			);
+		} catch (error) {
+			toast.error("Failed to update template default", {
+				description: message(error),
+			});
+		}
+	}
+}
+
+export function contentWithDefaultTemplateFalse(markdown: string) {
+	return withDefaultTemplateDirective(markdown, false);
+}
+
+export function templateChoiceStubsForPath(targetPath: string) {
+	return templateChoices(targetPath).map((choice) =>
+		editorChoice(choice, false),
+	);
+}
+
+export async function templateChoicesForPath(targetPath: string) {
+	const choices = templateChoices(targetPath);
+	const defaultPaths = new Set(
+		(await validDefaultChoices(choices)).map((choice) => choice.path),
+	);
+	return choices.map((choice) =>
+		editorChoice(choice, defaultPaths.has(choice.path)),
+	);
+}
+
+function templateChoices(targetPath: string) {
+	const { files, workspacePath } = workspaceStore.get();
+	return discoverTemplateChoices({
+		files,
+		targetPath,
+		workspacePath,
+		currentPath: targetPath,
+	});
+}
+
+function editorChoice(choice: TemplateChoice, isDefault: boolean) {
+	const workspacePath = workspaceStore.get().workspacePath;
+	const owner = choice.ownerPath
+		? relativeWorkspacePath(choice.ownerPath, workspacePath) ||
+			basename(choice.ownerPath)
+		: undefined;
+	return {
+		id: choice.path,
+		title: basename(choice.label),
+		description: choice.libraryRelativePath,
+		library: owner,
+		path: choice.path,
+		isDefault,
+		keywords: [choice.label, choice.libraryRelativePath, owner ?? ""],
+	} satisfies TemplateEditorChoice;
+}
+
+async function resolveDefaultTemplatePath(targetFolderPath: string) {
+	const { files, workspacePath } = workspaceStore.get();
+	if (!workspacePath) return null;
+	const choices = discoverTemplateChoices({
+		files,
+		targetPath: joinPath(targetFolderPath, "__new__.md"),
+		workspacePath,
+		currentPath: null,
+	});
+	return (
+		resolveDefaultTemplateChoice(await validDefaultChoices(choices))?.path ??
+		null
+	);
+}
+
+async function validDefaultChoices(choices: readonly TemplateChoice[]) {
+	const defaults: TemplateChoice[] = [];
+	for (const choice of choices) {
+		try {
+			const content = await desktopApi.readFileText(choice.path);
+			const directive = readDefaultTemplateDirective(
+				parseMarkdownFrontMatter(content),
+			);
+			if (directive === true) defaults.push(choice);
+		} catch {}
+	}
+	return defaults;
+}
+
+function isValidDefaultTransition(
+	previousContent: string,
+	nextContent: string,
+) {
+	const previous = readDefaultTemplateDirective(
+		parseMarkdownFrontMatter(previousContent),
+	);
+	const next = readDefaultTemplateDirective(
+		parseMarkdownFrontMatter(nextContent),
+	);
+	return previous === false && next === true;
+}
+
+function stripDefaultTemplateDirective(markdown: string) {
+	const parsed = parseMarkdownFrontMatter(markdown);
+	if (parsed.type === "invalid") throw new Error(parsed.error);
+	if (parsed.type === "none") return markdown;
+	const properties = parsed.properties.filter(
+		(property) => property.key !== DEFAULT_TEMPLATE_PROPERTY_KEY,
+	);
+	return combineMarkdownFrontMatter(
+		serializeFrontMatter(properties),
+		parsed.body,
+	);
+}
+
+function withDefaultTemplateDirective(markdown: string, value: boolean) {
+	const parsed = parseMarkdownFrontMatter(markdown);
+	if (parsed.type === "invalid") throw new Error(parsed.error);
+	const properties =
+		parsed.type === "valid"
+			? parsed.properties.filter(
+					(property) => property.key !== DEFAULT_TEMPLATE_PROPERTY_KEY,
+				)
+			: [];
+	const nextProperties: FileProperty[] = [
+		...properties,
+		{ key: DEFAULT_TEMPLATE_PROPERTY_KEY, type: "checkbox", value },
+	];
+	return combineMarkdownFrontMatter(
+		serializeFrontMatter(nextProperties),
+		parsed.body,
+	);
+}
+
+function message(error: unknown) {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/packages/editor/src/frontMatter.test.ts
+++ b/packages/editor/src/frontMatter.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from "vitest";
 import {
 	combineMarkdownFrontMatter,
 	detectFilePropertyType,
+	mergeTemplateFrontMatter,
 	parseDateInput,
 	parseMarkdownFrontMatter,
+	readDefaultTemplateDirective,
+	removeDefaultTemplateProperty,
 	serializeFrontMatter,
 } from "./frontMatter.js";
 
@@ -137,5 +140,95 @@ title: Test
 		expect(parseDateInput("04/06/2025")).toBe("2025-04-06");
 		expect(parseDateInput("04-06-2025")).toBe("2025-04-06");
 		expect(parseDateInput("13/40/2025")).toBeNull();
+	});
+
+	it("reads only boolean default-template directives", () => {
+		expect(
+			readDefaultTemplateDirective(
+				parseMarkdownFrontMatter(`---
+default-template: true
+---
+Body`),
+			),
+		).toBe(true);
+		expect(
+			readDefaultTemplateDirective(
+				parseMarkdownFrontMatter(`---
+default-template: false
+---
+Body`),
+			),
+		).toBe(false);
+		expect(
+			readDefaultTemplateDirective(
+				parseMarkdownFrontMatter(`---
+default-template: "true"
+---
+Body`),
+			),
+		).toBeNull();
+	});
+
+	it("removes default-template before applying template properties", () => {
+		const parsed = parseMarkdownFrontMatter(`---
+title: Template
+default-template: true
+---
+Body`);
+		expect(parsed.type).toBe("valid");
+		if (parsed.type !== "valid") return;
+
+		expect(removeDefaultTemplateProperty(parsed.properties)).toEqual([
+			{ key: "title", type: "text", value: "Template" },
+		]);
+	});
+
+	it("merges template properties target-first and case-sensitively", () => {
+		const result = mergeTemplateFrontMatter(
+			`---
+title: Template
+Title: Kept separately
+tags:
+  - template
+nested:
+  child: value
+default-template: true
+---
+Template body`,
+			`---
+title: Target
+tags:
+  - target
+---
+Target body`,
+		);
+
+		expect(result.type).toBe("valid");
+		if (result.type !== "valid") return;
+		expect(result.properties).toEqual([
+			{ key: "title", type: "text", value: "Target" },
+			{ key: "tags", type: "tags", value: ["target"] },
+			{ key: "Title", type: "text", value: "Kept separately" },
+			{
+				key: "nested",
+				type: "unsupported",
+				raw: "nested:\n  child: value",
+			},
+		]);
+		expect(result.frontMatter).toBe(`title: "Target"
+tags:
+  - target
+Title: "Kept separately"
+nested:
+  child: value`);
+	});
+
+	it("reports invalid template or target front matter without merging", () => {
+		expect(
+			mergeTemplateFrontMatter("---\nbroken: [one\n---\nBody", "Target"),
+		).toMatchObject({ type: "invalid-template" });
+		expect(
+			mergeTemplateFrontMatter("Template", "---\nbroken: [one\n---\nBody"),
+		).toMatchObject({ type: "invalid-target" });
 	});
 });

--- a/packages/editor/src/frontMatter.ts
+++ b/packages/editor/src/frontMatter.ts
@@ -37,6 +37,8 @@ export type ParsedFrontMatter =
 	| { type: "invalid"; raw: string; body: string; error: string }
 	| { type: "valid"; raw: string; body: string; properties: FileProperty[] };
 
+export const DEFAULT_TEMPLATE_PROPERTY_KEY = "default-template";
+
 export function parseMarkdownFrontMatter(markdown: string): ParsedFrontMatter {
 	const split = splitFrontMatter(markdown);
 	if (!split) return { type: "none", body: markdown };
@@ -67,6 +69,61 @@ export function parseMarkdownFrontMatter(markdown: string): ParsedFrontMatter {
 		raw: split.raw,
 		body: split.body,
 		properties: mapToProperties(doc.contents),
+	};
+}
+
+export function readDefaultTemplateDirective(
+	frontMatter: ParsedFrontMatter,
+): boolean | null {
+	if (frontMatter.type !== "valid") return null;
+	const property = frontMatter.properties.find(
+		(candidate) => candidate.key === DEFAULT_TEMPLATE_PROPERTY_KEY,
+	);
+	if (!property || property.type !== "checkbox") return null;
+	return property.value;
+}
+
+export function removeDefaultTemplateProperty(
+	properties: FileProperty[],
+): FileProperty[] {
+	return properties.filter(
+		(property) => property.key !== DEFAULT_TEMPLATE_PROPERTY_KEY,
+	);
+}
+
+export type MergeTemplateFrontMatterResult =
+	| { type: "valid"; frontMatter: string; properties: FileProperty[] }
+	| { type: "invalid-template"; error: string }
+	| { type: "invalid-target"; error: string };
+
+export function mergeTemplateFrontMatter(
+	templateMarkdown: string,
+	targetMarkdown: string,
+): MergeTemplateFrontMatterResult {
+	const template = parseMarkdownFrontMatter(templateMarkdown);
+	if (template.type === "invalid") {
+		return { type: "invalid-template", error: template.error };
+	}
+	const target = parseMarkdownFrontMatter(targetMarkdown);
+	if (target.type === "invalid") {
+		return { type: "invalid-target", error: target.error };
+	}
+	const targetProperties = target.type === "valid" ? target.properties : [];
+	const templateProperties =
+		template.type === "valid"
+			? removeDefaultTemplateProperty(template.properties)
+			: [];
+	const existingKeys = new Set(
+		targetProperties.map((property) => property.key),
+	);
+	const missingTemplateProperties = templateProperties.filter(
+		(property) => !existingKeys.has(property.key),
+	);
+	const properties = [...targetProperties, ...missingTemplateProperties];
+	return {
+		type: "valid",
+		frontMatter: serializeFrontMatter(properties),
+		properties,
 	};
 }
 

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -17,14 +17,19 @@ export {
 } from "./FindExtension.js";
 export {
 	combineMarkdownFrontMatter,
+	DEFAULT_TEMPLATE_PROPERTY_KEY,
 	detectFilePropertyType,
 	type FileProperty,
 	type FilePropertyType,
 	isDateString,
 	isSimplePropertyKey,
+	type MergeTemplateFrontMatterResult,
+	mergeTemplateFrontMatter,
 	type ParsedFrontMatter,
 	parseDateInput,
 	parseMarkdownFrontMatter,
+	readDefaultTemplateDirective,
+	removeDefaultTemplateProperty,
 	serializeFrontMatter,
 	setMarkdownFrontMatter,
 } from "./frontMatter.js";

--- a/packages/ui/src/components/GlobalSearchPalette.test.ts
+++ b/packages/ui/src/components/GlobalSearchPalette.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+	getNameResults,
+	type PaletteFile,
+	rankContentResults,
+} from "./GlobalSearchPalette";
+
+const files: PaletteFile[] = [
+	{
+		path: "/vault/templates/plan.md",
+		relativePath: "templates/plan.md",
+		modifiedAt: 30,
+		isTemplate: true,
+	},
+	{
+		path: "/vault/plan.md",
+		relativePath: "plan.md",
+		modifiedAt: 10,
+	},
+	{
+		path: "/vault/notes/plan.md",
+		relativePath: "notes/plan.md",
+		modifiedAt: 20,
+	},
+];
+
+describe("GlobalSearchPalette ranking", () => {
+	it("ranks ordinary notes above equally relevant templates by name", () => {
+		expect(getNameResults(files, "plan").map((file) => file.path)).toEqual([
+			"/vault/notes/plan.md",
+			"/vault/plan.md",
+			"/vault/templates/plan.md",
+		]);
+	});
+
+	it("keeps modification time as the tie-break within ordinary notes", () => {
+		expect(getNameResults(files, "").map((file) => file.path)).toEqual([
+			"/vault/notes/plan.md",
+			"/vault/plan.md",
+			"/vault/templates/plan.md",
+		]);
+	});
+
+	it("ranks ordinary notes above templates for content matches", () => {
+		const results = rankContentResults(
+			[
+				{ path: "/vault/templates/plan.md", matches: [] },
+				{ path: "/vault/plan.md", matches: [] },
+				{ path: "/vault/notes/plan.md", matches: [] },
+			],
+			files,
+		);
+
+		expect(results.map((result) => result.path)).toEqual([
+			"/vault/notes/plan.md",
+			"/vault/plan.md",
+			"/vault/templates/plan.md",
+		]);
+	});
+});

--- a/packages/ui/src/components/GlobalSearchPalette.tsx
+++ b/packages/ui/src/components/GlobalSearchPalette.tsx
@@ -27,6 +27,7 @@ export type PaletteFile = {
 	path: string;
 	relativePath: string;
 	modifiedAt: number;
+	isTemplate?: boolean;
 };
 
 export type PaletteContentMatch = {
@@ -87,18 +88,37 @@ function folderPath(relativePath: string) {
 	return slash === -1 ? "" : relativePath.slice(0, slash);
 }
 
-function getNameResults(files: PaletteFile[], query: string) {
+function comparePaletteFiles(a: PaletteFile, b: PaletteFile) {
+	const byTemplate =
+		Number(a.isTemplate ?? false) - Number(b.isTemplate ?? false);
+	return byTemplate || b.modifiedAt - a.modifiedAt;
+}
+
+export function getNameResults(files: PaletteFile[], query: string) {
 	if (query.trim() === "") {
-		return [...files]
-			.sort((a, b) => b.modifiedAt - a.modifiedAt)
-			.slice(0, MAX_RECENT_FILES);
+		return [...files].sort(comparePaletteFiles).slice(0, MAX_RECENT_FILES);
 	}
 	return files
 		.map((file) => ({ file, score: scorePath(query, file.relativePath) }))
 		.filter((entry) => entry.score > 0)
-		.sort((a, b) => b.score - a.score || b.file.modifiedAt - a.file.modifiedAt)
+		.sort((a, b) => b.score - a.score || comparePaletteFiles(a.file, b.file))
 		.slice(0, MAX_NAME_RESULTS)
 		.map((entry) => entry.file);
+}
+
+export function rankContentResults(
+	results: PaletteFileMatches[],
+	files: PaletteFile[],
+) {
+	const fileByPath = new Map(files.map((file) => [file.path, file]));
+	return [...results].sort((a, b) => {
+		const fileA = fileByPath.get(a.path);
+		const fileB = fileByPath.get(b.path);
+		if (!fileA && !fileB) return 0;
+		if (!fileA) return 1;
+		if (!fileB) return -1;
+		return comparePaletteFiles(fileA, fileB);
+	});
 }
 
 /**
@@ -241,9 +261,10 @@ function GlobalSearchPalette({
 	);
 	const namePaths = new Set(nameResults.map((file) => file.path));
 	// A file that already matched by name appears once, in the name group.
-	const contentResults = (result?.results ?? []).filter(
-		(entry) => !namePaths.has(entry.path),
-	);
+	const contentResults = rankContentResults(
+		result?.results ?? [],
+		files,
+	).filter((entry) => !namePaths.has(entry.path));
 
 	const select = (path: string) => {
 		onOpenChange(false);

--- a/packages/ui/src/editor/EditorPathAttribution.test.tsx
+++ b/packages/ui/src/editor/EditorPathAttribution.test.tsx
@@ -194,6 +194,81 @@ describe("editor path attribution", () => {
 
 		expect(editor.can().undo()).toBe(true);
 	});
+
+	it("applies a prepared template through the rich editor host contract", async () => {
+		const onLocalChange = vi.fn();
+		const onSave = vi.fn();
+		const prepareTemplateApplication = vi.fn().mockResolvedValue({
+			body: "## Template\n\nBody",
+			frontMatter: `title: "Target"
+tags:
+  - work`,
+			cleanupToken: "assets-1",
+		});
+		const cleanupTemplateApplication = vi.fn();
+		const root = createTestRoot();
+		const getEditor = captureEditorCreation();
+
+		await act(async () => {
+			root.render(
+				<EditorView
+					path="/note.md"
+					initialMarkdown={`---
+title: Target
+---
+/template`}
+					saveDebounceMs={LONG_SAVE_DEBOUNCE_MS}
+					onLocalChange={onLocalChange}
+					onSave={onSave}
+					onOpenExternalLink={() => {}}
+					onOpenWikiLink={() => {}}
+					templateChoices={[{ id: "daily", title: "Daily" }]}
+					prepareTemplateApplication={prepareTemplateApplication}
+					cleanupTemplateApplication={cleanupTemplateApplication}
+				/>,
+			);
+		});
+		const editor = getEditor();
+
+		await act(async () => {
+			editor.commands.focus("end");
+		});
+		await act(async () => {
+			editor.view.dom.dispatchEvent(
+				new KeyboardEvent("keydown", {
+					key: "Enter",
+					bubbles: true,
+					cancelable: true,
+				}),
+			);
+		});
+		const templateItem = document.querySelector(
+			'[cmdk-item][data-value="daily"]',
+		);
+		expect(templateItem).toBeInstanceOf(HTMLElement);
+		await act(async () => {
+			(templateItem as HTMLElement).click();
+		});
+
+		expect(prepareTemplateApplication).toHaveBeenCalledWith(
+			{ id: "daily", title: "Daily" },
+			{
+				targetPath: "/note.md",
+				targetMarkdown: `---
+title: Target
+---
+/template`,
+			},
+		);
+		expect(cleanupTemplateApplication).not.toHaveBeenCalled();
+		expect(onLocalChange).toHaveBeenCalled();
+		const markdown = onLocalChange.mock.lastCall?.[1] as string;
+		expect(markdown).toContain('title: "Target"');
+		expect(markdown).toContain("tags:\n  - work");
+		expect(markdown).toContain("## Template");
+		expect(markdown).toContain("Body");
+		expect(markdown).not.toContain("/template");
+	});
 });
 
 function createTestRoot() {

--- a/packages/ui/src/editor/EditorView.tsx
+++ b/packages/ui/src/editor/EditorView.tsx
@@ -37,8 +37,12 @@ import {
 	type PendingSave,
 	schedulePendingSave,
 } from "./pendingSave";
-import { SlashCommandMenu } from "./SlashCommandMenu";
+import { SlashCommandMenu, type SlashTemplateChoice } from "./SlashCommandMenu";
 import { SmartLinkExtension } from "./SmartLinkExtension";
+import {
+	applyTemplateSlashCommand,
+	type SlashToken,
+} from "./slashCommandActions";
 import { TableCellSelectionExtension } from "./TableCellSelectionExtension";
 import {
 	MarkdownTableCell,
@@ -65,6 +69,18 @@ import type { VirtualCursorMode } from "./virtualCursorMode";
 const DEFAULT_SAVE_DEBOUNCE_MS = 120;
 
 export type { WikiTarget };
+export type EditorTemplateChoice = SlashTemplateChoice;
+
+export type PrepareTemplateApplicationContext = {
+	targetPath: string;
+	targetMarkdown: string;
+};
+
+export type PreparedTemplateApplication = {
+	body: string;
+	frontMatter: string;
+	cleanupToken?: string;
+};
 
 export type EditorViewProps = {
 	path: string;
@@ -87,6 +103,13 @@ export type EditorViewProps = {
 	onOpenExternalLink: (href: string) => void | Promise<void>;
 	onOpenWikiLink: (target: string) => void | Promise<void>;
 	onMessage?: (message: string, type: "success" | "error") => void;
+	templateChoices?: EditorTemplateChoice[];
+	loadTemplateChoices?: () => Promise<EditorTemplateChoice[]>;
+	prepareTemplateApplication?: (
+		choice: EditorTemplateChoice,
+		context: PrepareTemplateApplicationContext,
+	) => Promise<PreparedTemplateApplication>;
+	cleanupTemplateApplication?: (cleanupToken: string) => void | Promise<void>;
 	/** Review threads in the open document, republished on every edit, so an
 	 * app can list them in its own chrome. */
 	onReviewThreadsChange?: (threads: ReviewThread[]) => void;
@@ -111,6 +134,10 @@ export function EditorView({
 	onOpenExternalLink,
 	onOpenWikiLink,
 	onMessage,
+	templateChoices = [],
+	loadTemplateChoices,
+	prepareTemplateApplication,
+	cleanupTemplateApplication,
 	onReviewThreadsChange,
 }: EditorViewProps) {
 	const initialFrontMatter = parseMarkdownFrontMatter(initialMarkdown);
@@ -358,7 +385,30 @@ export function EditorView({
 							onMessage={onMessage}
 							onCursorModeChange={setCursorModeOverride}
 						/>
-						<SlashCommandMenu editor={editor} viewportRef={editorViewportRef} />
+						<SlashCommandMenu
+							editor={editor}
+							viewportRef={editorViewportRef}
+							templateChoices={templateChoices}
+							loadTemplateChoices={loadTemplateChoices}
+							onSelectTemplate={
+								prepareTemplateApplication
+									? (choice, token) => {
+											void applyPreparedTemplate({
+												choice,
+												cleanupTemplateApplication,
+												editorRef,
+												latestMarkdownRef,
+												onMessage,
+												partsRef,
+												pathRef,
+												prepareTemplateApplication,
+												setFrontMatterState,
+												token,
+											});
+										}
+									: undefined
+							}
+						/>
 						<SelectionFormattingToolbar
 							editor={editor}
 							viewport={editorViewportEl}
@@ -383,6 +433,107 @@ export function EditorView({
 			<FormattingStatusBar editor={editor} scrollContainer={editorViewportEl} />
 		</div>
 	);
+}
+
+type EditorParts = {
+	body: string;
+	frontMatter: string;
+};
+
+type ApplyPreparedTemplateOptions = {
+	choice: EditorTemplateChoice;
+	cleanupTemplateApplication: EditorViewProps["cleanupTemplateApplication"];
+	editorRef: { current: Editor | null };
+	latestMarkdownRef: { current: string };
+	onMessage: EditorViewProps["onMessage"];
+	partsRef: { current: EditorParts };
+	pathRef: { current: string };
+	prepareTemplateApplication: NonNullable<
+		EditorViewProps["prepareTemplateApplication"]
+	>;
+	setFrontMatterState: (
+		state: ReturnType<typeof frontMatterStateFromMarkdown>,
+	) => void;
+	token: SlashToken;
+};
+
+async function applyPreparedTemplate({
+	choice,
+	cleanupTemplateApplication,
+	editorRef,
+	latestMarkdownRef,
+	onMessage,
+	partsRef,
+	pathRef,
+	prepareTemplateApplication,
+	setFrontMatterState,
+	token,
+}: ApplyPreparedTemplateOptions) {
+	if (!editorRef.current) return;
+	const targetPath = pathRef.current;
+	const targetMarkdown = latestMarkdownRef.current;
+	try {
+		const preparedTemplate = await prepareTemplateApplication(choice, {
+			targetPath,
+			targetMarkdown,
+		});
+		const cleanupPreparedTemplate = async () => {
+			if (!preparedTemplate.cleanupToken || !cleanupTemplateApplication) return;
+			await cleanupTemplateApplication(preparedTemplate.cleanupToken);
+		};
+		const currentEditor = editorRef.current;
+		if (
+			!currentEditor ||
+			pathRef.current !== targetPath ||
+			latestMarkdownRef.current !== targetMarkdown
+		) {
+			await cleanupPreparedTemplate();
+			return;
+		}
+		const previousParts = partsRef.current;
+		const currentBody = previousParts.body;
+		const restoreParts = () => {
+			partsRef.current = previousParts;
+			setFrontMatterState(
+				frontMatterStateFromMarkdown(latestMarkdownRef.current),
+			);
+		};
+		try {
+			partsRef.current = {
+				body: currentBody,
+				frontMatter: preparedTemplate.frontMatter,
+			};
+			setFrontMatterState(
+				frontMatterStateFromMarkdown(
+					combineMarkdownFrontMatter(preparedTemplate.frontMatter, currentBody),
+				),
+			);
+			const applied = applyTemplateSlashCommand(
+				currentEditor,
+				token,
+				preparedTemplate.body,
+			);
+			if (applied) return;
+			restoreParts();
+			await cleanupPreparedTemplate();
+		} catch (error) {
+			restoreParts();
+			await cleanupPreparedTemplate();
+			throw error;
+		}
+	} catch (error) {
+		if (
+			error &&
+			typeof error === "object" &&
+			"reported" in error &&
+			error.reported === true
+		)
+			return;
+		onMessage?.(
+			error instanceof Error ? error.message : "Template unavailable",
+			"error",
+		);
+	}
 }
 
 function hasUploadImage(node: JSONContent): boolean {

--- a/packages/ui/src/editor/SlashCommandMenu.tsx
+++ b/packages/ui/src/editor/SlashCommandMenu.tsx
@@ -4,7 +4,9 @@ import { Command } from "cmdk";
 import {
 	type ComponentType,
 	type RefObject,
+	useCallback,
 	useEffect,
+	useMemo,
 	useRef,
 	useState,
 } from "react";
@@ -29,8 +31,20 @@ import {
 	type SlashToken,
 } from "./slashCommandActions";
 
+export type SlashTemplateChoice = {
+	id: string;
+	title: string;
+	description?: string;
+	library?: string;
+	path?: string;
+	isDefault?: boolean;
+	keywords?: string[];
+};
+
+type SlashMenuKind = SlashCommandKind | "template";
+
 type SlashCommand = {
-	kind: SlashCommandKind;
+	kind: SlashMenuKind;
 	title: string;
 	description: string;
 	aliases: string[];
@@ -128,28 +142,68 @@ const SLASH_COMMANDS: SlashCommand[] = [
 	},
 ];
 
+const TEMPLATE_COMMAND: SlashCommand = {
+	kind: "template",
+	title: "Template",
+	description: "Insert a Markdown template",
+	aliases: ["template", "templates"],
+	icon: MingcuteTextLine,
+};
+
 // Table cells only hold inline content, so block commands are hidden there.
 const INLINE_COMMANDS = new Set<SlashCommandKind>(["strike"]);
 
 export function SlashCommandMenu({
 	editor,
 	viewportRef,
+	templateChoices = [],
+	loadTemplateChoices,
+	onSelectTemplate,
 }: {
 	editor: Editor | null;
 	viewportRef: RefObject<HTMLDivElement | null>;
+	templateChoices?: SlashTemplateChoice[];
+	loadTemplateChoices?: () => Promise<SlashTemplateChoice[]>;
+	onSelectTemplate?: (choice: SlashTemplateChoice, token: SlashToken) => void;
 }) {
 	const [token, setToken] = useState<SlashToken | null>(null);
 	const [position, setPosition] = useState<MenuPosition | null>(null);
-	const [selectedKind, setSelectedKind] =
-		useState<SlashCommandKind>("paragraph");
+	const [selectedKind, setSelectedKind] = useState<SlashMenuKind>("paragraph");
+	const [mode, setMode] = useState<"commands" | "templates">("commands");
+	const [templateSearch, setTemplateSearch] = useState("");
+	const [selectedTemplateId, setSelectedTemplateId] = useState<string>("");
+	const [loadedTemplateChoices, setLoadedTemplateChoices] = useState<
+		SlashTemplateChoice[] | null
+	>(null);
 	const suppressedFromRef = useRef<number | null>(null);
 	const positionedFromRef = useRef<number | null>(null);
 	const menuRef = useRef<HTMLDivElement | null>(null);
+	const templateInputRef = useRef<HTMLInputElement | null>(null);
 	const insideTable = editor?.isActive("table") ?? false;
-	const visibleCommands = SLASH_COMMANDS.filter(
-		(command) =>
-			matchesCommand(command, token?.query ?? "") &&
-			(!insideTable || INLINE_COMMANDS.has(command.kind)),
+	const templatesEnabled = templateChoices.length > 0 && !!onSelectTemplate;
+	const commands = useMemo(
+		() =>
+			templatesEnabled ? [...SLASH_COMMANDS, TEMPLATE_COMMAND] : SLASH_COMMANDS,
+		[templatesEnabled],
+	);
+	const visibleCommands = useMemo(
+		() =>
+			commands.filter(
+				(command) =>
+					matchesCommand(command, token?.query ?? "") &&
+					(!insideTable ||
+						command.kind === "template" ||
+						isInlineCommand(command)),
+			),
+		[commands, insideTable, token?.query],
+	);
+	const availableTemplateChoices = loadedTemplateChoices ?? templateChoices;
+	const visibleTemplates = useMemo(
+		() =>
+			availableTemplateChoices.filter(
+				(choice) => templateChoiceScore(choice, templateSearch) > 0,
+			),
+		[availableTemplateChoices, templateSearch],
 	);
 	// Keep selection visible even when the current query filters out the
 	// previously selected command.
@@ -158,6 +212,59 @@ export function SlashCommandMenu({
 	)
 		? selectedKind
 		: visibleCommands[0]?.kind;
+	const activeTemplateId = visibleTemplates.some(
+		(choice) => choice.id === selectedTemplateId,
+	)
+		? selectedTemplateId
+		: visibleTemplates[0]?.id;
+
+	const closeMenu = useCallback(() => {
+		setMode("commands");
+		setTemplateSearch("");
+		setSelectedTemplateId("");
+		setLoadedTemplateChoices(null);
+		setToken(null);
+		setPosition(null);
+	}, []);
+
+	const openTemplatePicker = useCallback(async () => {
+		setMode("templates");
+		setTemplateSearch("");
+		setSelectedTemplateId(templateChoices[0]?.id ?? "");
+		queueMicrotask(() => templateInputRef.current?.focus());
+		if (!loadTemplateChoices) return;
+		await loadTemplateChoices().then(
+			(choices) => {
+				setLoadedTemplateChoices(choices);
+				setSelectedTemplateId(choices[0]?.id ?? "");
+			},
+			() => undefined,
+		);
+	}, [loadTemplateChoices, templateChoices]);
+
+	const selectCommand = useCallback(
+		(command: SlashCommand) => {
+			if (!editor || !token) return;
+			if (command.kind === "template") {
+				void openTemplatePicker();
+				return;
+			}
+			applySlashCommand(editor, token, command.kind);
+			suppressedFromRef.current = null;
+			closeMenu();
+		},
+		[closeMenu, editor, openTemplatePicker, token],
+	);
+
+	const selectTemplate = useCallback(
+		(choice: SlashTemplateChoice) => {
+			if (!onSelectTemplate || !token) return;
+			onSelectTemplate(choice, token);
+			suppressedFromRef.current = null;
+			closeMenu();
+		},
+		[closeMenu, onSelectTemplate, token],
+	);
 
 	useEffect(() => {
 		if (!editor) return;
@@ -166,18 +273,17 @@ export function SlashCommandMenu({
 		// The query lives in ProseMirror text, not in the cmdk input. Recompute
 		// the token and anchor whenever the editor may have moved.
 		const update = () => {
+			if (mode === "templates") return;
 			const nextToken = findSlashToken(editor);
 			if (!nextToken) {
 				suppressedFromRef.current = null;
 				positionedFromRef.current = null;
-				setToken(null);
-				setPosition(null);
+				closeMenu();
 				return;
 			}
 			if (suppressedFromRef.current === nextToken.from) {
 				positionedFromRef.current = null;
-				setToken(null);
-				setPosition(null);
+				closeMenu();
 				return;
 			}
 			if (positionedFromRef.current !== nextToken.from) {
@@ -203,7 +309,7 @@ export function SlashCommandMenu({
 			viewport?.removeEventListener("scroll", update);
 			window.removeEventListener("resize", update);
 		};
-	}, [editor, viewportRef]);
+	}, [closeMenu, editor, mode, viewportRef]);
 
 	useCommandMenuPosition({
 		editor,
@@ -220,17 +326,22 @@ export function SlashCommandMenu({
 	}, [activeKind]);
 
 	useEffect(() => {
+		menuRef.current
+			?.querySelector(`[cmdk-item][data-value="${activeTemplateId}"]`)
+			?.scrollIntoView({ block: "nearest" });
+	}, [activeTemplateId]);
+
+	useEffect(() => {
 		if (!editor) return;
 
 		// Keep focus in the editor so typing continues to update the document;
 		// the menu only handles navigation and command selection keys.
 		const handleKeyDown = (event: KeyboardEvent) => {
-			if (!token) return;
+			if (!token || mode === "templates") return;
 			if (event.key === "Escape") {
 				event.preventDefault();
 				suppressedFromRef.current = token.from;
-				setToken(null);
-				setPosition(null);
+				closeMenu();
 				return;
 			}
 			if (event.key === "ArrowDown" || event.key === "ArrowUp") {
@@ -252,19 +363,29 @@ export function SlashCommandMenu({
 				);
 				if (!selectedCommand) return;
 				event.preventDefault();
-				applySlashCommand(editor, token, selectedCommand.kind);
-				suppressedFromRef.current = null;
-				setToken(null);
-				setPosition(null);
+				selectCommand(selectedCommand);
 			}
 		};
 
 		editor.view.dom.addEventListener("keydown", handleKeyDown, true);
 		return () =>
 			editor.view.dom.removeEventListener("keydown", handleKeyDown, true);
-	}, [activeKind, editor, token, visibleCommands]);
+	}, [
+		activeKind,
+		closeMenu,
+		editor,
+		mode,
+		selectCommand,
+		token,
+		visibleCommands,
+	]);
 
-	if (!editor || !token || visibleCommands.length === 0) {
+	if (
+		!editor ||
+		!token ||
+		(mode === "commands" && visibleCommands.length === 0) ||
+		(mode === "templates" && availableTemplateChoices.length === 0)
+	) {
 		return null;
 	}
 
@@ -278,64 +399,138 @@ export function SlashCommandMenu({
 				visibility: position ? "visible" : "hidden",
 			}}
 		>
-			<Command
-				className="flex max-h-[var(--command-menu-height)] flex-col"
-				label="Slash commands"
-				value={activeKind}
-				onValueChange={(value) => setSelectedKind(value as SlashCommandKind)}
-				shouldFilter={false}
-				loop
-				onMouseDown={(event) => event.preventDefault()}
-			>
-				<Command.Input
-					value={token.query}
-					readOnly
-					className="sr-only"
-					aria-hidden="true"
-					tabIndex={-1}
-				/>
-				<Command.List className="min-h-0 max-h-64 overflow-y-auto p-1">
-					{visibleCommands.map((command) => {
-						const Icon = command.icon;
-						return (
+			{mode === "commands" ? (
+				<Command
+					className="flex max-h-[var(--command-menu-height)] flex-col"
+					label="Slash commands"
+					value={activeKind}
+					onValueChange={(value) => setSelectedKind(value as SlashMenuKind)}
+					shouldFilter={false}
+					loop
+					onMouseDown={(event) => event.preventDefault()}
+				>
+					<Command.Input
+						value={token.query}
+						readOnly
+						className="sr-only"
+						aria-hidden="true"
+						tabIndex={-1}
+					/>
+					<Command.List className="min-h-0 max-h-64 overflow-y-auto p-1">
+						{visibleCommands.map((command) => {
+							const Icon = command.icon;
+							return (
+								<Command.Item
+									key={command.kind}
+									value={command.kind}
+									keywords={[
+										command.title,
+										command.description,
+										...command.aliases,
+									]}
+									onSelect={() => selectCommand(command)}
+									className={cn(
+										"flex min-w-0 cursor-default items-center gap-2 rounded-[var(--radius-inner)] px-2 py-1.5 text-start text-[11px] leading-[15px] outline-hidden",
+										"data-[selected=true]:bg-accent data-[selected=true]:text-foreground",
+									)}
+								>
+									<span className="flex size-4 shrink-0 items-center justify-center text-muted-foreground">
+										<Icon className="size-3.5" />
+									</span>
+									<span className="block min-w-0 flex-1 truncate text-foreground">
+										{command.title}
+									</span>
+									{command.shortcut && (
+										<span
+											className="shrink-0 text-[10px] leading-none text-muted-foreground/60"
+											aria-hidden="true"
+										>
+											{formatCommandShortcut(command.shortcut)}
+										</span>
+									)}
+								</Command.Item>
+							);
+						})}
+					</Command.List>
+				</Command>
+			) : (
+				<Command
+					className="flex max-h-[var(--command-menu-height)] flex-col"
+					label="Templates"
+					value={activeTemplateId}
+					onValueChange={setSelectedTemplateId}
+					shouldFilter={false}
+					loop
+					onKeyDown={(event) => {
+						if (event.key === "Escape") {
+							event.preventDefault();
+							setMode("commands");
+							queueMicrotask(() => editor.view.focus());
+						}
+					}}
+				>
+					<Command.Input
+						ref={templateInputRef}
+						value={templateSearch}
+						onValueChange={setTemplateSearch}
+						placeholder="Search templates..."
+						className="h-8 border-border border-b bg-transparent px-2 text-[12px] outline-none placeholder:text-muted-foreground"
+					/>
+					<Command.List className="min-h-0 max-h-64 overflow-y-auto p-1">
+						{visibleTemplates.map((choice) => (
 							<Command.Item
-								key={command.kind}
-								value={command.kind}
+								key={choice.id}
+								value={choice.id}
 								keywords={[
-									command.title,
-									command.description,
-									...command.aliases,
+									choice.title,
+									choice.description ?? "",
+									choice.library ?? "",
+									choice.path ?? "",
+									...(choice.keywords ?? []),
 								]}
-								onSelect={() => {
-									applySlashCommand(editor, token, command.kind);
-									setToken(null);
-									setPosition(null);
-								}}
+								onSelect={() => selectTemplate(choice)}
 								className={cn(
 									"flex min-w-0 cursor-default items-center gap-2 rounded-[var(--radius-inner)] px-2 py-1.5 text-start text-[11px] leading-[15px] outline-hidden",
 									"data-[selected=true]:bg-accent data-[selected=true]:text-foreground",
 								)}
 							>
-								<span className="flex size-4 shrink-0 items-center justify-center text-muted-foreground">
-									<Icon className="size-3.5" />
-								</span>
-								<span className="block min-w-0 flex-1 truncate text-foreground">
-									{command.title}
-								</span>
-								{command.shortcut && (
-									<span
-										className="shrink-0 text-[10px] leading-none text-muted-foreground/60"
-										aria-hidden="true"
-									>
-										{formatCommandShortcut(command.shortcut)}
+								<span className="block min-w-0 flex-1">
+									<span className="flex min-w-0 items-center gap-1.5">
+										<span className="truncate text-foreground">
+											{choice.title}
+										</span>
+										{choice.isDefault && (
+											<span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[9px] uppercase leading-none text-muted-foreground">
+												Default
+											</span>
+										)}
 									</span>
-								)}
+									{(choice.description || choice.library) && (
+										<span className="block truncate text-muted-foreground">
+											{[choice.description, choice.library]
+												.filter(Boolean)
+												.join(" · ")}
+										</span>
+									)}
+								</span>
 							</Command.Item>
-						);
-					})}
-				</Command.List>
-			</Command>
+						))}
+						{visibleTemplates.length === 0 && (
+							<Command.Empty className="px-2 py-3 text-[11px] text-muted-foreground">
+								No templates found
+							</Command.Empty>
+						)}
+					</Command.List>
+				</Command>
+			)}
 		</div>
+	);
+}
+
+function isInlineCommand(command: SlashCommand) {
+	return (
+		command.kind !== "template" &&
+		INLINE_COMMANDS.has(command.kind as SlashCommandKind)
 	);
 }
 
@@ -364,6 +559,16 @@ function commandScore(value: string, search: string, keywords: string[]) {
 		}
 	}
 	return best;
+}
+
+function templateChoiceScore(choice: SlashTemplateChoice, search: string) {
+	return commandScore(choice.id, search, [
+		choice.title,
+		choice.description ?? "",
+		choice.library ?? "",
+		choice.path ?? "",
+		...(choice.keywords ?? []),
+	]);
 }
 
 function normalize(value: string) {

--- a/packages/ui/src/editor/slashCommandActions.test.ts
+++ b/packages/ui/src/editor/slashCommandActions.test.ts
@@ -7,6 +7,7 @@ import StarterKit from "@tiptap/starter-kit";
 import { afterEach, describe, expect, it } from "vitest";
 import {
 	applySlashCommand,
+	applyTemplateSlashCommand,
 	findSlashToken,
 	type SlashToken,
 } from "./slashCommandActions";
@@ -138,6 +139,78 @@ describe("slash command document actions", () => {
 						},
 					],
 				},
+			],
+		});
+	});
+
+	it("replaces a slash-only paragraph with multiple template blocks", () => {
+		const editor = createEditor(docWithParagraph("/template"));
+		const token = expectSlashToken(editor);
+
+		applyTemplateSlashCommand(editor, token, "# Agenda\n\n- one\n- two");
+
+		expect(editor.getJSON()).toMatchObject({
+			type: "doc",
+			content: [
+				{
+					type: "heading",
+					attrs: { level: 1 },
+					content: [{ type: "text", text: "Agenda" }],
+				},
+				{
+					type: "bulletList",
+					content: [
+						{
+							attrs: { checked: null },
+							type: "listItem",
+							content: [
+								{ type: "paragraph", content: [{ type: "text", text: "one" }] },
+							],
+						},
+						{
+							attrs: { checked: null },
+							type: "listItem",
+							content: [
+								{ type: "paragraph", content: [{ type: "text", text: "two" }] },
+							],
+						},
+					],
+				},
+				{ type: "paragraph" },
+			],
+		});
+	});
+
+	it("inserts template blocks after a non-empty slash paragraph", () => {
+		const editor = createEditor(docWithParagraph("Intro /template"));
+		const token = expectSlashToken(editor);
+
+		applyTemplateSlashCommand(editor, token, "## Details\n\nBody");
+
+		expect(editor.getJSON()).toMatchObject({
+			type: "doc",
+			content: [
+				{ type: "paragraph", content: [{ type: "text", text: "Intro " }] },
+				{
+					type: "heading",
+					attrs: { level: 2 },
+					content: [{ type: "text", text: "Details" }],
+				},
+				{ type: "paragraph", content: [{ type: "text", text: "Body" }] },
+			],
+		});
+	});
+
+	it("removes the slash token for property-only templates", () => {
+		const editor = createEditor(docWithParagraph("Intro /template"));
+		const token = expectSlashToken(editor);
+
+		applyTemplateSlashCommand(editor, token, "");
+
+		expect(editor.getJSON()).toMatchObject({
+			type: "doc",
+			content: [
+				{ type: "paragraph", content: [{ type: "text", text: "Intro " }] },
 			],
 		});
 	});

--- a/packages/ui/src/editor/slashCommandActions.ts
+++ b/packages/ui/src/editor/slashCommandActions.ts
@@ -1,6 +1,7 @@
+import { markdownToTiptapDoc } from "@hubble.md/editor";
 import type { Editor } from "@tiptap/core";
 import { Fragment, type Node as PMNode } from "@tiptap/pm/model";
-import { TextSelection } from "@tiptap/pm/state";
+import { Selection, TextSelection } from "@tiptap/pm/state";
 
 export type SlashCommandKind =
 	| "paragraph"
@@ -128,6 +129,72 @@ export function applySlashCommand(
 	);
 	view.dispatch(tr.scrollIntoView());
 	view.focus();
+}
+
+export function applyTemplateSlashCommand(
+	editor: Editor,
+	token: SlashToken,
+	templateBody: string,
+): boolean {
+	const { state, view } = editor;
+	const { schema } = state;
+	const $from = state.doc.resolve(token.from);
+	if ($from.depth === 0) return false;
+	const topLevelDepth = Math.min(1, $from.depth);
+	const blockStart = $from.before(topLevelDepth);
+	const blockEnd = $from.after(topLevelDepth);
+	const block = state.doc.nodeAt(blockStart);
+	const nodes =
+		templateBody.trim().length === 0
+			? []
+			: trimTrailingEmptyParagraphs(
+					(markdownToTiptapDoc(templateBody).content ?? []).map((node) =>
+						schema.nodeFromJSON(node),
+					),
+				);
+	const content =
+		nodes.length > 0
+			? Fragment.fromArray(nodes)
+			: Fragment.from(schema.nodes.paragraph.create());
+	const canReplaceParagraph =
+		block?.type.name === "paragraph" &&
+		block.content.size === token.to - token.from;
+	const tr = state.tr.delete(token.from, token.to);
+
+	if (canReplaceParagraph) {
+		const mappedBlockStart = tr.mapping.map(blockStart);
+		const mappedBlockEnd = tr.mapping.map(blockEnd);
+		tr.replaceWith(mappedBlockStart, mappedBlockEnd, content);
+		tr.setSelection(Selection.near(tr.doc.resolve(mappedBlockStart), 1));
+		view.dispatch(tr.scrollIntoView());
+		view.focus();
+		return true;
+	}
+
+	if (nodes.length === 0) {
+		view.dispatch(tr.scrollIntoView());
+		view.focus();
+		return true;
+	}
+
+	const insertAt = tr.mapping.map(blockEnd);
+	tr.insert(insertAt, content);
+	tr.setSelection(Selection.near(tr.doc.resolve(insertAt + content.size), -1));
+	view.dispatch(tr.scrollIntoView());
+	view.focus();
+	return true;
+}
+
+function trimTrailingEmptyParagraphs(nodes: PMNode[]) {
+	const trimmed = [...nodes];
+	while (isEmptyParagraph(trimmed[trimmed.length - 1])) {
+		trimmed.pop();
+	}
+	return trimmed;
+}
+
+function isEmptyParagraph(node: PMNode | undefined) {
+	return node?.type.name === "paragraph" && node.childCount === 0;
 }
 
 function createInsertedBlock(

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -29,8 +29,11 @@ export {
 	setActiveEditor,
 } from "./editor/activeEditor";
 export {
+	type EditorTemplateChoice,
 	EditorView,
 	type EditorViewProps,
+	type PreparedTemplateApplication,
+	type PrepareTemplateApplicationContext,
 	type WikiTarget,
 } from "./editor/EditorView";
 export { FormattingStatusBar } from "./editor/FormattingStatusBar";

--- a/specs/gh-221/PRODUCT.md
+++ b/specs/gh-221/PRODUCT.md
@@ -1,0 +1,82 @@
+# Folder-aware Markdown templates
+
+## Summary
+
+Hubble lets users keep reusable Markdown templates in visible `templates` Folders, discover the templates available to the current note, insert them additively, and choose a default for new Markdown Files. Templates, File Properties, and Assets remain portable filesystem content.
+
+`templates` folders can exist anywhere in the folder tree. Templates available to a given note are based on the cascade of `templates` folders up the chain:
+
+```sh
+templates/
+    main.md
+    journal.md
+notes/
+    meetings/
+        templates/
+            main.md
+        2026-05-08.md
+    entry-2.md
+```
+
+Here, `2026-05-08.md` has these templates available:
+
+- `templates/main.md`
+- `templates/journal.md`
+- `meetings/templates/main.md`
+
+And `entry-2.md` has these templates:
+
+- `templates/main.md`
+- `templates/journal.md`
+
+## Flows
+
+### Find and apply a template
+
+1. The user creates or opens a Markdown File in a Workspace Folder or Plain Folder.
+2. They type `/template` and see templates collected from `templates` Folders between the note's Folder and the open-folder root.
+3. They search or select a template; Hubble adds its missing File Properties and inserts its body at the Slash Command location.
+
+- Every visible Folder named `templates`, case-insensitively, is a Template Library with no opt-in marker; every Markdown File recursively inside it is a template. Existing ignore rules still apply.
+- Templates from the nearest Template Library appear first. Same-named templates remain separate choices, with their internal path and owning Folder shown as secondary text.
+- The picker shows filenames without `.md`; default templates show a **Default** badge. Template Libraries and files remain visible and editable in the sidebar.
+- Command-P name and content search keeps templates available but ranks an equally relevant ordinary note above a template.
+- If `/template` is the only content in its paragraph, the body replaces that paragraph. Otherwise, the body is inserted after the current top-level block.
+- File Property names match case-sensitively. Existing properties keep their value and type; missing properties append in template order. Arrays, tags, and nested values are not merged; `default-template` is never added.
+- Applying a template copies its associated Assets into the target note's Asset Folder and adjusts Markdown, HTML, Asset, and Wikilink references as needed to preserve their resolved targets.
+- Application is atomic. Invalid template or target front matter changes nothing and shows an error toast; invalid template front matter offers **Edit template**. An unreadable template shows an error without that action.
+- While editing a template, `/template` remains available for composition but omits the current file. Loose Files have no Folder context, so `/template` is unavailable.
+
+### Create a Markdown File from a default
+
+1. The user sets `default-template: true` on a template through File Properties.
+2. They create a Markdown File through any Desktop new-file entry point.
+3. Hubble applies the effective default before opening the independent new file.
+
+- Setting a default through Hubble unchecks other defaults in the same Template Library.
+- The nearest Template Library containing a valid default wins. If it contains multiple defaults after external edits, the alphabetically first library-relative path wins silently.
+- Default resolution starts from the actual creation destination; a Folder focused when the keyboard shortcut runs therefore contributes its local and inherited defaults.
+- With no valid default, creation remains blank.
+- Template content never influences the filename. Existing unique `new-file.md`, inline rename, save, and open behavior remain unchanged.
+- A failure to read or apply the chosen default creates no partial Markdown File or Assets and shows an actionable error toast.
+- Creating a Markdown File anywhere inside a Template Library instead creates blank `new-template.md` with `default-template: false`; inherited defaults do not apply.
+
+### Save a note as a template
+
+1. From a Markdown File's overflow menu, the user selects **Save as template**.
+2. Hubble creates `templates` beside the note when needed, copies the note and its complete associated Asset Folder, and opens the copy.
+3. The copy keeps the source filename and content, uses a collision-safe filename when needed, and has `default-template: false`.
+
+- Relative references keep resolving to the same targets; the source remains unchanged and **Save as template** is hidden when already editing a template.
+- The copy is atomic; invalid source front matter or filesystem failure leaves no partial template or Asset Folder and shows an error toast.
+- Template Markdown Files and Assets participate in Cloud Sync like ordinary workspace files.
+- Desktop supports template actions in this slice. Synced templates remain visible and editable on web, but web template actions are deferred.
+
+## Out of scope
+
+- HTML App templates or defaults.
+- Dynamic variables, prompts, scripts, or generated values.
+- Property replacement, deep merging, or retroactive template updates.
+- Web `/template`, default creation, or Save as template actions.
+- Template behavior for Loose Files.
+

--- a/specs/gh-221/TECH.md
+++ b/specs/gh-221/TECH.md
@@ -1,0 +1,67 @@
+# Folder-aware Markdown templates technical plan
+
+Product behavior: [`PRODUCT.md`](./PRODUCT.md). Issue: [#221](https://github.com/bholmesdev/hubble.md/issues/221).
+
+## Approach
+
+### Shared parsing and editor behavior
+
+- Add template helpers beside `parseMarkdownFrontMatter()` in `packages/editor/src/frontMatter.ts`: recognize the boolean `default-template` directive, remove it from applied properties, and merge valid template properties into a valid target with case-sensitive, target-first, shallow semantics.
+- Keep `isSimplePropertyKey()` unchanged; `default-template` already round-trips through the supported File Properties controls. Reuse `serializeFrontMatter()` so unsupported valid values remain preserved under ADR-0003.
+- Extend `packages/ui/src/editor/SlashCommandMenu.tsx` with a Template command that opens a focused `cmdk` picker supplied by the host. Keep filesystem discovery outside `packages/ui` so web can provide the same interface later.
+- Add a multi-block template insertion helper to `packages/ui/src/editor/slashCommandActions.ts`. Parse the prepared body with `markdownToTiptapDoc()`, replace a slash-only paragraph or insert after the current top-level block, and dispatch one ProseMirror transaction.
+- Extend `EditorView` with template choices plus an async prepare callback. Before dispatching the body transaction, update `partsRef` and `frontMatterState` with merged properties so the existing `onUpdate` path emits one combined Markdown document through `onLocalChange` and `onSave`.
+- Keep template application unavailable in source mode and Loose Files. The current template path is removed from its own picker; other templates remain available while editing a template.
+
+### Desktop discovery and actions
+
+- Add pure path/discovery helpers in `apps/desktop/src/lib/templates.ts`: classify case-insensitive `templates` path segments, find the owning Template Library, walk owner Folders to the open-folder root, and produce nearest-first choices with library-relative labels.
+- Derive candidate paths from `workspaceStore.files`, the same ephemeral snapshot used by Command-P under ADR-0008. Read candidate contents on picker open and default resolution rather than adding a second recursive crawl or content cache.
+- Parse candidates independently: invalid files remain picker choices but never defaults. Resolve defaults by the nearest library with valid `default-template: true` candidates, then case-insensitive library-relative path with a case-sensitive tie-break.
+- Add `prepareTemplateApplication(templatePath, targetPath)` in `apps/desktop/src/store/templateActions.ts`: snapshot and validate the target/template, invoke the Asset-copy IPC, revalidate the editor identity/content before insertion, and return rebased Markdown to `EditorView`. Cancel and clean up if the user navigated or edited while preparation ran. Use Sonner's existing toast action shape to offer **Edit template** only for invalid readable templates.
+- In `updateEditorContent()`, detect a valid `default-template` false→true transition before replacing `viewerStore.content`, then queue updates setting every other template in that library to `false`. Ordinary saves and direct filesystem conflicts do not normalize siblings.
+- Refactor `createMarkdownFileInFolder()` in `apps/desktop/src/store/actions.ts` to resolve from its existing `parentPath`. A destination inside a Template Library writes `new-template.md` with `default-template: false`; otherwise it atomically materializes the effective default or retains blank creation.
+- Do not call `titleManager.start()` for a default-populated note, preventing static template headings from driving generated filenames. Keep existing collision-safe path selection, store publication, `loadPath()`, refresh, and blank-note title behavior.
+- Add `saveCurrentAsTemplate()` using valid live `viewerStore.content`, a collision-safe destination under the current note's sibling `templates` Folder, and the same bundle-copy IPC. Reject invalid source front matter, wire the action into `ActionsMenu` in `apps/desktop/src/components/Toolbar.tsx`, and omit it when the current path is already a template.
+- Add `isTemplate` to `PaletteFile` in `packages/ui/src/components/GlobalSearchPalette.tsx`. Preserve fuzzy score as the primary key, then rank ordinary notes before templates, then modification time; sort content matches with the same ordinary-before-template tie-break.
+
+### Filesystem, references, and sync
+
+- Add a narrow `materialize-template` IPC to `DesktopApi`, `preload.ts`, and Electron main instead of exposing generic recursive copy. It accepts source/target Markdown paths, prepared content, and create-versus-existing mode.
+- In Electron main, stage the complete source `<stem>.assets/` bundle beside the destination, deduplicate byte-identical hashed files, choose collision-safe names for different bytes, and publish only after every read/copy succeeds. Remove staged/new files on failure.
+- Generalize `apps/desktop/src/lib/markdownLinkRewrite.ts` with copy rebasing: relative Markdown links, images, and HTML `src`/`href` preserve resolved targets; managed Asset references follow copied names; workspace-relative Wikilinks remain unchanged unless their target path is remapped.
+- For new notes and Save as template, the IPC writes Markdown and Assets as one rollback-capable bundle. For insertion into an existing note, it publishes Assets before returning rebased Markdown; if editor dispatch fails, remove only Assets newly created by that request.
+- No `packages/sync` or Convex schema changes: `fs-node.ts` already walks every non-dot Markdown File and image Asset, so visible `templates` trees and their `.assets` descendants sync normally and participate in delayed orphan-Asset reachability.
+
+## E2E test plan
+
+### Desktop
+
+- Run `HUBBLE_DESKTOP_ENABLE_CDP=1 pnpm dev:desktop`; use the generated editable playground and CDP per `test-desktop-app`.
+- Create root and nested Template Libraries containing same-named templates, File Properties, nested organizing Folders, links, and pasted images. Open a nested note, run `/template`, and confirm nearest-first ordering, Folder labels, Default badge, current-template exclusion, additive insertion placement, existing-wins properties, working links, and rendered copied images.
+- Open Command-P with equally matching ordinary/template files and confirm the ordinary note ranks first while the template remains selectable; repeat with content-only matches.
+- Mark root and nested defaults, focus the nested Folder, press the New File shortcut, and confirm the nested default, Assets, `new-file.md`, opening, and inline rename behavior. Check one sibling default and confirm the previous sibling becomes unchecked; create external duplicate defaults and confirm alphabetical selection without a warning.
+- Focus a Template Library and create a Markdown File; confirm blank `new-template.md`, `default-template: false`, and no inherited content. Use **Save as template** on a note with Assets and relative links; confirm the local library/copy opens, links and images work, the source is unchanged, and the action is absent on the copy.
+- Apply an invalid template and confirm no note/Asset change plus an error toast with **Edit template**. Make the target front matter invalid and confirm application changes nothing; cover unreadable-file messaging in integration tests where permissions are controllable.
+- Repeat discovery/default creation in a Plain Folder. Open a Loose File and confirm `/template` is unavailable. Confirm new HTML Apps remain blank.
+
+### Automated coverage and commands
+
+- `packages/editor/src/frontMatter.test.ts`: directive recognition/removal; case-sensitive existing-wins merge; arrays, nested values, empty properties, invalid input.
+- `packages/ui/src/editor/slashCommandActions.test.ts` and picker component tests: slash-only replacement, after-block insertion, property-only templates, focus/search/labels.
+- `apps/desktop/src/lib/templates.test.ts`: case-insensitive libraries, recursive membership, ancestry boundary, duplicate names, current-file exclusion, deterministic defaults, Plain Folder and Windows paths.
+- `apps/desktop/src/store/actions.test.ts`: focused destination defaults, blank fallback, `new-template`, title-manager exclusion, false→true sibling uncheck, invalid Save as template, actionable failures, and no partial store/file state.
+- Electron integration tests: bundle copy, rebasing, hashed deduplication, byte collisions, rollback, and associated Asset Folder absence. Extend `GlobalSearchPalette` tests for template tie-breaking.
+- Iteration: `pnpm check` and `pnpm check:react-compiler`. Final confidence: `pnpm build:desktop`.
+
+## Risks
+
+- Link corruption across Folder depths: centralize copy rebasing beside existing move rebasing and cover Markdown, HTML, Wikilink, query/hash, Windows, and Asset cases.
+- Partial bundle publication: stage first, track exactly which destination paths were created, and roll back only those paths.
+- Large-workspace regressions: use the existing sidebar snapshot and on-demand reads; do not add recursive watchers or full-folder scans.
+- Template-seeded filename changes: explicitly bypass title management only for populated defaults and test the first subsequent user edit.
+
+## Follow-ups
+
+- Reuse the host-provided template picker/application contract on web.
+- Add dynamic variables or prompts only through a separate template-language design.


### PR DESCRIPTION
## Description

Adds visible, cascading templates folders for Markdown notes. Users can apply templates through /template, choose folder defaults for new notes, and save an existing note as a template. File Properties merge additively, template Assets copy with rebased links and rollback safety, and Command-P keeps templates searchable while preferring ordinary notes on ties.

Closes #221

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update

## Testing

- [x] Existing tests pass
- [x] Added new tests for changes
- [x] Tested manually (describe below)

**Manual Testing Details:**

- Ran pnpm check, pnpm check:react-compiler, all editor/UI/desktop tests, and pnpm build:desktop.
- Drove the Electron playground through CDP: opened /template, confirmed focused searchable choices and Default badges, applied additive properties/body, created a default-backed note with Cmd-N, and saved that note as a template. Confirmed default-template is stripped on application and forced false on saved templates.
- Confirmed the dev app and watcher processes were stopped after testing.

## Checklist

- [x] I discussed this change in a GitHub issue before submitting this PR
- [x] I have run the linter, formatter, and tests to ensure my code is ready for review

## Known limitations

- Template actions remain Desktop-only; synced templates stay visible and editable on web as specified.