### PR TITLE
fix(desktop): raise the window when macOS opens a file into a running app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 
 ### Fixed
 
+- Opening a Markdown file from Finder now brings Hubble to the front, and opens a window when the app is running with none open. [#287](https://github.com/bholmesdev/hubble.md/issues/287)
+
 ## [0.1.28] - 2026-08-19
 
 ### Added

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1977,6 +1977,29 @@ protocol.registerSchemesAsPrivileged([
 	},
 ]);
 
+// A document opened against an already-running app has to raise the window
+// itself. macOS routes that through `open-file` and other platforms through
+// `second-instance`, so both share this. `pendingOpenPath` is set by the
+// caller, which is what covers the two paths that don't reach the renderer
+// here: a window created below, and an `open-file` that arrives before
+// `whenReady()` on a cold launch. Both drain it via
+// `desktop:get-launch-file-path` during renderer init.
+function revealForOpenFile(openPath: string) {
+	if (!mainWindow || mainWindow.isDestroyed()) {
+		// macOS keeps the app alive with no window after ⌘W. Before ready, the
+		// `whenReady()` handler is about to create the window anyway.
+		if (app.isReady()) void createWindow();
+		return;
+	}
+	if (mainWindow.isMinimized()) mainWindow.restore();
+	mainWindow.show();
+	// `BrowserWindow.focus()` alone does not raise the app above the frontmost
+	// one when the open request came from another app, such as Finder.
+	app.focus({ steal: true });
+	mainWindow.focus();
+	sendToRenderer("desktop:open-file", toRendererPath(openPath));
+}
+
 const singleInstanceLock = app.requestSingleInstanceLock();
 if (!singleInstanceLock) {
 	app.quit();
@@ -1985,11 +2008,7 @@ if (!singleInstanceLock) {
 		const openPath = firstExistingFileArg(argv.slice(1));
 		if (!openPath) return;
 		pendingOpenPath = openPath;
-		if (mainWindow) {
-			if (mainWindow.isMinimized()) mainWindow.restore();
-			mainWindow.focus();
-			sendToRenderer("desktop:open-file", toRendererPath(openPath));
-		}
+		revealForOpenFile(openPath);
 	});
 
 	app.on("open-file", (event, filePath) => {
@@ -1997,7 +2016,7 @@ if (!singleInstanceLock) {
 		const resolved = resolvePath(filePath);
 		grantFileWithParent(resolved);
 		pendingOpenPath = resolved;
-		sendToRenderer("desktop:open-file", toRendererPath(resolved));
+		revealForOpenFile(resolved);
 	});
 
 	// "Desktop Active" means the app was used that day (TELEMETRY.md): launch

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1977,18 +1977,34 @@ protocol.registerSchemesAsPrivileged([
 	},
 ]);
 
+// `createWindow` awaits persisted state before it assigns `mainWindow`, so two
+// callers racing the same gap would each open a window. Every caller shares the
+// in-flight promise instead.
+let pendingWindowCreation: Promise<void> | null = null;
+function ensureMainWindow() {
+	if (mainWindow && !mainWindow.isDestroyed()) return Promise.resolve();
+	pendingWindowCreation ??= createWindow().finally(() => {
+		pendingWindowCreation = null;
+	});
+	return pendingWindowCreation;
+}
+
+// Set once the `whenReady()` handler below has registered IPC, so a window
+// created outside it always has the handlers its renderer calls during init.
+let appBootstrapped = false;
+
 // A document opened against an already-running app has to raise the window
 // itself. macOS routes that through `open-file` and other platforms through
 // `second-instance`, so both share this. `pendingOpenPath` is set by the
 // caller, which is what covers the two paths that don't reach the renderer
-// here: a window created below, and an `open-file` that arrives before
-// `whenReady()` on a cold launch. Both drain it via
-// `desktop:get-launch-file-path` during renderer init.
+// here: a window created below, and an `open-file` that arrives before the
+// bootstrap finishes. Both drain it via `desktop:get-launch-file-path` during
+// renderer init.
 function revealForOpenFile(openPath: string) {
 	if (!mainWindow || mainWindow.isDestroyed()) {
-		// macOS keeps the app alive with no window after ⌘W. Before ready, the
-		// `whenReady()` handler is about to create the window anyway.
-		if (app.isReady()) void createWindow();
+		// macOS keeps the app alive with no window after ⌘W. During bootstrap
+		// there is nothing to do: it ends in the same `ensureMainWindow()`.
+		if (appBootstrapped) void ensureMainWindow();
 		return;
 	}
 	if (mainWindow.isMinimized()) mainWindow.restore();
@@ -2041,7 +2057,8 @@ if (!singleInstanceLock) {
 		registerIpc();
 		buildMenu();
 		configureAutoUpdates();
-		await createWindow();
+		appBootstrapped = true;
+		await ensureMainWindow();
 	});
 
 	app.on("window-all-closed", () => {
@@ -2049,8 +2066,6 @@ if (!singleInstanceLock) {
 	});
 
 	app.on("activate", () => {
-		if (BrowserWindow.getAllWindows().length === 0) {
-			void createWindow();
-		}
+		void ensureMainWindow();
 	});
 }


### PR DESCRIPTION
Fixes #287.

## What changed

`app.on("open-file")` and `app.on("second-instance")` now share one `revealForOpenFile` helper. It restores a minimized window, shows and raises it, and creates a window when the app is running without one.

The `open-file` handler previously only forwarded the path to the renderer. On macOS that is the handler a document open hits when the app is already running (`second-instance` never fires), so the file loaded while the window stayed behind whatever app was in front. With no window open — ⌘W keeps a macOS app alive — `sendToRenderer`'s `mainWindow?.` swallowed the message and nothing happened at all.

Both callers keep setting `pendingOpenPath` before calling the helper, which is what covers the two paths that don't reach the renderer directly: a window created inside the helper, and an `open-file` that arrives before `whenReady()` on a cold launch. Both drain it through `desktop:get-launch-file-path` during renderer init (`App.tsx:615`), so no extra plumbing was needed.

`app.focus({ steal: true })` is there because `BrowserWindow.focus()` alone does not take key status when the open request came from another app. That is measurable — see the table below.

Folding `second-instance` into the same helper rather than only patching `open-file` keeps the two from drifting again, and it is a smaller diff than duplicating the reveal. It also means a Windows/Linux `second-instance` with no window now gets one instead of returning silently.

## How I tested it

`pnpm build` passes (Biome, all package builds, typecheck).

There is no main-process test harness for `main.ts`, so this is manual verification against a `pnpm bundle:desktop:mac` build, driven over the renderer CDP endpoint (`HUBBLE_DESKTOP_FORCE_DEV=1 HUBBLE_DESKTOP_ENABLE_CDP=1`) with a separate `HUBBLE_DESKTOP_DEV_APP_NAME` userData dir. macOS 15 (Darwin 25.6.0), arm64. The bundled build got a distinct `CFBundleIdentifier` so `open -a` could not be resolved to the installed 0.1.28 copy by LaunchServices.

`pages` is the count of page targets, so `pages=0` means no window exists. `hasFocus` is `document.hasFocus()` in the renderer.

**Case A — app running behind another app, window open**

| | before the open | after the open |
| --- | --- | --- |
| 0.1.28 | front=Slack, hasFocus=false | front=Hubble, hasFocus=**false** |
| this branch | front=Slack, hasFocus=false | front=Hubble, hasFocus=**true** |

In both builds the file loads and macOS marks the app active, but only with this branch does the window actually take focus. This is the "not focused" half of the report.

**Case B — app running, no window open (after ⌘W)**

| | after ⌘W | after opening a file |
| --- | --- | --- |
| 0.1.28 | pages=0, process alive | pages=**0**, file never loads |
| this branch | pages=0, process alive | pages=**1**, `case-b.md` loaded, front=Hubble |

**Cold start (no regression)** — app not running, open a file: `pages=1` with `cold.md` loaded, app frontmost. Unchanged from 0.1.28.

**Minimized window** — not covered by the automated run. Driving a native minimize needs either Accessibility permission or main-process `--inspect`, and Electron's CDP has no `Browser.getWindowForTarget`. The `isMinimized() → restore()` line is the pre-existing `second-instance` code moved into the helper unchanged, with `show()` added ahead of the focus call. Worth a click-through by a reviewer if you want all four criteria signed off on a real machine.

## Checklist

- [x] `pnpm build`
- [x] `CHANGELOG.md` entry under `[Unreleased]` → `Fixed`
- [x] Linked issue
