### PR TITLE
fix: focus the editor after creating Markdown notes

### DIFF
--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -7,6 +7,7 @@ import {
 import { useStoreValue } from "@simplestack/store/react";
 import type { ReactNode } from "react";
 import { desktopApi } from "../desktopApi";
+import { focusMarkdownEditorAfterRender } from "../fileActions";
 import { copyText } from "../lib/clipboard";
 import { useCompactWindow } from "../lib/layout";
 import { revealFileLabel } from "../lib/revealFile";
@@ -133,7 +134,13 @@ export function Sidebar({
 				});
 			}}
 			revealLabel={revealFileLabel(desktopApi.platform)}
-			onRenameFile={(path, nextName) => void renameMarkdownFile(path, nextName)}
+			onRenameFile={(path, nextName, { origin, commit }) => {
+				void renameMarkdownFile(path, nextName).then((renamedPath) => {
+					if (origin === "new-note" && commit === "enter" && renamedPath) {
+						focusMarkdownEditorAfterRender(renamedPath);
+					}
+				});
+			}}
 			onRenameFolder={(folderId, nextName, targetDisplayPath) =>
 				void renameFolder(
 					absolutePath(folderId),

--- a/apps/desktop/src/fileActions.test.ts
+++ b/apps/desktop/src/fileActions.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment happy-dom
+
+import { getActiveEditor } from "@hubble.md/ui";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createMarkdownFile } from "./fileActions";
+import { createMarkdownFileInFolder } from "./store/actions";
+import { viewerStore, workspaceStore } from "./store/state";
+
+vi.mock("@hubble.md/ui", () => ({ getActiveEditor: vi.fn() }));
+vi.mock("./store/actions", () => ({
+	createHtmlFileInFolder: vi.fn(),
+	createMarkdownFileInFolder: vi.fn(),
+}));
+vi.mock("./store/state", () => ({
+	viewerStore: { get: vi.fn() },
+	workspaceStore: { get: vi.fn() },
+}));
+
+const focus = vi.fn();
+let pendingFrame: FrameRequestCallback | null = null;
+const nextFrame = vi.fn((callback: FrameRequestCallback) => {
+	pendingFrame = callback;
+	return 1;
+});
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	pendingFrame = null;
+	vi.stubGlobal("requestAnimationFrame", nextFrame);
+	vi.mocked(workspaceStore.get).mockReturnValue({
+		workspacePath: "/workspace",
+	} as never);
+	vi.mocked(getActiveEditor).mockReturnValue({
+		commands: { focus },
+	} as never);
+});
+
+function renderNextFrame() {
+	if (!pendingFrame) throw new Error("No frame was requested");
+	const callback = pendingFrame;
+	pendingFrame = null;
+	callback(0);
+}
+
+describe("createMarkdownFile", () => {
+	it("focuses the editor after the created Markdown file renders", async () => {
+		vi.mocked(createMarkdownFileInFolder).mockResolvedValue(
+			"/workspace/new-file.md",
+		);
+		vi.mocked(viewerStore.get).mockReturnValue({
+			currentPath: "/workspace/new-file.md",
+		} as never);
+		await createMarkdownFile();
+
+		expect(nextFrame).toHaveBeenCalledOnce();
+		expect(focus).not.toHaveBeenCalled();
+		renderNextFrame();
+		expect(focus).toHaveBeenCalledWith("end");
+	});
+
+	it("does not focus after creation fails", async () => {
+		vi.mocked(createMarkdownFileInFolder).mockResolvedValue(null);
+		await createMarkdownFile();
+
+		expect(nextFrame).not.toHaveBeenCalled();
+		expect(focus).not.toHaveBeenCalled();
+	});
+
+	it("does not steal focus if another file opens before the next frame", async () => {
+		vi.mocked(createMarkdownFileInFolder).mockResolvedValue(
+			"/workspace/new-file.md",
+		);
+		vi.mocked(viewerStore.get).mockReturnValue({
+			currentPath: "/workspace/new-file.md",
+		} as never);
+		await createMarkdownFile();
+		vi.mocked(viewerStore.get).mockReturnValue({
+			currentPath: "/workspace/other.md",
+		} as never);
+		renderNextFrame();
+
+		expect(getActiveEditor).not.toHaveBeenCalled();
+		expect(focus).not.toHaveBeenCalled();
+	});
+});

--- a/apps/desktop/src/fileActions.ts
+++ b/apps/desktop/src/fileActions.ts
@@ -1,13 +1,23 @@
+import { getActiveEditor } from "@hubble.md/ui";
 import {
 	createHtmlFileInFolder,
 	createMarkdownFileInFolder,
 } from "./store/actions";
-import { workspaceStore } from "./store/state";
+import { viewerStore, workspaceStore } from "./store/state";
 
 export async function createMarkdownFile(parentPath?: string | null) {
 	const targetPath = parentPath ?? workspaceStore.get().workspacePath;
 	if (!targetPath) return;
-	await createMarkdownFileInFolder(targetPath);
+	const path = await createMarkdownFileInFolder(targetPath);
+	if (!path) return;
+	focusMarkdownEditorAfterRender(path);
+}
+
+export function focusMarkdownEditorAfterRender(path: string) {
+	requestAnimationFrame(() => {
+		if (viewerStore.get().currentPath !== path) return;
+		getActiveEditor()?.commands.focus("end");
+	});
 }
 
 export async function createHtmlFile(parentPath?: string | null) {

--- a/apps/desktop/src/store/actions.test.ts
+++ b/apps/desktop/src/store/actions.test.ts
@@ -664,8 +664,9 @@ describe("desktop renameMarkdownFile", () => {
 			},
 		}));
 
-		await renameMarkdownFile(path, "renamed");
+		const renamedPath = await renameMarkdownFile(path, "renamed");
 
+		expect(renamedPath).toBe("/workspace/renamed.md");
 		expect(api.renameFile).toHaveBeenCalledWith(path, "/workspace/renamed.md");
 		expect(api.readFileText).toHaveBeenLastCalledWith("/workspace/renamed.md");
 		expect(viewerStore.get().currentPath).toBe("/workspace/renamed.md");

--- a/apps/desktop/src/store/actions.ts
+++ b/apps/desktop/src/store/actions.ts
@@ -858,18 +858,19 @@ export async function renameMarkdownFile(path: string, nextName: string) {
 	const { files: filesBeforeRename, workspacePath } = workspaceStore.get();
 
 	const trimmedName = nextName.trim();
-	if (trimmedName.length === 0) return;
+	if (trimmedName.length === 0) return null;
 
 	const parent = dirname(path);
-	if (!parent) return;
+	if (!parent) return null;
 
 	const proposedStem = renameStem(trimmedName, currentExt);
 	const nextNameWithExt = `${proposedStem}${currentExt}`;
 	// Slash paths are relative to the current file's folder, matching sidebar
 	// rename behavior for nested notes.
 	const nextPath = normalizePath(joinPath(parent, nextNameWithExt));
-	if (!isSafeRelativeRenamePath(trimmedName, nextPath, workspacePath)) return;
-	if (nextPath === path) return;
+	if (!isSafeRelativeRenamePath(trimmedName, nextPath, workspacePath))
+		return null;
+	if (nextPath === path) return path;
 
 	try {
 		if (isCurrentFile && isEditableFile(path)) {
@@ -919,10 +920,12 @@ export async function renameMarkdownFile(path: string, nextName: string) {
 			// Path rewrite already updated history; reload content without a new visit.
 			await loadPath(nextPath, { history: "none", launchExternal: false });
 		}
+		return nextPath;
 	} catch (err) {
 		pendingRenames.delete(path);
 		const message = handleFileError(err);
 		toast.error("Failed to rename file", { description: message });
+		return null;
 	} finally {
 		window.setTimeout(() => pendingRenames.delete(path), 1000);
 	}

--- a/packages/ui/src/components/Sidebar.test.tsx
+++ b/packages/ui/src/components/Sidebar.test.tsx
@@ -1,0 +1,204 @@
+// @vitest-environment happy-dom
+
+import { act, type ComponentProps, type ReactNode, useState } from "react";
+// @ts-expect-error This package does not ship @types/react-dom; the test only
+// needs createRoot's render/unmount surface.
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Sidebar, type SidebarFile } from "./Sidebar";
+
+type Root = {
+	render(children: ReactNode): void;
+	unmount(): void;
+};
+type RenameFile = NonNullable<ComponentProps<typeof Sidebar>["onRenameFile"]>;
+
+const roots: Root[] = [];
+
+(
+	globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+afterEach(() => {
+	act(() => {
+		for (const root of roots) root.unmount();
+	});
+	roots.length = 0;
+	document.body.replaceChildren();
+});
+
+describe("Sidebar", () => {
+	it("continues editing after a new note name is submitted", async () => {
+		const onRenameFile = vi.fn();
+		renderSidebar(onRenameFile);
+
+		await act(async () => newFileButton().click());
+		await act(async () => {
+			newNoteMenuItem().click();
+			await Promise.resolve();
+		});
+
+		const input = renameInput("new-file");
+		act(() => {
+			setInputValue(input, "daily-notes");
+			input.dispatchEvent(
+				new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+			);
+		});
+
+		expect(onRenameFile).toHaveBeenCalledWith(
+			"/workspace/new-file.md",
+			"daily-notes",
+			{ origin: "new-note", commit: "enter" },
+		);
+	});
+
+	it("returns to the sidebar after an existing note is renamed", () => {
+		const onRenameFile = vi.fn();
+		renderSidebar(onRenameFile, [
+			{ path: "/workspace/existing.md", modifiedAt: 1 },
+		]);
+
+		act(() => {
+			existingNoteButton().dispatchEvent(
+				new MouseEvent("dblclick", { bubbles: true, detail: 2 }),
+			);
+		});
+		const input = renameInput("existing");
+		act(() => {
+			setInputValue(input, "renamed");
+			input.dispatchEvent(
+				new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+			);
+		});
+
+		expect(onRenameFile).toHaveBeenCalledWith(
+			"/workspace/existing.md",
+			"renamed",
+			{ origin: "rename", commit: "enter" },
+		);
+	});
+
+	it("returns to the sidebar after a new HTML app is named", async () => {
+		const onRenameFile = vi.fn();
+		renderSidebar(onRenameFile);
+
+		await act(async () => newFileButton().click());
+		await act(async () => {
+			newHtmlMenuItem().click();
+			await Promise.resolve();
+		});
+
+		const input = renameInput("new-app");
+		act(() => {
+			setInputValue(input, "dashboard");
+			input.dispatchEvent(
+				new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+			);
+		});
+
+		expect(onRenameFile).toHaveBeenCalledWith(
+			"/workspace/new-app.html",
+			"dashboard",
+			{ origin: "new-html", commit: "enter" },
+		);
+	});
+});
+
+function renderSidebar(
+	onRenameFile: RenameFile,
+	initialFiles: SidebarFile[] = [],
+) {
+	const container = document.createElement("div");
+	document.body.append(container);
+	const root = createRoot(container);
+	roots.push(root);
+	act(() =>
+		root.render(
+			<SidebarHarness
+				onRenameFile={onRenameFile}
+				initialFiles={initialFiles}
+			/>,
+		),
+	);
+}
+
+function SidebarHarness({
+	onRenameFile,
+	initialFiles,
+}: {
+	onRenameFile: RenameFile;
+	initialFiles: SidebarFile[];
+}) {
+	const [files, setFiles] = useState(initialFiles);
+	return (
+		<Sidebar
+			files={files}
+			currentPath={null}
+			sortMode="alpha"
+			getDisplayPath={(path) => path.replace("/workspace/", "")}
+			onSortModeChange={() => {}}
+			onSelectFile={() => {}}
+			onRenameFile={onRenameFile}
+			onCreateFile={async () => {
+				const path = "/workspace/new-file.md";
+				setFiles([{ path, modifiedAt: 1 }]);
+				return path;
+			}}
+			onCreateHtmlFile={async () => {
+				const path = "/workspace/new-app.html";
+				setFiles([{ path, modifiedAt: 1 }]);
+				return path;
+			}}
+		/>
+	);
+}
+
+function newFileButton() {
+	const button = document.querySelector<HTMLButtonElement>(
+		'button[aria-label="New file"]',
+	);
+	if (!button) throw new Error("Missing new file button");
+	return button;
+}
+
+function newNoteMenuItem() {
+	const item = Array.from(
+		document.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+	).find((element) => element.textContent?.includes("New Note"));
+	if (!item) throw new Error("Missing New Note menu item");
+	return item;
+}
+
+function newHtmlMenuItem() {
+	const item = Array.from(
+		document.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+	).find((element) => element.textContent?.includes("New HTML App"));
+	if (!item) throw new Error("Missing New HTML App menu item");
+	return item;
+}
+
+function existingNoteButton() {
+	const button = Array.from(
+		document.querySelectorAll<HTMLButtonElement>("button"),
+	).find((element) => element.textContent?.trim() === "existing.md");
+	if (!button) throw new Error("Missing existing note button");
+	return button;
+}
+
+function renameInput(value: string) {
+	const input = Array.from(
+		document.querySelectorAll<HTMLInputElement>("input"),
+	).find((element) => element.value === value);
+	if (!input) throw new Error("Missing rename input");
+	return input;
+}
+
+function setInputValue(input: HTMLInputElement, value: string) {
+	const setter = Object.getOwnPropertyDescriptor(
+		HTMLInputElement.prototype,
+		"value",
+	)?.set;
+	setter?.call(input, value);
+	input.dispatchEvent(new Event("input", { bubbles: true }));
+}

--- a/packages/ui/src/components/Sidebar.test.tsx
+++ b/packages/ui/src/components/Sidebar.test.tsx
@@ -25,6 +25,7 @@ afterEach(() => {
 	});
 	roots.length = 0;
 	document.body.replaceChildren();
+	vi.restoreAllMocks();
 });
 
 describe("Sidebar", () => {
@@ -39,11 +40,20 @@ describe("Sidebar", () => {
 		});
 
 		const input = renameInput("new-file");
+		const focusTree = vi.spyOn(sidebarTree(), "focus");
+		const frames: FrameRequestCallback[] = [];
+		vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+			frames.push(callback);
+			return frames.length;
+		});
 		act(() => {
 			setInputValue(input, "daily-notes");
 			input.dispatchEvent(
 				new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
 			);
+		});
+		act(() => {
+			for (const frame of frames) frame(0);
 		});
 
 		expect(onRenameFile).toHaveBeenCalledWith(
@@ -51,6 +61,7 @@ describe("Sidebar", () => {
 			"daily-notes",
 			{ origin: "new-note", commit: "enter" },
 		);
+		expect(focusTree).not.toHaveBeenCalled();
 	});
 
 	it("returns to the sidebar after an existing note is renamed", () => {
@@ -184,6 +195,12 @@ function existingNoteButton() {
 	).find((element) => element.textContent?.trim() === "existing.md");
 	if (!button) throw new Error("Missing existing note button");
 	return button;
+}
+
+function sidebarTree() {
+	const tree = document.querySelector<HTMLElement>('[role="tree"]');
+	if (!tree) throw new Error("Missing sidebar tree");
+	return tree;
 }
 
 function renameInput(value: string) {

--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -84,7 +84,11 @@ export type SidebarFocusedItem =
 	| null;
 
 type RenameItem =
-	| { kind: "file"; path: string }
+	| {
+			kind: "file";
+			path: string;
+			origin?: "new-note" | "new-html";
+	  }
 	| {
 			kind: "folder";
 			path: string;
@@ -440,7 +444,14 @@ export function Sidebar({
 	onRevealFolder?: (folderId: string) => void;
 	onFocusedItemChange?: (item: SidebarFocusedItem) => void;
 	revealLabel?: string;
-	onRenameFile?: (path: string, nextName: string) => void;
+	onRenameFile?: (
+		path: string,
+		nextName: string,
+		options: {
+			origin: "new-note" | "new-html" | "rename";
+			commit: "enter" | "blur";
+		},
+	) => void;
 	onRenameFolder?: (
 		folderId: string,
 		nextName: string,
@@ -520,7 +531,7 @@ export function Sidebar({
 		const path = await onCreateFile(folderId);
 		if (!path) return;
 		beginRename(
-			{ kind: "file", path },
+			{ kind: "file", path, origin: "new-note" },
 			fileNameFromPath(getDisplayPath(path)),
 			{
 				deleteOnUnchangedCancel: true,
@@ -534,7 +545,7 @@ export function Sidebar({
 		const path = await onCreateHtmlFile(folderId);
 		if (!path) return;
 		beginRename(
-			{ kind: "file", path },
+			{ kind: "file", path, origin: "new-html" },
 			fileNameFromPath(getDisplayPath(path)),
 			{
 				deleteOnUnchangedCancel: true,
@@ -862,13 +873,14 @@ export function Sidebar({
 		return `A ${item.kind} ${targetName} already exists at this location.`;
 	};
 
-	const commitRename = (focusTree = false) => {
+	const commitRename = (commit: "enter" | "blur") => {
 		const item = renamingItem;
 		if (!item) return;
 		const nextName = renameDraft.trim();
 		if (!nextName) {
 			resetRename();
-			if (focusTree) requestAnimationFrame(() => navRef.current?.focus());
+			if (commit === "enter")
+				requestAnimationFrame(() => navRef.current?.focus());
 			return;
 		}
 		const error = getRenameError(item, nextName);
@@ -877,14 +889,20 @@ export function Sidebar({
 			requestAnimationFrame(() => renameInputRef.current?.focus());
 			return;
 		}
-		if (focusTree) {
+		const origin = item.kind === "file" ? (item.origin ?? "rename") : "rename";
+		const handsOffFocus = origin === "new-note" && commit === "enter";
+		if (commit === "enter" && !handsOffFocus) {
 			setPendingFocusDisplayPath(
 				renameTargetDisplayPath(item, nextName, getDisplayPath),
 			);
 			requestAnimationFrame(() => navRef.current?.focus());
 		}
 		resetRename();
-		if (item.kind === "file") onRenameFile?.(item.path, nextName);
+		if (item.kind === "file")
+			onRenameFile?.(item.path, nextName, {
+				origin,
+				commit,
+			});
 		else
 			onRenameFolder?.(
 				item.path,
@@ -2307,7 +2325,7 @@ function FileRenameInput({
 	error: string | null;
 	onChange: (value: string) => void;
 	onCancel: () => void;
-	onCommit: (focusTree?: boolean) => void;
+	onCommit: (commit: "enter" | "blur") => void;
 }) {
 	return (
 		<span className="relative flex min-w-0 flex-1 items-center">
@@ -2316,12 +2334,12 @@ function FileRenameInput({
 				aria-invalid={error ? true : undefined}
 				className="min-w-0 flex-1 rounded-none border-0 bg-muted/70 p-0 text-[13px] text-sidebar-foreground outline-none selection:bg-selected/70 selection:text-sidebar-foreground focus:outline-none focus-visible:outline-none focus-visible:ring-0"
 				value={value}
-				onBlur={() => onCommit()}
+				onBlur={() => onCommit("blur")}
 				onChange={(event) => onChange(event.target.value)}
 				onKeyDown={(event) => {
 					if (event.key === "Enter") {
 						event.preventDefault();
-						onCommit(true);
+						onCommit("enter");
 					} else if (event.key === "Escape") {
 						event.preventDefault();
 						onCancel();


### PR DESCRIPTION
## Rationale

Creating a Markdown note with Cmd+N opened the new document but left focus outside the editor, so there was no visible caret and typing had no effect. This began when Tiptap autofocus and the path-change focus effect were removed while adding file properties.

Restoring either behavior would also focus the editor during ordinary file navigation, stealing focus from the sidebar. Editor focus should follow creation intent instead of every path change.

Hubble has two Markdown creation flows:

- Cmd+N, the native File menu, the command palette, and the toolbar create and open a note that is immediately ready for typing.
- The sidebar creates a placeholder note and opens its inline name field. It should keep that field focused until the user presses Enter, then transfer focus to the editor after the rename succeeds.

HTML creation keeps its existing sidebar focus behavior because it does not open the Markdown editor.

### Alternatives considered

I considered restoring Tiptap's autofocus option or the previous path-change focus effect. Both would fix new-note creation, but they would also move focus into the editor whenever a user opened a file from the sidebar.

I also considered focusing the editor as soon as the sidebar creates a note. That would interrupt the inline naming step.

A `continueEditing` flag would express the desktop app's policy inside the shared sidebar. Instead, the sidebar reports the rename origin and how it was committed. The desktop app uses those facts to decide whether to focus the Markdown editor.

## Summary

- Focus the Markdown editor on the next frame after successful note creation.
- Confirm that the created note is still active before moving focus.
- Keep Cmd+N, the native File menu, the command palette, and toolbar creation on the same focus path.
- After a sidebar note name is submitted with Enter, wait for the rename and focus the editor at the final path.
- Avoid an intermediate sidebar focus change during that handoff.
- Preserve existing focus behavior for HTML creation, blur commits, existing-file renames, and ordinary file navigation.
- Add regression coverage for creation focus, navigation races, and sidebar rename intent.

## Testing

- `pnpm check`
- `pnpm check:react-compiler`
- `pnpm build:desktop`
- `pnpm --filter @hubble.md/ui test`
- `pnpm --filter @hubble.md/desktop test`
- Verified Cmd+N and command palette creation in the Electron app.
- Verified that submitting a new sidebar note name focuses the Markdown editor without first focusing the sidebar tree.
- Verified that new HTML apps and existing-file renames retain sidebar focus.
- Verified that ordinary sidebar navigation does not focus the editor.
