### PR TITLE
Add expand and collapse all to the sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 
 ### Added
 
+- Expand or collapse all sidebar folders at once. Thanks [@n00ki](https://github.com/n00ki)! [#271](https://github.com/bholmesdev/hubble.md/pull/271)
+
 ### Changed
 
 ### Fixed

--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -479,13 +479,12 @@ export function Sidebar({
 	const uncompactFolderId =
 		deleteOnCancel?.kind === "folder" ? deleteOnCancel.path : null;
 	const {
-		collapseAllFolders,
 		collapseFolder,
-		expandAllFolders,
 		expandFolder,
 		hasExpandedFolders,
 		hasFolders,
 		rows,
+		toggleAllFolders,
 		toggleFolder,
 	} = useSidebarTree({
 		files,
@@ -1294,7 +1293,7 @@ export function Sidebar({
 						Files
 					</span>
 				)}
-				<div className="flex items-center gap-1">
+				<div className="flex shrink-0 items-center gap-1">
 					{onCreateFile && (
 						<NewFileMenu
 							onCreateFile={() => void createFile(creationFolderId)}
@@ -1358,9 +1357,7 @@ export function Sidebar({
 							size="icon-xs"
 							aria-label={allFoldersActionLabel}
 							title={allFoldersActionLabel}
-							onClick={
-								hasExpandedFolders ? collapseAllFolders : expandAllFolders
-							}
+							onClick={toggleAllFolders}
 						>
 							{hasExpandedFolders ? (
 								<MingcuteFoldVerticalLine className="size-3.5" />

--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -34,6 +34,7 @@ import MingcuteCopy2Line from "~icons/mingcute/copy-2-line";
 import MingcuteDeleteLine from "~icons/mingcute/delete-line";
 import MingcuteEditLine from "~icons/mingcute/edit-line";
 import MingcuteExternalLinkLine from "~icons/mingcute/external-link-line";
+import MingcuteFoldVerticalLine from "~icons/mingcute/fold-vertical-line";
 import MingcuteFolderOpenLine from "~icons/mingcute/folder-open-line";
 import MingcuteMore2Line from "~icons/mingcute/more-2-line";
 import MingcuteNewFolderLine from "~icons/mingcute/new-folder-line";
@@ -41,6 +42,7 @@ import MingcutePinFill from "~icons/mingcute/pin-fill";
 import MingcutePinLine from "~icons/mingcute/pin-line";
 import MingcuteRightLine from "~icons/mingcute/right-line";
 import MingcuteSortDescendingLine from "~icons/mingcute/sort-descending-line";
+import MingcuteUnfoldVerticalLine from "~icons/mingcute/unfold-vertical-line";
 import { useResizeSeparator } from "../hooks/useResizeSeparator";
 import { isEditableEventTarget } from "../lib/dom";
 import {
@@ -476,7 +478,16 @@ export function Sidebar({
 	const highlightPath = pendingPath ?? currentPath;
 	const uncompactFolderId =
 		deleteOnCancel?.kind === "folder" ? deleteOnCancel.path : null;
-	const { collapseFolder, expandFolder, rows, toggleFolder } = useSidebarTree({
+	const {
+		collapseAllFolders,
+		collapseFolder,
+		expandAllFolders,
+		expandFolder,
+		hasExpandedFolders,
+		hasFolders,
+		rows,
+		toggleFolder,
+	} = useSidebarTree({
 		files,
 		folders,
 		getDisplayPath,
@@ -485,6 +496,9 @@ export function Sidebar({
 		storageScope,
 		uncompactFolderId,
 	});
+	const allFoldersActionLabel = hasExpandedFolders
+		? "Collapse all folders"
+		: "Expand all folders";
 	const [selection, setSelection] = useState<SidebarSelectionState>({
 		selectedKeys: new Set(),
 		anchorKey: null,
@@ -1338,6 +1352,23 @@ export function Sidebar({
 							</Select.Positioner>
 						</Select.Portal>
 					</Select.Root>
+					{hasFolders ? (
+						<Button
+							variant="ghost"
+							size="icon-xs"
+							aria-label={allFoldersActionLabel}
+							title={allFoldersActionLabel}
+							onClick={
+								hasExpandedFolders ? collapseAllFolders : expandAllFolders
+							}
+						>
+							{hasExpandedFolders ? (
+								<MingcuteFoldVerticalLine className="size-3.5" />
+							) : (
+								<MingcuteUnfoldVerticalLine className="size-3.5" />
+							)}
+						</Button>
+					) : null}
 				</div>
 			</div>
 			{tree}

--- a/packages/ui/src/components/useSidebarTree.test.ts
+++ b/packages/ui/src/components/useSidebarTree.test.ts
@@ -211,6 +211,43 @@ describe("flattenRows", () => {
 });
 
 describe("useSidebarTree", () => {
+	it("expands and collapses every folder", () => {
+		const harness = renderTree({
+			files: [
+				{ path: "/workspace/alpha/root.md", modifiedAt: 1 },
+				{ path: "/workspace/alpha/beta/one.md", modifiedAt: 2 },
+				{ path: "/workspace/gamma/delta/two.md", modifiedAt: 3 },
+			],
+		});
+
+		expect(harness.current.hasFolders).toBe(true);
+		expect(harness.current.hasExpandedFolders).toBe(false);
+		expect(filePaths(harness.current.rows)).toEqual([]);
+
+		act(() => harness.current.expandAllFolders());
+
+		expect(harness.current.hasExpandedFolders).toBe(true);
+		expect(filePaths(harness.current.rows)).toEqual([
+			"/workspace/alpha/beta/one.md",
+			"/workspace/alpha/root.md",
+			"/workspace/gamma/delta/two.md",
+		]);
+
+		act(() => harness.current.collapseAllFolders());
+
+		expect(harness.current.hasExpandedFolders).toBe(false);
+		expect(filePaths(harness.current.rows)).toEqual([]);
+	});
+
+	it("reports when there are no folders to toggle", () => {
+		const harness = renderTree({
+			files: [{ path: "/workspace/one.md", modifiedAt: 1 }],
+		});
+
+		expect(harness.current.hasFolders).toBe(false);
+		expect(harness.current.hasExpandedFolders).toBe(false);
+	});
+
 	it("keeps selected-file ancestors collapsed across unrelated rerenders", () => {
 		const harness = renderTree({
 			files: nestedFiles,

--- a/packages/ui/src/components/useSidebarTree.test.ts
+++ b/packages/ui/src/components/useSidebarTree.test.ts
@@ -224,7 +224,7 @@ describe("useSidebarTree", () => {
 		expect(harness.current.hasExpandedFolders).toBe(false);
 		expect(filePaths(harness.current.rows)).toEqual([]);
 
-		act(() => harness.current.expandAllFolders());
+		act(() => harness.current.toggleAllFolders());
 
 		expect(harness.current.hasExpandedFolders).toBe(true);
 		expect(filePaths(harness.current.rows)).toEqual([
@@ -233,7 +233,7 @@ describe("useSidebarTree", () => {
 			"/workspace/gamma/delta/two.md",
 		]);
 
-		act(() => harness.current.collapseAllFolders());
+		act(() => harness.current.toggleAllFolders());
 
 		expect(harness.current.hasExpandedFolders).toBe(false);
 		expect(filePaths(harness.current.rows)).toEqual([]);
@@ -246,6 +246,26 @@ describe("useSidebarTree", () => {
 
 		expect(harness.current.hasFolders).toBe(false);
 		expect(harness.current.hasExpandedFolders).toBe(false);
+	});
+
+	it("keeps a compacted folder chain expanded when its shape changes", () => {
+		const nestedFile = {
+			path: "/workspace/alpha/beta/one.md",
+			modifiedAt: 1,
+		};
+		const harness = renderTree({ files: [nestedFile] });
+
+		act(() => harness.current.toggleAllFolders());
+		harness.rerender({
+			files: [nestedFile, { path: "/workspace/alpha/root.md", modifiedAt: 2 }],
+		});
+
+		expect(folderRow(harness.current.rows, "alpha/").expanded).toBe(true);
+		expect(folderRow(harness.current.rows, "alpha/beta/").expanded).toBe(true);
+		expect(filePaths(harness.current.rows)).toEqual([
+			"/workspace/alpha/beta/one.md",
+			"/workspace/alpha/root.md",
+		]);
 	});
 
 	it("keeps selected-file ancestors collapsed across unrelated rerenders", () => {

--- a/packages/ui/src/components/useSidebarTree.ts
+++ b/packages/ui/src/components/useSidebarTree.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { startTransition, useEffect, useRef, useState } from "react";
 import { z } from "zod/v4";
 import { fileNameFromPath, normalizeDisplayPath } from "../lib/filePath";
 
@@ -106,7 +106,7 @@ export function useSidebarTree({
 		expandedFolders,
 		uncompactFolderId,
 	});
-	const folderRowIds = getFolderRowIds(tree, uncompactFolderId);
+	const folderIds = getFolderIds(tree, uncompactFolderId);
 	const hasExpandedFolders = rows.some(
 		(row) => row.kind === "folder" && row.expanded,
 	);
@@ -151,21 +151,22 @@ export function useSidebarTree({
 	const collapseFolder = (id: string) => setExpanded(id, false);
 	const toggleFolder = (id: string) =>
 		setExpanded(id, !expandedFolders.has(id));
-	const expandAllFolders = () => {
-		setExpandedState({ key: storageKey, folders: new Set(folderRowIds) });
-	};
-	const collapseAllFolders = () => {
-		setExpandedState({ key: storageKey, folders: new Set() });
+	const toggleAllFolders = () => {
+		startTransition(() => {
+			setExpandedState({
+				key: storageKey,
+				folders: hasExpandedFolders ? new Set() : new Set(folderIds),
+			});
+		});
 	};
 
 	return {
-		collapseAllFolders,
 		collapseFolder,
-		expandAllFolders,
 		expandFolder,
 		hasExpandedFolders,
-		hasFolders: folderRowIds.length > 0,
+		hasFolders: folderIds.length > 0,
 		rows,
+		toggleAllFolders,
 		toggleFolder,
 	};
 }
@@ -231,22 +232,17 @@ function ensureFolder(parent: FolderNode, name: string): FolderNode {
 	return folder;
 }
 
-function getFolderRowIds(tree: FolderNode, uncompactFolderId: string | null) {
+function getFolderIds(tree: FolderNode, uncompactFolderId: string | null) {
 	const ids: string[] = [];
-	appendFolderRowIds(tree, uncompactFolderId, ids);
+	const walk = (folder: FolderNode) => {
+		for (const child of folder.folders.values()) {
+			const compacted = compactFolder(child, uncompactFolderId);
+			for (const segment of compacted.segments) ids.push(segment.id);
+			walk(compacted.folder);
+		}
+	};
+	walk(tree);
 	return ids;
-}
-
-function appendFolderRowIds(
-	folder: FolderNode,
-	uncompactFolderId: string | null,
-	ids: string[],
-) {
-	for (const child of folder.folders.values()) {
-		const compacted = compactFolder(child, uncompactFolderId);
-		ids.push(compacted.folder.id);
-		appendFolderRowIds(compacted.folder, uncompactFolderId, ids);
-	}
 }
 
 export function flattenRows({

--- a/packages/ui/src/components/useSidebarTree.ts
+++ b/packages/ui/src/components/useSidebarTree.ts
@@ -106,6 +106,10 @@ export function useSidebarTree({
 		expandedFolders,
 		uncompactFolderId,
 	});
+	const folderRowIds = getFolderRowIds(tree, uncompactFolderId);
+	const hasExpandedFolders = rows.some(
+		(row) => row.kind === "folder" && row.expanded,
+	);
 
 	useEffect(() => {
 		if (!highlightPath || revealedPathRef.current === highlightPath) return;
@@ -147,8 +151,23 @@ export function useSidebarTree({
 	const collapseFolder = (id: string) => setExpanded(id, false);
 	const toggleFolder = (id: string) =>
 		setExpanded(id, !expandedFolders.has(id));
+	const expandAllFolders = () => {
+		setExpandedState({ key: storageKey, folders: new Set(folderRowIds) });
+	};
+	const collapseAllFolders = () => {
+		setExpandedState({ key: storageKey, folders: new Set() });
+	};
 
-	return { collapseFolder, expandFolder, rows, toggleFolder };
+	return {
+		collapseAllFolders,
+		collapseFolder,
+		expandAllFolders,
+		expandFolder,
+		hasExpandedFolders,
+		hasFolders: folderRowIds.length > 0,
+		rows,
+		toggleFolder,
+	};
 }
 
 function makeFolder(id: string, name: string): FolderNode {
@@ -210,6 +229,24 @@ function ensureFolder(parent: FolderNode, name: string): FolderNode {
 		parent.folders.set(name, folder);
 	}
 	return folder;
+}
+
+function getFolderRowIds(tree: FolderNode, uncompactFolderId: string | null) {
+	const ids: string[] = [];
+	appendFolderRowIds(tree, uncompactFolderId, ids);
+	return ids;
+}
+
+function appendFolderRowIds(
+	folder: FolderNode,
+	uncompactFolderId: string | null,
+	ids: string[],
+) {
+	for (const child of folder.folders.values()) {
+		const compacted = compactFolder(child, uncompactFolderId);
+		ids.push(compacted.folder.id);
+		appendFolderRowIds(compacted.folder, uncompactFolderId, ids);
+	}
 }
 
 export function flattenRows({


### PR DESCRIPTION
## Description

Add a state-aware sidebar header action for expanding or collapsing every Folder at once. The shared tree hook accounts for nested and compacted Folder paths, preserves the existing workspace-scoped expansion state, and hides the action when there are no Folders.

The button follows established file-explorer behavior: it offers collapse-all whenever a visible Folder is open, otherwise it offers expand-all. Its Mingcute icon, tooltip, and accessible label always describe the next action.

Closes #270

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update

## Testing

- [x] Existing tests pass
- [x] Added new tests for changes
- [x] Tested manually (describe below)

**Manual Testing Details:**

Ran the Electron playground and verified expand-all and collapse-all with real pointer input. Confirmed nested files appear and disappear, the icon and accessible label change in both directions, local storage updates for the open Folder, and expanded state restores after a renderer reload.

Automated checks:

- `pnpm --filter @hubble.md/ui test`
- `pnpm check`
- `pnpm check:react-compiler`
- `pnpm build:desktop`

## Checklist

- [ ] I discussed this change in a GitHub issue before submitting this PR
- [x] I have run the linter, formatter, and tests to ensure my code is ready for review