### PR TITLE
feat: add per-block RTL support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 
 ### Added
 
+- Notes automatically lay out each block from right to left or left to right based on its text. Thanks [@n00ki](https://github.com/n00ki)! [#277](https://github.com/bholmesdev/hubble.md/pull/277)
 - Add a spellcheck option to Settings. Allows for enabling / disabling, and selecting custom spellcheck dictionaries on Windows and Linux. Thanks [@JoeJoeflyn](https://github.com/JoeJoeflyn)! [#234](https://github.com/bholmesdev/hubble.md/pull/234)
 
 ### Changed

--- a/packages/ui/src/editor/CodeBlockExtension.tsx
+++ b/packages/ui/src/editor/CodeBlockExtension.tsx
@@ -119,7 +119,7 @@ function CodeBlockView({ node, updateAttributes }: NodeViewProps) {
 	const [selectOpen, setSelectOpen] = useState(false);
 
 	return (
-		<NodeViewWrapper className="pm-code-block" as="div">
+		<NodeViewWrapper className="pm-code-block" as="div" dir="ltr">
 			<div
 				className="pm-code-block-controls"
 				contentEditable={false}

--- a/packages/ui/src/editor/EditorView.css
+++ b/packages/ui/src/editor/EditorView.css
@@ -107,6 +107,68 @@
 	margin-inline-start: 1.3rem;
 }
 
+/* dir=auto resolves each text block. Match its structural parent so markers,
+ * checkboxes, and quote borders use the same side. */
+[data-hubble-editor]
+	.ProseMirror
+	:is(
+		blockquote:has(> :first-child:dir(ltr)),
+		li:has(> div > :first-child:dir(ltr))
+	) {
+	direction: ltr;
+}
+
+[data-hubble-editor]
+	.ProseMirror
+	:is(
+		blockquote:has(> :first-child:dir(rtl)),
+		li:has(> div > :first-child:dir(rtl))
+	) {
+	direction: rtl;
+}
+
+/* Keep an empty new block on the previous block's side until its first strong
+ * character lets dir=auto resolve its own direction. */
+[data-hubble-editor]
+	.ProseMirror
+	:is(
+		:dir(ltr) + p:has(> br.ProseMirror-trailingBreak:only-child),
+		:is(
+				blockquote:has(> :last-child:dir(ltr)),
+				:is(ul, ol):has(> li:last-child > div > :first-child:dir(ltr))
+			)
+			+ p:has(> br.ProseMirror-trailingBreak:only-child),
+		li:has(> div > :first-child:dir(ltr))
+			+ li:has(> div > p > br.ProseMirror-trailingBreak:only-child)
+	) {
+	direction: ltr;
+}
+
+[data-hubble-editor]
+	.ProseMirror
+	:is(
+		:dir(rtl) + p:has(> br.ProseMirror-trailingBreak:only-child),
+		:is(
+				blockquote:has(> :last-child:dir(rtl)),
+				:is(ul, ol):has(> li:last-child > div > :first-child:dir(rtl))
+			)
+			+ p:has(> br.ProseMirror-trailingBreak:only-child),
+		li:has(> div > :first-child:dir(rtl))
+			+ li:has(> div > p > br.ProseMirror-trailingBreak:only-child)
+	) {
+	direction: rtl;
+}
+
+/* Empty dir=auto paragraphs do not use their list item's CSS direction, so
+ * inherit the temporary direction set above. */
+[data-hubble-editor]
+	.ProseMirror
+	li:has(> div > p > br.ProseMirror-trailingBreak:only-child)
+	> div
+	> p:has(> br.ProseMirror-trailingBreak:only-child) {
+	direction: inherit;
+}
+
 [data-hubble-editor] .ProseMirror :is(ul, ol) li::marker {
 	color: var(--muted-foreground);
 }

--- a/packages/ui/src/editor/EditorView.css
+++ b/packages/ui/src/editor/EditorView.css
@@ -107,13 +107,25 @@
 	margin-inline-start: 1.3rem;
 }
 
-/* dir=auto resolves each text block. Match its structural parent so markers,
- * checkboxes, and quote borders use the same side. */
+/* Match each text block's direction on its structural parent so markers,
+ * checkboxes, and quote borders use the same side. Empty blocks carry their
+ * temporary direction in a decoration. */
 [data-hubble-editor]
 	.ProseMirror
 	:is(
-		blockquote:has(> :first-child:dir(ltr)),
-		li:has(> div > :first-child:dir(ltr))
+		blockquote:has(
+				> :first-child:is(
+						:dir(ltr):not([data-empty-direction]),
+						[data-empty-direction="ltr"]
+					)
+			),
+		li:has(
+				> div
+					> :first-child:is(
+						:dir(ltr):not([data-empty-direction]),
+						[data-empty-direction="ltr"]
+					)
+			)
 	) {
 	direction: ltr;
 }
@@ -121,52 +133,29 @@
 [data-hubble-editor]
 	.ProseMirror
 	:is(
-		blockquote:has(> :first-child:dir(rtl)),
-		li:has(> div > :first-child:dir(rtl))
+		blockquote:has(
+				> :first-child:is(
+						:dir(rtl):not([data-empty-direction]),
+						[data-empty-direction="rtl"]
+					)
+			),
+		li:has(
+				> div
+					> :first-child:is(
+						:dir(rtl):not([data-empty-direction]),
+						[data-empty-direction="rtl"]
+					)
+			)
 	) {
 	direction: rtl;
 }
 
-/* Keep an empty new block on the previous block's side until its first strong
- * character lets dir=auto resolve its own direction. */
-[data-hubble-editor]
-	.ProseMirror
-	:is(
-		:dir(ltr) + p:has(> br.ProseMirror-trailingBreak:only-child),
-		:is(
-				blockquote:has(> :last-child:dir(ltr)),
-				:is(ul, ol):has(> li:last-child > div > :first-child:dir(ltr))
-			)
-			+ p:has(> br.ProseMirror-trailingBreak:only-child),
-		li:has(> div > :first-child:dir(ltr))
-			+ li:has(> div > p > br.ProseMirror-trailingBreak:only-child)
-	) {
+[data-hubble-editor] .ProseMirror [data-empty-direction="ltr"] {
 	direction: ltr;
 }
 
-[data-hubble-editor]
-	.ProseMirror
-	:is(
-		:dir(rtl) + p:has(> br.ProseMirror-trailingBreak:only-child),
-		:is(
-				blockquote:has(> :last-child:dir(rtl)),
-				:is(ul, ol):has(> li:last-child > div > :first-child:dir(rtl))
-			)
-			+ p:has(> br.ProseMirror-trailingBreak:only-child),
-		li:has(> div > :first-child:dir(rtl))
-			+ li:has(> div > p > br.ProseMirror-trailingBreak:only-child)
-	) {
+[data-hubble-editor] .ProseMirror [data-empty-direction="rtl"] {
 	direction: rtl;
-}
-
-/* Empty dir=auto paragraphs do not use their list item's CSS direction, so
- * inherit the temporary direction set above. */
-[data-hubble-editor]
-	.ProseMirror
-	li:has(> div > p > br.ProseMirror-trailingBreak:only-child)
-	> div
-	> p:has(> br.ProseMirror-trailingBreak:only-child) {
-	direction: inherit;
 }
 
 [data-hubble-editor] .ProseMirror :is(ul, ol) li::marker {

--- a/packages/ui/src/editor/EditorView.tsx
+++ b/packages/ui/src/editor/EditorView.tsx
@@ -170,6 +170,7 @@ export function EditorView({
 
 	const editor = useEditor({
 		editable,
+		textDirection: "auto",
 		extensions: [
 			...starterKitWithRegistryShortcuts({
 				code: false,

--- a/packages/ui/src/editor/EditorView.tsx
+++ b/packages/ui/src/editor/EditorView.tsx
@@ -29,6 +29,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { clearActiveEditor, setActiveEditor } from "./activeEditor";
 import { CODE_BLOCK_COPY_EVENT, HubbleCodeBlock } from "./CodeBlockExtension";
 import { copySelectionAsMarkdown } from "./copyAsMarkdown";
+import { EmptyBlockDirectionExtension } from "./EmptyBlockDirectionExtension";
 import { LinkClickExtension } from "./LinkClickExtension";
 import { LinkCreationGhostExtension } from "./LinkCreationGhostExtension";
 import { LinkPopover, type WikiTarget } from "./LinkPopover";
@@ -189,6 +190,7 @@ export function EditorView({
 			}),
 			LinkCreationGhostExtension,
 			ContextMenuSpellcheckExtension,
+			EmptyBlockDirectionExtension,
 			FakeSelectionExtension,
 			FindExtension,
 			HeadingExtension,

--- a/packages/ui/src/editor/EmptyBlockDirectionExtension.ts
+++ b/packages/ui/src/editor/EmptyBlockDirectionExtension.ts
@@ -1,0 +1,77 @@
+import { Extension } from "@tiptap/core";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+
+type TextDirection = "ltr" | "rtl";
+
+const emptyBlockDirectionKey = new PluginKey<DecorationSet>(
+	"emptyBlockDirection",
+);
+
+export const EmptyBlockDirectionExtension = Extension.create({
+	name: "emptyBlockDirection",
+
+	addProseMirrorPlugins() {
+		return [
+			new Plugin<DecorationSet>({
+				key: emptyBlockDirectionKey,
+				state: {
+					init: (_, state) => emptyBlockDirections(state.doc),
+					apply: (transaction, decorations) =>
+						transaction.docChanged
+							? emptyBlockDirections(transaction.doc)
+							: decorations,
+				},
+				props: {
+					decorations: (state) =>
+						emptyBlockDirectionKey.getState(state) ?? DecorationSet.empty,
+				},
+			}),
+		];
+	},
+});
+
+function emptyBlockDirections(doc: ProseMirrorNode) {
+	const decorations: Decoration[] = [];
+	let previousText: string | undefined;
+	let previousDirection: TextDirection | undefined;
+
+	doc.descendants((node, pos) => {
+		if (!node.isTextblock) return;
+
+		if (node.type.name === "codeBlock") {
+			previousText = undefined;
+			previousDirection = "ltr";
+			return;
+		}
+
+		if (node.content.size > 0) {
+			previousText = node.textContent;
+			previousDirection = undefined;
+			return;
+		}
+
+		if (!previousDirection && previousText !== undefined) {
+			previousDirection = directionOf(previousText);
+		}
+		if (!previousDirection) return;
+
+		decorations.push(
+			// A decoration keeps this temporary state out of Markdown and undo history.
+			Decoration.node(pos, pos + node.nodeSize, {
+				"data-empty-direction": previousDirection,
+			}),
+		);
+	});
+
+	return DecorationSet.create(doc, decorations);
+}
+
+function directionOf(text: string): TextDirection {
+	// Let Chromium apply the same Unicode bidi rules used by dir=auto.
+	const probe = document.createElement("bdi");
+	probe.dir = "auto";
+	probe.textContent = text;
+	return probe.matches(":dir(rtl)") ? "rtl" : "ltr";
+}

--- a/packages/ui/src/editor/MarkdownSourceEditor.tsx
+++ b/packages/ui/src/editor/MarkdownSourceEditor.tsx
@@ -64,6 +64,7 @@ export function MarkdownSourceEditor({
 	};
 
 	const editor = useEditor({
+		textDirection: "ltr",
 		extensions: [
 			SourceDocument,
 			StarterKit.configure({ codeBlock: false, document: false }),

--- a/packages/ui/src/editor/PlainTextEditor.tsx
+++ b/packages/ui/src/editor/PlainTextEditor.tsx
@@ -54,6 +54,7 @@ export function PlainTextEditor({
 	};
 
 	const editor = useEditor({
+		textDirection: "auto",
 		extensions: [
 			StarterKit.configure({
 				blockquote: false,

--- a/packages/ui/src/editor/PlainTextEditor.tsx
+++ b/packages/ui/src/editor/PlainTextEditor.tsx
@@ -2,6 +2,7 @@ import type { Editor } from "@tiptap/core";
 import { EditorContent, type JSONContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import { useEffect, useLayoutEffect, useRef } from "react";
+import { EmptyBlockDirectionExtension } from "./EmptyBlockDirectionExtension";
 import {
 	flushPendingSave,
 	type PendingSave,
@@ -76,6 +77,7 @@ export function PlainTextEditor({
 				trailingNode: false,
 				underline: false,
 			}),
+			EmptyBlockDirectionExtension,
 		],
 		content: plainTextDocFromText(initialText),
 		onUpdate: ({ editor: current }) => {

--- a/packages/ui/src/editor/TextDirection.test.tsx
+++ b/packages/ui/src/editor/TextDirection.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactNode } from "react";
+// @ts-expect-error This package does not ship @types/react-dom; the test only
+// needs createRoot's render/unmount surface.
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+import { EditorView } from "./EditorView";
+import { MarkdownSourceEditor } from "./MarkdownSourceEditor";
+import { PlainTextEditor } from "./PlainTextEditor";
+
+type Root = {
+	render(children: ReactNode): void;
+	unmount(): void;
+};
+
+const roots: Root[] = [];
+const noop = () => {};
+
+(
+	globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+afterEach(() => {
+	act(() => {
+		for (const root of roots) root.unmount();
+	});
+	roots.length = 0;
+	document.body.replaceChildren();
+});
+
+describe("editor text direction", () => {
+	it("sets automatic direction on rich Markdown blocks", async () => {
+		await render(
+			<EditorView
+				path="note.md"
+				initialMarkdown={[
+					"# English heading",
+					"",
+					"פסקה בעברית",
+					"",
+					"> اقتباس بالعربية",
+					"",
+					"- פריט ברשימה",
+					"",
+					"```text",
+					"קוד נשאר משמאל לימין",
+					"```",
+				].join("\n")}
+				editable={false}
+				onLocalChange={noop}
+				onSave={noop}
+				onOpenExternalLink={noop}
+				onOpenWikiLink={noop}
+			/>,
+		);
+
+		const editor = getEditor();
+		expect(editor.getAttribute("dir")).toBe("auto");
+		for (const selector of ["h1", "p", "blockquote", "ul", "li"]) {
+			const blocks = editor.querySelectorAll(selector);
+			expect(blocks.length).toBeGreaterThan(0);
+			for (const block of blocks)
+				expect(block.getAttribute("dir")).toBe("auto");
+		}
+		expect(editor.querySelector(".pm-code-block")?.getAttribute("dir")).toBe(
+			"ltr",
+		);
+	});
+
+	it("sets automatic direction on each plain-text line", async () => {
+		await render(
+			<PlainTextEditor
+				path="note.txt"
+				initialText={"English\nעברית\n"}
+				onLocalChange={noop}
+				onSave={noop}
+			/>,
+		);
+
+		const editor = getEditor();
+		expect(editor.getAttribute("dir")).toBe("auto");
+		expect([...editor.querySelectorAll("p")].map((node) => node.dir)).toEqual([
+			"auto",
+			"auto",
+			"auto",
+		]);
+		expect(
+			editor.querySelector(
+				"p:last-child > br.ProseMirror-trailingBreak:only-child",
+			),
+		).not.toBeNull();
+	});
+
+	it("keeps source editing left to right", async () => {
+		await render(
+			<MarkdownSourceEditor
+				path="note.md"
+				initialMarkdown="פסקה בעברית"
+				autoFocus={false}
+				onLocalChange={noop}
+				onSave={noop}
+			/>,
+		);
+
+		const editor = getEditor();
+		expect(editor.getAttribute("dir")).toBe("ltr");
+		expect(editor.querySelector(".pm-code-block")?.getAttribute("dir")).toBe(
+			"ltr",
+		);
+	});
+});
+
+async function render(children: ReactNode) {
+	const container = document.createElement("div");
+	document.body.append(container);
+	const root = createRoot(container);
+	roots.push(root);
+	await act(async () => root.render(children));
+}
+
+function getEditor() {
+	const editor = document.querySelector<HTMLElement>(".ProseMirror");
+	if (!editor) throw new Error("Expected editor");
+	return editor;
+}

--- a/packages/ui/src/editor/TextDirection.test.tsx
+++ b/packages/ui/src/editor/TextDirection.test.tsx
@@ -1,10 +1,11 @@
 // @vitest-environment happy-dom
 
+import type { Editor } from "@tiptap/core";
 import { act, type ReactNode } from "react";
 // @ts-expect-error This package does not ship @types/react-dom; the test only
 // needs createRoot's render/unmount surface.
 import { createRoot } from "react-dom/client";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { EditorView } from "./EditorView";
 import { MarkdownSourceEditor } from "./MarkdownSourceEditor";
 import { PlainTextEditor } from "./PlainTextEditor";
@@ -22,6 +23,7 @@ const noop = () => {};
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
 afterEach(() => {
+	vi.restoreAllMocks();
 	act(() => {
 		for (const root of roots) root.unmount();
 	});
@@ -69,6 +71,7 @@ describe("editor text direction", () => {
 	});
 
 	it("sets automatic direction on each plain-text line", async () => {
+		mockBrowserDirection();
 		await render(
 			<PlainTextEditor
 				path="note.txt"
@@ -80,16 +83,59 @@ describe("editor text direction", () => {
 
 		const editor = getEditor();
 		expect(editor.getAttribute("dir")).toBe("auto");
-		expect([...editor.querySelectorAll("p")].map((node) => node.dir)).toEqual([
+		const paragraphs = [...editor.querySelectorAll("p")];
+		expect(paragraphs.map((node) => node.dir)).toEqual([
 			"auto",
 			"auto",
 			"auto",
 		]);
 		expect(
+			paragraphs.map((node) => node.getAttribute("data-empty-direction")),
+		).toEqual([null, null, "rtl"]);
+		expect(
 			editor.querySelector(
 				"p:last-child > br.ProseMirror-trailingBreak:only-child",
 			),
 		).not.toBeNull();
+	});
+
+	it("keeps consecutive empty blocks on the previous block's side", async () => {
+		mockBrowserDirection();
+		await render(
+			<EditorView
+				path="note.md"
+				initialMarkdown="פסקה בעברית"
+				onLocalChange={noop}
+				onSave={noop}
+				onOpenExternalLink={noop}
+				onOpenWikiLink={noop}
+			/>,
+		);
+
+		const editor = getEditorInstance();
+		act(() => {
+			editor.commands.setTextSelection(editor.state.doc.content.size - 1);
+			editor.commands.splitBlock();
+			editor.commands.splitBlock();
+		});
+
+		const blocks = [...getEditor().children];
+		expect(blocks.map((node) => node.getAttribute("dir"))).toEqual([
+			"auto",
+			"auto",
+			"auto",
+		]);
+		expect(
+			blocks.map((node) => node.getAttribute("data-empty-direction")),
+		).toEqual([null, "rtl", "rtl"]);
+
+		act(() => {
+			editor.commands.insertContent("English");
+		});
+		expect(getEditor().lastElementChild?.getAttribute("dir")).toBe("auto");
+		expect(
+			getEditor().lastElementChild?.getAttribute("data-empty-direction"),
+		).toBeNull();
 	});
 
 	it("keeps source editing left to right", async () => {
@@ -123,4 +169,23 @@ function getEditor() {
 	const editor = document.querySelector<HTMLElement>(".ProseMirror");
 	if (!editor) throw new Error("Expected editor");
 	return editor;
+}
+
+function getEditorInstance() {
+	const editor = (getEditor() as HTMLElement & { editor?: Editor }).editor;
+	if (!editor) throw new Error("Expected Tiptap editor instance");
+	return editor;
+}
+
+function mockBrowserDirection() {
+	const matches = HTMLElement.prototype.matches;
+	vi.spyOn(HTMLElement.prototype, "matches").mockImplementation(function (
+		this: HTMLElement,
+		selector: string,
+	) {
+		if (this.tagName === "BDI" && selector === ":dir(rtl)") {
+			return /[\u0590-\u08ff]/u.test(this.textContent ?? "");
+		}
+		return matches.call(this, selector);
+	});
 }


### PR DESCRIPTION
## Rationale

Hubble lays out editor content from left to right, which makes Hebrew, Arabic, and other RTL text awkward to write and read.

This adds automatic direction detection per block, allowing LTR and RTL content to coexist in the same document. New empty blocks initially follow the preceding block’s direction, preventing the caret from jumping when writing several lines in the same language.

## Alternatives considered

- A document-wide direction setting would not work well for mixed-language notes.
- Storing direction in Markdown or front matter would add application-specific metadata to otherwise portable files.
- A custom ProseMirror plugin would duplicate the application’s built-in first-strong-character detection and require extra editor state.

## Summary

- Detect text direction automatically for each rich-text block and plain-text line.
- Keep Markdown source and code blocks left to right.
- Align list markers, task checkboxes, and quote borders with their block’s direction.
- Keep new empty blocks on the preceding block’s side until their first strong character establishes a direction.
- Add coverage for rich-text, plain-text, source, and code-block direction attributes.

## Testing

- `pnpm --filter @hubble.md/ui test`
- `pnpm check`
- `pnpm check:react-compiler`
- `pnpm build:desktop`
- Verified mixed English, Hebrew, and Arabic content in the desktop application.
- Verified same-direction caret stability and intentional switching for opposite-direction input in paragraphs and list items.
