### PR TITLE
Add codeblock syntax highlight for sql and makefile

### DIFF
--- a/packages/ui/src/editor/CodeBlockExtension.tsx
+++ b/packages/ui/src/editor/CodeBlockExtension.tsx
@@ -33,6 +33,8 @@ lowlight.registerAlias({
 	xml: ["html"],
 	bash: ["sh", "shell"],
 	markdown: ["md"],
+	sql: ["sql"],
+	mk: ["mk"],
 });
 
 export const HubbleCodeBlock = CodeBlockLowlight.extend({
@@ -238,4 +240,6 @@ const codeBlockLanguages = [
 	{ value: "python", label: "Python" },
 	{ value: "rust", label: "Rust" },
 	{ value: "go", label: "Go" },
+	{ value: "sql", label: "SQL" },
+	{ value: "mk", label: "Makefile" },
 ] as const;


### PR DESCRIPTION
## Description
Add SQL and Makefile syntax highlighting to codeblock.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update

## Testing
<!-- Describe the tests you ran to verify your changes -->

- [x] Existing tests pass
- [ ] Added new tests for changes
- [ ] Tested manually (describe below)

## Checklist

- [ ] I discussed this change in a GitHub issue before submitting this PR
- [x] I have run the linter, formatter, and tests to ensure my code is ready for review
